### PR TITLE
Proposal: XWS ids

### DIFF
--- a/data/pilots/galactic-empire/alpha-class-star-wing.json
+++ b/data/pilots/galactic-empire/alpha-class-star-wing.json
@@ -43,6 +43,7 @@
       "caption": "Brash Noble",
       "initiative": 3,
       "limited": 1,
+      "xws": "lieutenantkarsabi",
       "ability": "After you gain a disarm token, if you are not stressed, you may gain 1 stress token to remove 1 disarm token."
     },
     {
@@ -50,12 +51,14 @@
       "caption": "Pragmatic Survivor",
       "initiative": 4,
       "limited": 1,
+      "xws": "majorvynder",
       "ability": "While you defend, if you are disarmed, roll 1 additional defense die."
     },
     {
       "name": "Nu Squadron Pilot",
       "initiative": 2,
       "limited": 0,
+      "xws": "nusquadronpilot",
       "text": "With a design inspired by other Cygnus Spaceworks vessels, the Alpha-class star wing is a versatile craft assigned to Imperial Navy specialist units that need a starfighter they can outfit for multiple roles.",
       "image": "https://i.imgur.com/TbEOuBf.png"
     },
@@ -63,6 +66,7 @@
       "name": "Rho Squadron Pilot",
       "initiative": 3,
       "limited": 0,
+      "xws": "rhosquadronpilot",
       "text": "The elite pilots of Rho Squadron instill terror in the Rebellion, using both the Xg-1 assault configuration and Os-1 arsenal loadout of the Alpha-class star wing to devastating effect."
     }
   ]

--- a/data/pilots/galactic-empire/lambda-class-t-4a-shuttle.json
+++ b/data/pilots/galactic-empire/lambda-class-t-4a-shuttle.json
@@ -46,6 +46,7 @@
       "caption": "The Emperor's Shuttle Pilot",
       "initiative": 4,
       "limited": 1,
+      "xws": "captainkagi",
       "ability": "At the start of the Engagement Phase, you may choose 1 or more friendly ships at range 0-3. If you do, transfer all enemy lock tokens from the chosen ships to you.",
       "image": "https://i.imgur.com/s4RmmAe.jpg"
     },
@@ -54,6 +55,7 @@
       "caption": "Darth Vader's Shuttle Pilot",
       "initiative": 3,
       "limited": 1,
+      "xws": "coloneljendon",
       "ability": "At the start of the Activation Phase, you may spend 1 [Charge]. If you do, while friendly ships acquire lock this round, they must acquire locks beyond range 3 instead of at range 0-3.",
       "image": "https://i.imgur.com/68HNwaF.jpg",
       "charges": {
@@ -66,6 +68,7 @@
       "caption": "Death Squadron Veteran",
       "initiative": 3,
       "limited": 1,
+      "xws": "lieutenantsai",
       "ability": "After you a perform a [Coordinate] action, if the ship you chose performed an action on your action bar, you may perform that action.",
       "image": "https://i.imgur.com/L9rWWdJ.jpg",
       "charges": {
@@ -77,6 +80,7 @@
       "name": "Omicron Group Pilot",
       "initiative": 1,
       "limited": 0,
+      "xws": "omicrongrouppilot",
       "text": "Noted for its tri-wing design and advanced sensor suite, the Lambda-class shuttle serves a critical role as a light utility craft in the Imperial Navy.",
       "image": "https://i.imgur.com/Bdeg9gR.png"
     }

--- a/data/pilots/galactic-empire/tie-advanced-v1.json
+++ b/data/pilots/galactic-empire/tie-advanced-v1.json
@@ -47,6 +47,7 @@
       "name": "Baron of the Empire",
       "initiative": 3,
       "limited": 0,
+      "xws": "baronoftheempire",
       "text": "Sienar Fleet System's TIE Advanced v1 is a groundbreaking starfighter design, featuring upgraded engines, a missile launcher, and folding s-foils.",
       "image": "https://i.imgur.com/6CV2VXS.png"
     },
@@ -55,6 +56,7 @@
       "caption": "Master of the Inquisitorious",
       "initiative": 5,
       "limited": 1,
+      "xws": "grandinquisitor",
       "ability": "While you defend at attack range 1, you may spend 1 [Force] to prevent the range 1 bonus. While you perform an attack against a defender at attack range 2-3, you may spend 1 [Force] to apply the range 1 bonus.",
       "image": "https://i.imgur.com/PElhrM5.png",
       "force": {
@@ -66,6 +68,7 @@
       "name": "Inquisitor",
       "initiative": 3,
       "limited": 0,
+      "xws": "inquisitor",
       "text": "The fearsome Inquisitors are given a great deal of autonomy and access to the Empire's latest technology, like the prototype TIE Advanced v1.",
       "image": "https://i.imgur.com/6CV2VXS.png",
       "force": {
@@ -78,6 +81,7 @@
       "caption": "Sadistic Interrogator",
       "initiative": 4,
       "limited": 1,
+      "xws": "seventhsister",
       "ability": "While you perform a primary attack, before the Neutralize Results step, you may spend 2 [Force] to cancel 1 [Evade] result.",
       "image": "https://i.imgur.com/za20byz.jpg",
       "force": {

--- a/data/pilots/galactic-empire/tie-advanced-x1.json
+++ b/data/pilots/galactic-empire/tie-advanced-x1.json
@@ -51,6 +51,7 @@
       "caption": "Black Leader",
       "initiative": 6,
       "limited": 1,
+      "xws": "darthvader",
       "ability": "After you perform an action, you may spend 1 [Force] to perform an action.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/4a/a3/4aa31721-624a-456c-ab97-9224ba04099c/swz15_a1_darth-vader.png",
       "force": {
@@ -63,6 +64,7 @@
       "caption": "Servant of the Empire",
       "initiative": 5,
       "limited": 1,
+      "xws": "maarekstele",
       "ability": "While you perform an attack, if the defender would be dealt a faceup damage card, instead draw 3 damage cards, choose 1, and discard the rest.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/a7/2e/a72ea6fe-b11c-439b-a1f8-6185b9b961f2/swz15_a1_maarek-stele.png"
     },
@@ -70,6 +72,7 @@
       "name": "Storm Squadron Ace",
       "initiative": 3,
       "limited": 0,
+      "xws": "stormsquadronace",
       "text": "The TIE Advanced x1 was produced in limited quantities, but Sienar engineers incorporated many of its best qualities into their next TIE model, the TIE Interceptor.",
       "image": "https://i.imgur.com/ZPCZxyz.png"
     },
@@ -77,6 +80,7 @@
       "name": "Tempest Squadron Pilot",
       "initiative": 2,
       "limited": 0,
+      "xws": "tempestsquadronpilot",
       "text": "The TIE Advanced improved on the popular TIE/ln design by adding shielding, better weapons systems, curved solar panels, and a hyperdrive."
     },
     {
@@ -84,6 +88,7 @@
       "caption": "Ambitious Engineer",
       "initiative": 4,
       "limited": 1,
+      "xws": "vedfoslo",
       "ability": "While you execute a maneuver, you may execute a maneuver of the same bearing and difficulty of a speed 1 higher or lower instead.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/62/a6/62a6ca0a-40bf-4bf6-a9b4-304a6cfb1f87/swz15_a1_ved-foslo.png"
     },
@@ -92,6 +97,7 @@
       "caption": "Pitiless Administrator",
       "initiative": 3,
       "limited": 1,
+      "xws": "zertikstrom",
       "ability": "During the End Phase, you may spend a lock you have on an enemy ship to expose 1 of that ship's damage cards.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/59/4b/594b12d4-847a-4193-ab55-36ec29a85e1e/swz15_a1_zertik-strom.png"
     }

--- a/data/pilots/galactic-empire/tie-ag-aggressor.json
+++ b/data/pilots/galactic-empire/tie-ag-aggressor.json
@@ -44,6 +44,7 @@
       "caption": "Contingency Planner",
       "initiative": 2,
       "limited": 1,
+      "xws": "doubleedge",
       "ability": "After you perform a [Turret] or [Missile] attack that misses, you may perform a bonus attack using a different weapon.",
       "image": "https://i.imgur.com/9CAQhnT.jpg"
     },
@@ -52,6 +53,7 @@
       "caption": "Innate Deadeye",
       "initiative": 4,
       "limited": 1,
+      "xws": "lieutenantkestal",
       "ability": "While you perform an attack, after the defender rolls defense dice, you may spend 1 focus token to cancel all of the defender's blank/[Focus] results.",
       "image": "https://i.imgur.com/2B28yb9.jpg"
     },
@@ -59,6 +61,7 @@
       "name": "Onyx Squadron Scout",
       "initiative": 3,
       "limited": 0,
+      "xws": "onyxsquadronscout",
       "text": "Designed for extended engagements, the TIE/ag is flown primarily by elite pilots trained to leverage both its unique weapons loadout and its maneuverability to full effect.",
       "image": "https://i.imgur.com/vitbEbv.png"
     },
@@ -66,6 +69,7 @@
       "name": "Sienar Specialist",
       "initiative": 2,
       "limited": 0,
+      "xws": "sienarspecialist",
       "text": "During the development of the TIE aggressor, Sienar Fleet Systems valued performance and versatility over raw cost efficiency.",
       "image": "https://i.imgur.com/dfWi6CV.jpg"
     }

--- a/data/pilots/galactic-empire/tie-ca-punisher.json
+++ b/data/pilots/galactic-empire/tie-ca-punisher.json
@@ -44,6 +44,7 @@
       "caption": "Dexterous Bombardier",
       "initiative": 4,
       "limited": 1,
+      "xws": "deathrain",
       "ability": "After you drop or launch a device, you may perform an action.",
       "image": "https://i.imgur.com/mMqDBzJ.png"
     },
@@ -52,12 +53,14 @@
       "caption": "Adrenaline Junkie",
       "initiative": 5,
       "limited": 1,
+      "xws": "redline",
       "ability": "You can maintain up to 2 locks. After you perform an action, you may acquire a lock."
     },
     {
       "name": "Cutlass Squadron Pilot",
       "initiative": 2,
       "limited": 0,
+      "xws": "cutlasssquadronpilot",
       "text": "The TIE punisher's design builds upon the success of the TIE bomber, adding shielding, a second bomb chute, and three additional ordnance pods, each equipped with a twin ion engine.",
       "image": "https://i.imgur.com/EvOPUtc.png"
     }

--- a/data/pilots/galactic-empire/tie-d-defender.json
+++ b/data/pilots/galactic-empire/tie-d-defender.json
@@ -51,6 +51,7 @@
       "caption": "Contemplative Commander",
       "initiative": 4,
       "limited": 1,
+      "xws": "colonelvessery",
       "ability": "While you perform an attack against a locked ship, after you roll attack dice, you may acquire a lock on the defender.",
       "image": "https://i.imgur.com/zMIFfUy.jpg"
     },
@@ -59,6 +60,7 @@
       "caption": "Cutthroat Politico",
       "initiative": 4,
       "limited": 1,
+      "xws": "countessryad",
       "ability": "While you would execute a [Straight] maneuver, you may increase the difficulty of the maneuver. If you do, execute it as a [Koiogran Turn] maneuver instead.",
       "image": "https://i.imgur.com/2xlGiqx.png"
     },
@@ -66,6 +68,7 @@
       "name": "Delta Squadron Pilot",
       "initiative": 1,
       "limited": 0,
+      "xws": "deltasquadronpilot",
       "text": "In addition to its missile launchers and six wingtip laser cannons, the formidable TIE defender is equipped with deflector shields and a hyperdrive.",
       "image": "https://i.imgur.com/ed9jBrD.jpg"
     },
@@ -73,6 +76,7 @@
       "name": "Onyx Squadron Ace",
       "initiative": 4,
       "limited": 0,
+      "xws": "onyxsquadronace",
       "text": "The experimental TIE defender outclasses all other contemporary starfighters, though its size, speed, and array of weapons come at a tremendous cost in credits.",
       "image": "https://i.imgur.com/anocoLw.png"
     },
@@ -81,6 +85,7 @@
       "caption": "Onyx Leader",
       "initiative": 5,
       "limited": 1,
+      "xws": "rexlerbrath",
       "ability": "After you perform an attack that hits, if you are evading, expose 1 of the defender's damage cards.",
       "image": "https://i.imgur.com/Sne4UCs.jpg"
     }

--- a/data/pilots/galactic-empire/tie-interceptor.json
+++ b/data/pilots/galactic-empire/tie-interceptor.json
@@ -45,6 +45,7 @@
       "name": "Alpha Squadron Pilot",
       "initiative": 1,
       "limited": 0,
+      "xws": "alphasquadronpilot",
       "text": "Sienar Fleet Systems designed the TIE interceptor with four wing-mounted laser cannons, a dramatic increase in firepower over its predecessors.",
       "image": "https://i.imgur.com/i4vYHvP.jpg"
     },
@@ -52,6 +53,7 @@
       "name": "Saber Squadron Ace",
       "initiative": 4,
       "limited": 0,
+      "xws": "sabersquadronace",
       "text": "Led by Baron Soontir Fel, the pilots of Saber Squadron are among the Empire's best. Their TIE interceptors are marked with red stripes to designate pilots with at least ten confirmed kills.",
       "image": "https://i.imgur.com/kBjOZ5j.png"
     },
@@ -60,6 +62,7 @@
       "caption": "Ace of Legend",
       "initiative": 6,
       "limited": 1,
+      "xws": "soontirfel",
       "ability": "At the start of the Engagement Phase, if there is an enemy ship in your [Bullseye Arc], gain 1 focus token.",
       "image": "https://i.imgur.com/4TFKKVN.png"
     },
@@ -68,6 +71,7 @@
       "caption": "Ambitious Ace",
       "initiative": 4,
       "limited": 1,
+      "xws": "turrphennir",
       "ability": "After you perform an attack, you may perform a [Barrel Roll] or [Boost] action, even if you are stressed.",
       "image": "https://i.imgur.com/biHV5cr.jpg"
     }

--- a/data/pilots/galactic-empire/tie-ln-fighter.json
+++ b/data/pilots/galactic-empire/tie-ln-fighter.json
@@ -41,6 +41,7 @@
       "caption": "Obsidian Leader",
       "initiative": 5,
       "limited": 1,
+      "xws": "howlrunner",
       "ability": "While a friendly ship at range 0-1 performs a primary attack, that ship may reroll 1 attack die.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/61/10/61100be4-2767-4d2c-a17f-5eb3c1a6c843/swz07_howlrunner.png"
     },
@@ -49,6 +50,7 @@
       "caption": "Black Two",
       "initiative": 5,
       "limited": 1,
+      "xws": "maulermithel",
       "ability": "While you perform an attack at attack range 1, roll 1 additional attack die.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/27/a3/27a38715-323d-45ff-b72d-f37c347a362d/swz14_mauler.png"
     },
@@ -57,6 +59,7 @@
       "caption": "Obsidian Two",
       "initiative": 2,
       "limited": 1,
+      "xws": "nightbeast",
       "ability": "After you fully execute a blue maneuver, you may perform a [Focus] action.",
       "image": "https://i.imgur.com/FbwsflC.png"
     },
@@ -65,6 +68,7 @@
       "caption": "Seasoned Veteran",
       "initiative": 5,
       "limited": 1,
+      "xws": "scourgeskutu",
       "ability": "While you perform an attack against a defender in your [Bullseye Arc], roll 1 additional attack die.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/98/a2/98a2f940-77d7-4ecf-aa21-b2b3faa4715e/swz14_scourge.png"
     },
@@ -73,6 +77,7 @@
       "caption": "Black Eleven",
       "initiative": 1,
       "limited": 1,
+      "xws": "wampa",
       "ability": "While you perform an attack, you may spend 1 [Charge] to roll 1 additional attack die. After defending, lose 1 [Charge].",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/b6/1c/b61c7b54-5fe6-431c-866d-3adf6018e9f7/swz14_wampa.png",
       "charges": {
@@ -84,6 +89,7 @@
       "name": "Academy Pilot",
       "initiative": 1,
       "limited": 0,
+      "xws": "academypilot",
       "text": "The Galactic Empire uses the fast and agile TIE/ln, developed by Sienar Fleet Systems and produced in staggering quantity, as its primary starfighter.",
       "image": "https://i.imgur.com/EmVpvsx.png"
     },
@@ -91,6 +97,7 @@
       "name": "Black Squadron Ace",
       "initiative": 3,
       "limited": 0,
+      "xws": "blacksquadronace",
       "text": "The elite TIE/ln pilots of Black Squadron accompanied Darth Vader on a devastating strike against the Rebel forces at the Battle of Yavin.",
       "image": "https://i.imgur.com/5LhGep7.png"
     },
@@ -99,6 +106,7 @@
       "caption": "Inferno Three",
       "initiative": 4,
       "limited": 1,
+      "xws": "delmeeko",
       "ability": "While a friendly ship at range 0-2 defends against a damaged attacker, the defender may reroll 1 defense die.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/21/c6/21c66049-cbee-4783-a346-6e7167b0f685/swz14_del-meeko.png"
     },
@@ -107,6 +115,7 @@
       "caption": "Inferno Two",
       "initiative": 4,
       "limited": 1,
+      "xws": "gideonhask",
       "ability": "While you perform an attack against a damaged defender, roll 1 additional attack die.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/95/aa/95aa2578-4127-4532-9cf4-df9cd63fc00c/swz14_gideon-hask.png"
     },
@@ -115,6 +124,7 @@
       "caption": "Inferno Leader",
       "initiative": 4,
       "limited": 1,
+      "xws": "idenversio",
       "ability": "Before a friendly TIE/ln fighter at range 0-1 would suffer 1 or more damage, you may spend 1 [Charge]. If you do, prevent that damage.",
       "image": "https://i.imgur.com/1GqfiBc.jpg",
       "charges": {
@@ -126,6 +136,7 @@
       "name": "Obsidian Squadron Pilot",
       "initiative": 2,
       "limited": 0,
+      "xws": "obsidiansquadronpilot",
       "text": "The TIE fighter's Twin Ion Engine system was designed for speed, making the TIE/ln one of the most maneuverable starships ever mass-produced.",
       "image": "https://i.imgur.com/DDeq1x3.jpg"
     },
@@ -134,6 +145,7 @@
       "caption": "Inferno Four",
       "initiative": 4,
       "limited": 1,
+      "xws": "seynmarana",
       "ability": "While you perform an attack, you may spend 1 [Critical Hit] result. If you do, deal 1 facedown damage card to the defender, then cancel you remaining results.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/6e/35/6e356c04-5171-418f-891f-e35852a0bc57/swz14_seyn-marana.png",
       "charges": {
@@ -146,6 +158,7 @@
       "caption": "Braggadocious Baron",
       "initiative": 3,
       "limited": 1,
+      "xws": "valenrudor",
       "ability": "After a friendly ship at range 0-1 defends (after damage is resolved, if any), you may perform an action.",
       "image": "https://i.imgur.com/YFaADU4.png"
     }

--- a/data/pilots/galactic-empire/tie-ph-phantom.json
+++ b/data/pilots/galactic-empire/tie-ph-phantom.json
@@ -50,6 +50,7 @@
       "caption": "Slippery Trickster",
       "initiative": 4,
       "limited": 1,
+      "xws": "echo",
       "ability": "While you decloak, you must use the (2 [Bank Left]) or (2 [Bank Right]) template instead of the (2 [Straight]) template.",
       "image": "https://i.imgur.com/sVRjx6w.png"
     },
@@ -58,6 +59,7 @@
       "caption": "Soft-Spoken Slayer",
       "initiative": 5,
       "limited": 1,
+      "xws": "whisper",
       "ability": "After you perform an attack that hits, gain 1 evade token.",
       "image": "https://i.imgur.com/iUbk70J.png"
     },
@@ -65,6 +67,7 @@
       "name": "Imdaar Test Pilot",
       "initiative": 3,
       "limited": 0,
+      "xws": "imdaartestpilot",
       "text": "The primary result of a hidden research facility on Imdaar Alpha, the TIE phantom achieves what many thought was impossible: a small starfighter equipped with an advanced cloaking device.",
       "image": "https://i.imgur.com/m3UIgur.png"
     },
@@ -72,6 +75,7 @@
       "name": "Sigma Squadron Ace",
       "initiative": 4,
       "limited": 0,
+      "xws": "sigmasquadronace",
       "text": "Featuring a hyperdrive and shields, the TIE phantom is also equipped with five laser cannons, giving it substantial firepower for an Imperial fighter.",
       "image": "https://i.imgur.com/0EEsE4C.jpg"
     }

--- a/data/pilots/galactic-empire/tie-reaper.json
+++ b/data/pilots/galactic-empire/tie-reaper.json
@@ -49,6 +49,7 @@
       "caption": "Ruthless Tactician",
       "initiative": 2,
       "limited": 1,
+      "xws": "vizier",
       "ability": "After you fully execute a speed 1 maneuver using your Adaptive Ailerons ship ability, you may perform a [Coordinate] action. If you do, skip your Perform Action step.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/a0/86/a08685c2-260b-449c-ba91-a870f6058e22/swx75_card2_vizier.png"
     },
@@ -57,6 +58,7 @@
       "caption": "Imperial Courier",
       "initiative": 3,
       "limited": 1,
+      "xws": "captainferoph",
       "ability": "While you defend, if the attacker does not have any green tokens, you may change 1 of your [Focus]/blank results to an [Evade] result.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/9c/e9/9ce9dedf-8f3f-482e-bcbb-d105e5c78682/swx75_card2_captain-feroph.png"
     },
@@ -65,6 +67,7 @@
       "caption": "Veteran of Scarif",
       "initiative": 4,
       "limited": 1,
+      "xws": "majorvermeil",
       "ability": "While you perform an attack, if the defender does not have any green tokens, you may change 1 of your [Focus]/blank results to a [Hit] result.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/a7/29/a729992e-5e68-46e8-93d7-33f1220aed9d/swx75_card2_major-vermeil.png"
     },
@@ -72,6 +75,7 @@
       "name": "Scarif Base Pilot",
       "initiative": 1,
       "limited": 0,
+      "xws": "scarifbasepilot",
       "text": "The TIE reaper was designed to ferry elite troops to flashpoints on the battlefield, notably carrying Director Krennic's dreaded death troopers at the Battle of Scarif."
     }
   ]

--- a/data/pilots/galactic-empire/tie-sa-bomber.json
+++ b/data/pilots/galactic-empire/tie-sa-bomber.json
@@ -45,6 +45,7 @@
       "caption": "Unflinching Diehard",
       "initiative": 2,
       "limited": 1,
+      "xws": "deathfire",
       "ability": "After you are destroyed, before you are removed, you may perform an attack and drop or launch 1 device.",
       "image": "https://i.imgur.com/VLOw6DT.png"
     },
@@ -53,6 +54,7 @@
       "caption": "Disciplined Instructor",
       "initiative": 4,
       "limited": 1,
+      "xws": "captainjonus",
       "ability": "While a friendly ship at range 0-1 performs a [Torpedo] or [Missile] attack, that ship may reroll up to 2 attack dice.",
       "image": "https://i.imgur.com/Uldzayj.jpg"
     },
@@ -60,6 +62,7 @@
       "name": "Gamma Squadron Ace",
       "initiative": 3,
       "limited": 0,
+      "xws": "gammasquadronace",
       "text": "Though it sacrifices a degree of speed and maneuverability compared to a TIE/ln, the TIE bomber's increased payload can carry enough firepower to destroy virtually any enemy target.",
       "image": "https://i.imgur.com/92cvg2N.jpg"
     },
@@ -68,6 +71,7 @@
       "caption": "Scimitar Leader",
       "initiative": 4,
       "limited": 1,
+      "xws": "majorrhymer",
       "ability": "While you perform a [Torpedo] or [Missile] attack, you may increase or decrease the range requirement by 1, to a limit of 0-3.",
       "image": "https://i.imgur.com/rzJCriK.jpg"
     },
@@ -75,6 +79,7 @@
       "name": "Scimitar Squadron Pilot",
       "initiative": 2,
       "limited": 0,
+      "xws": "scimitarsquadronpilot",
       "text": "The TIE/sa is exceptionally nimble for a bomber, allowing it to pinpoint its target while avoiding excessive collateral damage to the surrounding area.",
       "image": "https://i.imgur.com/BIbaiHf.png"
     },
@@ -83,6 +88,7 @@
       "caption": "Brash Maverick",
       "initiative": 5,
       "limited": 1,
+      "xws": "tomaxbren",
       "ability": "After you perform a [Reload] action, you may revocer 1 [Charge] token on 1 of your equipped [Talent] upgrade cards.",
       "image": "https://i.imgur.com/ZSEw6Mf.jpg"
     }

--- a/data/pilots/galactic-empire/tie-sk-striker.json
+++ b/data/pilots/galactic-empire/tie-sk-striker.json
@@ -45,6 +45,7 @@
       "caption": "Death Defier",
       "initiative": 4,
       "limited": 1,
+      "xws": "countdown",
       "ability": "While you defend, after the Neutralize Results step, if you are not stressed, you may suffer 1 [Hit] damage and gain 1 stress token. If you do, cancel all dice results.",
       "image": "https://i.imgur.com/kVPdfuW.jpg"
     },
@@ -53,6 +54,7 @@
       "caption": "Urbane Ace",
       "initiative": 5,
       "limited": 1,
+      "xws": "duchess",
       "ability": "You may choose not to use your Adaptive Ailerons. You may use your Adaptive Ailerons even while stressed.",
       "image": "https://i.imgur.com/x4zm9K5.png"
     },
@@ -61,6 +63,7 @@
       "caption": "Confident Gambler",
       "initiative": 4,
       "limited": 1,
+      "xws": "puresabacc",
       "ability": "While you perform an attack, if you have 1 or fewer damage cards, you may roll 1 additional attack die.",
       "image": "https://i.imgur.com/YhDFdGk.jpg"
     },
@@ -68,6 +71,7 @@
       "name": "Black Squadron Scout",
       "initiative": 3,
       "limited": 0,
+      "xws": "blacksquadronscout",
       "text": "These heavily armed atmospheric craft employ their specialized moveable wings to gain additional speed and maneuverability.",
       "image": "https://i.imgur.com/tibcJCo.jpg"
     },
@@ -75,6 +79,7 @@
       "name": "Planetary Sentinel",
       "initiative": 1,
       "limited": 0,
+      "xws": "planetarysentinel",
       "text": "To protect its many military installations, the Empire requires a swift and vigilant defense force.",
       "image": "https://i.imgur.com/SBbPj7y.png"
     }

--- a/data/pilots/galactic-empire/vt-49-decimator.json
+++ b/data/pilots/galactic-empire/vt-49-decimator.json
@@ -45,6 +45,7 @@
       "caption": "Inspired Tactician",
       "initiative": 3,
       "limited": 1,
+      "xws": "captainoicunn",
       "ability": "You can perform primary attacks at range 0.",
       "image": "https://i.imgur.com/gcaOmCr.jpg"
     },
@@ -52,6 +53,7 @@
       "name": "Patrol Leader",
       "initiative": 2,
       "limited": 0,
+      "xws": "patrolleader",
       "text": "To be granted command of a VT-49 Decimator is seen as a significant promotion for a middling officer of the Imperial Navy.",
       "image": "https://i.imgur.com/GfdvoEy.png"
     },
@@ -60,6 +62,7 @@
       "caption": "Advisor to Admiral Piett",
       "initiative": 5,
       "limited": 1,
+      "xws": "rearadmiralchiraneau",
       "ability": "While you perform an attack, if you are reinforced and the defender is in the [Full Front Arc] or [Full Rear Arc] matching your reinforce token, you may change 1 of your [Focus] results to a [Critical Hit] result.",
       "image": "https://i.imgur.com/bZFFljY.png"
     }

--- a/data/pilots/rebel-alliance/a-sf-01-b-wing.json
+++ b/data/pilots/rebel-alliance/a-sf-01-b-wing.json
@@ -45,6 +45,7 @@
       "name": "Blade Squadron Veteran",
       "initiative": 3,
       "limited": 0,
+      "xws": "bladesquadronveteran",
       "text": "A unique gyrostabilization system surrounds the B-wing's cockpit, ensuring that the pilot always remains stationary during flight.",
       "image": "https://i.imgur.com/VQ0xIC7.jpg"
     },
@@ -52,6 +53,7 @@
       "name": "Blue Squadron Pilot",
       "initiative": 2,
       "limited": 0,
+      "xws": "bluesquadronpilot",
       "text": "Due to its heavy weapons array and resilient shielding, the B-wing has solidified itself as the Rebel Alliance's most innovative assault fighter.",
       "image": "https://i.imgur.com/Rdr3gF5.png"
     },
@@ -60,6 +62,7 @@
       "caption": "Blade Leader",
       "initiative": 4,
       "limited": 1,
+      "xws": "braylenstramm",
       "ability": "While you defend or perform an attack, if you are stressed, you may reroll up to 2 of your dice.",
       "image": "https://i.imgur.com/ti70cw0.jpg"
     },
@@ -68,6 +71,7 @@
       "caption": "Blue Five",
       "initiative": 4,
       "limited": 1,
+      "xws": "tennumb",
       "ability": "While you defend or perform an attack, you may spend 1 stress token to change all of your [Focus] results to [Evade] or [Hit] results.",
       "image": "https://i.imgur.com/iL6SGKW.png"
     }

--- a/data/pilots/rebel-alliance/arc-170-starfighter.json
+++ b/data/pilots/rebel-alliance/arc-170-starfighter.json
@@ -49,6 +49,7 @@
       "caption": "Red Leader",
       "initiative": 4,
       "limited": 1,
+      "xws": "garvendreis",
       "ability": "After you spend a focus token, you may choose 1 friendly ship at range 1-3. That ship gains 1 focus token.",
       "image": "https://i.imgur.com/7UeQLa2.png"
     },
@@ -57,6 +58,7 @@
       "caption": "Survivor of Endor",
       "initiative": 3,
       "limited": 1,
+      "xws": "ibtisam",
       "ability": "After you fully execute a maneuver, if you are stressed, you may roll 1 attack die. On a [Hit] or [Critical Hit] result, remove 1 stress token.",
       "image": "https://i.imgur.com/bTjz7fU.jpg"
     },
@@ -65,6 +67,7 @@
       "caption": "Gold Nine",
       "initiative": 5,
       "limited": 1,
+      "xws": "norrawexley",
       "ability": "While you defend, if there is an enemy ship at range 0-1, you may add 1 [Evade] result to your dice results.",
       "image": "https://i.imgur.com/ZbNfdWT.png"
     },
@@ -73,6 +76,7 @@
       "caption": "Green Four",
       "initiative": 4,
       "limited": 1,
+      "xws": "sharabey",
       "ability": "While you defend or perform a primary attack, you may spend 1 lock you have on the enemy ship to add 1 [Focus] result to your dice results.",
       "image": "https://i.imgur.com/82AO9To.jpg"
     }

--- a/data/pilots/rebel-alliance/attack-shuttle.json
+++ b/data/pilots/rebel-alliance/attack-shuttle.json
@@ -50,6 +50,7 @@
       "caption": "Spectre-4",
       "initiative": 2,
       "limited": 1,
+      "xws": "zeborrelios",
       "ability": "While you defend, [Critical Hit] results are neutralized before [Hit] results.",
       "image": "https://i.imgur.com/WXy3lrB.jpg"
     },
@@ -58,6 +59,7 @@
       "caption": "Spectre-6",
       "initiative": 3,
       "limited": 1,
+      "xws": "ezrabridger",
       "ability": "While you defend or perform an attack, if you are stressed, you may spend 1 [Force] to change up to 2 of your [Focus] results to [Evade] or [Hit] results.",
       "image": "https://i.imgur.com/01rgRqz.png",
       "force": {
@@ -70,6 +72,7 @@
       "caption": "Spectre-2",
       "initiative": 5,
       "limited": 1,
+      "xws": "herasyndulla",
       "ability": "After you reveal a red or blue maneuver, you may set your dial to another maneuver of the same difficulty.",
       "image": "https://i.imgur.com/Jq3qoJo.jpg"
     },
@@ -78,6 +81,7 @@
       "caption": "Spectre-5",
       "initiative": 3,
       "limited": 1,
+      "xws": "sabinewren",
       "ability": "Before you activate, you may perform a [Barrel Roll] or [Boost] action.",
       "image": "https://i.imgur.com/irQQrm8.jpg"
     }

--- a/data/pilots/rebel-alliance/auzituck-gunship.json
+++ b/data/pilots/rebel-alliance/auzituck-gunship.json
@@ -43,6 +43,7 @@
       "name": "Kashyyyk Defender",
       "initiative": 1,
       "limited": 0,
+      "xws": "kashyyykdefender",
       "text": "Equipped with three wide-range Sureggi twin laser cannons, the Auzituck gunship acts as a powerful deterrent to slaver operations in the Kashyyyk system.",
       "image": "https://i.imgur.com/oDDRdgb.png"
     },
@@ -51,6 +52,7 @@
       "caption": "Escaped Gladiator",
       "initiative": 3,
       "limited": 1,
+      "xws": "lowhhrick",
       "ability": "After a friendly ship at range 0-1 becomes the defender, you may spend 1 reinforce token. If you do, that ship gains 1 evade token.",
       "image": "https://i.imgur.com/8AIllum.jpg"
     },
@@ -59,6 +61,7 @@
       "caption": "Wookiee Chief",
       "initiative": 4,
       "limited": 1,
+      "xws": "wullffwarro",
       "ability": "While you perform a primary attack, if you are damaged, you may roll 1 additional attack die.",
       "image": "https://i.imgur.com/h0yZwaL.jpg"
     }

--- a/data/pilots/rebel-alliance/btl-a4-y-wing.json
+++ b/data/pilots/rebel-alliance/btl-a4-y-wing.json
@@ -44,6 +44,7 @@
       "caption": "Gold Leader",
       "initiative": 4,
       "limited": 1,
+      "xws": "dutchvander",
       "ability": "After you perform the [Lock] action, you may choose 1 friendly ship at range 1-3. That ship may acquire a lock on the object you locked, ignoring range restrictions.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/92/87/92874a68-d247-4848-9d00-68ae8e1b1d32/swz13_dutch-vander.png"
     },
@@ -52,6 +53,7 @@
       "caption": "Gold Three",
       "initiative": 3,
       "limited": 1,
+      "xws": "evaanverlaine",
       "ability": "At the start of the Engagement Phase, you may spend 1 focus token to choose a friendly ship at range 0-1. If you do, that ship rolls 1 additional defense die while defending until the end of the round.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/e1/3a/e13ae0c6-68ca-4d07-8f30-07e8aebef64c/swz13_evaan-verlaine.png"
     },
@@ -59,6 +61,7 @@
       "name": "Gold Squadron Veteran",
       "initiative": 3,
       "limited": 0,
+      "xws": "goldsquadronveteran",
       "text": "Commanded by Jon \"Dutch\" Vander, Gold Squadron played an instrumental role in the Battles of Scarif and Yavin.",
       "image": "https://i.imgur.com/3dC2FCg.png"
     },
@@ -66,6 +69,7 @@
       "name": "Gray Squadron Bomber",
       "initiative": 2,
       "limited": 0,
+      "xws": "graysquadronbomber",
       "text": "Long after the Y-wing was phased out by the Galactic Empire, its durability, dependability, and heavy armament help it remain a staple in the Rebel fleet.",
       "image": "https://i.imgur.com/fqMoeRW.png"
     },
@@ -74,6 +78,7 @@
       "caption": "Gray Leader",
       "initiative": 4,
       "limited": 1,
+      "xws": "hortonsalm",
       "ability": "While you perform an attack, you may reroll 1 attack die for each other friendly ship at range 0-1 of the defender.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/66/ee/66eecc61-6de1-46ae-b18b-e13ce7d6b553/swz13_horton-salm.png"
     },
@@ -82,6 +87,7 @@
       "caption": "Gold Nine",
       "initiative": 5,
       "limited": 1,
+      "xws": "norrawexley-2",
       "ability": "While you defend, if there is an enemy ship at range 0-1, you may add 1 [Evade] result to your dice results.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/a4/70/a4705409-9cc6-4218-ae90-df62482beef4/swz13_norra-wexley.png"
     }

--- a/data/pilots/rebel-alliance/btl-s8-k-wing.json
+++ b/data/pilots/rebel-alliance/btl-s8-k-wing.json
@@ -40,6 +40,7 @@
       "caption": "Selfless Hero",
       "initiative": 3,
       "limited": 1,
+      "xws": "esegetuketu",
       "ability": "While a friendly ship at range 0-2 defends or performs an attack, it may spend your focus tokens as if that ship has them.",
       "image": "https://i.imgur.com/c5763ZP.jpg"
     },
@@ -48,6 +49,7 @@
       "caption": "Heavy Hitter",
       "initiative": 4,
       "limited": 1,
+      "xws": "mirandadoni",
       "ability": "While you perform a primary attack, you may either spend 1 shield to roll 1 additional attack die or, if you are not shielded, you may roll 1 fewer attack die to recover 1 shield.",
       "image": "https://i.imgur.com/fQQiELo.png"
     },
@@ -55,6 +57,7 @@
       "name": "Warden Squadron Pilot",
       "initiative": 2,
       "limited": 0,
+      "xws": "wardensquadronpilot",
       "text": "Koensayr Manufacturing's K-wing boasts an advanced SubLight Acceleration Motor and an unprecedented 18 hard points, granting it unrivaled speed and firepower.",
       "image": "https://i.imgur.com/AZswO0L.png"
     }

--- a/data/pilots/rebel-alliance/e-wing.json
+++ b/data/pilots/rebel-alliance/e-wing.json
@@ -53,6 +53,7 @@
       "caption": "Tenacious Investigator",
       "initiative": 5,
       "limited": 1,
+      "xws": "corranhorn",
       "ability": "At initiative 0, you may perform a bonus primary attack against an enemy ship in your [Bullseye Arc]. If you do, at the start of the next Planning Phase, gain 1 disarm token.",
       "image": "https://i.imgur.com/g8jma0k.png"
     },
@@ -61,6 +62,7 @@
       "caption": "Bold Wingman",
       "initiative": 4,
       "limited": 1,
+      "xws": "gavindarklighter",
       "ability": "While a friendly ship performs an attack, if the defender is in your [Front Arc], the attacker may change 1 [Hit] result to a [Critical Hit] result.",
       "image": "https://i.imgur.com/y30x2FC.jpg"
     },
@@ -68,6 +70,7 @@
       "name": "Knave Squadron Escort",
       "initiative": 2,
       "limited": 0,
+      "xws": "knavesquadronescort",
       "text": "Designed to combine the best features of the X-wing series with the A-wing series, the E-wing boasts superior firepower, speed, and maneuverability.",
       "image": "https://i.imgur.com/khW6Wsa.jpg"
     },
@@ -75,6 +78,7 @@
       "name": "Rogue Squadron Escort",
       "initiative": 4,
       "limited": 0,
+      "xws": "roguesquadronescort",
       "text": "The elite pilots of Rogue Squadron are among the Rebellion's very best.",
       "image": "https://i.imgur.com/7eV24zH.png"
     }

--- a/data/pilots/rebel-alliance/hwk-290-light-freighter.json
+++ b/data/pilots/rebel-alliance/hwk-290-light-freighter.json
@@ -44,6 +44,7 @@
       "caption": "Espionage Expert",
       "initiative": 5,
       "limited": 1,
+      "xws": "janors",
       "ability": "While a friendly ship in your firing arc performs a primary attack, if you are not stressed, you may gain 1 stress token. If you do, that ship may roll 1 additional attack die.",
       "image": "https://i.imgur.com/4I6h8JE.png"
     },
@@ -52,6 +53,7 @@
       "caption": "Relentless Operative",
       "initiative": 3,
       "limited": 1,
+      "xws": "kylekatarn",
       "ability": "At the start of the Engagement Phase, you may transfer 1 of your focus tokens to a friendly ship in your firing arc.",
       "image": "https://i.imgur.com/LELO1t1.jpg"
     },
@@ -59,6 +61,7 @@
       "name": "Rebel Scout",
       "initiative": 2,
       "limited": 0,
+      "xws": "rebelscout",
       "text": "Designed to look like a bird in flight by the Corellian Engineering Corporation, \"hawk\" series ships are exemplary transport craft. Swift and rugged, the HWK-290 is often employed by Rebel agents as a mobile base of operations.",
       "image": "https://i.imgur.com/Fkya9qi.png"
     },
@@ -67,6 +70,7 @@
       "caption": "Good-Hearted Smuggler",
       "initiative": 4,
       "limited": 1,
+      "xws": "roarkgarnet",
       "ability": "At the start of the Engagement Phase, you may choose 1 ship in your firing arc. If you do, it engages at initiative 7 instead of its standard initiative value this phase.",
       "image": "https://i.imgur.com/PeNd1xH.jpg"
     }

--- a/data/pilots/rebel-alliance/modified-yt-1300-light-freighter.json
+++ b/data/pilots/rebel-alliance/modified-yt-1300-light-freighter.json
@@ -46,6 +46,7 @@
       "caption": "The Mighty",
       "initiative": 4,
       "limited": 1,
+      "xws": "chewbacca",
       "ability": "Before you would be dealt a faceup damage card, you may spend 1 [Charge] to be dealt the card facedown instead.",
       "image": "https://i.imgur.com/72poOIG.jpg",
       "charges": {
@@ -58,6 +59,7 @@
       "caption": "Scoundrel for Hire",
       "initiative": 6,
       "limited": 1,
+      "xws": "hansolo-2",
       "ability": "After you roll dice, if you are at range 0-1 of an obstacle, you may reroll all of your dice. This does not count as rerolling for the purpose of other effects.",
       "image": "https://i.imgur.com/vLoe0hz.png"
     },
@@ -66,6 +68,7 @@
       "caption": "General of the Alliance",
       "initiative": 5,
       "limited": 1,
+      "xws": "landocalrissian-2",
       "ability": "After you fully execute a blue maneuver, you may choose a friendly ship at range 0-3. That ship may perform an action.",
       "image": "https://i.imgur.com/lzS7Rsj.jpg"
     },
@@ -73,6 +76,7 @@
       "name": "Outer Rim Smuggler",
       "initiative": 1,
       "limited": 0,
+      "xws": "outerrimsmuggler",
       "text": "Known for its durability and modular design, the YT-1300 is one of the most popular, widely used, and extensively customized freighters in the galaxy.",
       "image": "https://i.imgur.com/8YSKpLP.png"
     }

--- a/data/pilots/rebel-alliance/rz-1-a-wing.json
+++ b/data/pilots/rebel-alliance/rz-1-a-wing.json
@@ -50,6 +50,7 @@
       "caption": "Green Leader",
       "initiative": 3,
       "limited": 1,
+      "xws": "arvelcrynyd",
       "ability": "You can perform primary attacks at range 0. If you would fail a [Boost] action by overlapping another ship, resilve it as though you were partially executing a maneuver instead.",
       "image": "https://i.imgur.com/merkkbN.png"
     },
@@ -57,6 +58,7 @@
       "name": "Green Squadron Pilot",
       "initiative": 3,
       "limited": 0,
+      "xws": "greensquadronpilot",
       "text": "Due to its sensitive controls and high maneuverability, only the most talented pilots belong in an A-wing cockpit.",
       "image": "https://i.imgur.com/BVko48i.jpg"
     },
@@ -65,6 +67,7 @@
       "caption": "Sage Instructor",
       "initiative": 4,
       "limited": 1,
+      "xws": "jakefarrell",
       "ability": "After you perform a [Barrel Roll] or [Boost] action, you may choose a friendly ship at range 0-1. That ship may perform a [Focus] action.",
       "image": "https://i.imgur.com/TmSyObs.jpg"
     },
@@ -72,6 +75,7 @@
       "name": "Phoenix Squadron Pilot",
       "initiative": 1,
       "limited": 0,
+      "xws": "phoenixsquadronpilot",
       "text": "Led by Commander Jun Sato, the brave but inexperienced pilots of Phoenix Squadron face staggering odds in their battle against the Galactic Empire.",
       "image": "https://i.imgur.com/G4scSoc.png"
     }

--- a/data/pilots/rebel-alliance/sheathipede-class-shuttle.json
+++ b/data/pilots/rebel-alliance/sheathipede-class-shuttle.json
@@ -54,6 +54,7 @@
       "caption": "Spectre-4",
       "initiative": 2,
       "limited": 1,
+      "xws": "zeborrelios-2",
       "ability": "While you defend, [Critical Hit] results are neutralized before [Hit] results.",
       "image": "https://i.imgur.com/2ujf4eY.jpg"
     },
@@ -62,6 +63,7 @@
       "caption": "Escaped Analyst Droid",
       "initiative": 1,
       "limited": 1,
+      "xws": "ap5",
       "ability": "While you coordinate, if you chose a ship with exactly 1 stress token, it can perform actions.",
       "image": "https://i.imgur.com/DhzlEwW.png"
     },
@@ -70,6 +72,7 @@
       "caption": "Spectre-6",
       "initiative": 3,
       "limited": 1,
+      "xws": "ezrabridger-2",
       "ability": "While you defend or perform an attack, if you are stressed, you may spend 1 [Force] to change up to 2 of your [Focus] results to [Evade]/[Hit] results.",
       "image": "https://i.imgur.com/8rzfJ7R.jpg",
       "force": {
@@ -82,6 +85,7 @@
       "caption": "Reluctant Rebel",
       "initiative": 6,
       "limited": 1,
+      "xws": "fennrau-2",
       "ability": "After an enemy ship in your firing arc engages, if you are not stressed, you may gain 1 stress token. If you do, that ship cannot spend tokens to modify dice while it performs an attack during this phase.",
       "image": "https://i.imgur.com/zir3Bdj.jpg"
     }

--- a/data/pilots/rebel-alliance/t-65-x-wing.json
+++ b/data/pilots/rebel-alliance/t-65-x-wing.json
@@ -46,6 +46,7 @@
       "caption": "Red Three",
       "initiative": 3,
       "limited": 1,
+      "xws": "biggsdarklighter",
       "ability": "While another friendly ship at range 0-1 defends, before the Neutralize Results step, if you are in the attack arc, you may suffer 1 [Hit] or [Critical Hit] damage to cancel 1 matching result.",
       "image": "https://i.imgur.com/P2Kn6DR.png"
     },
@@ -53,6 +54,7 @@
       "name": "Blue Squadron Escort",
       "initiative": 2,
       "limited": 0,
+      "xws": "bluesquadronescort",
       "text": "Designed by Incom Corporation, the T-65 X-wing quickly proved to be one of the most effective and versatile military vehicles in the galaxy and a boon to the Rebellion.",
       "image": "https://i.imgur.com/G1NoLFF.png"
     },
@@ -60,6 +62,7 @@
       "name": "Cavern Angels Zealot",
       "initiative": 1,
       "limited": 0,
+      "xws": "cavernangelszealot",
       "text": "Unlike most Rebel cells, Saw Gerrera's partisans are willing to use extreme methods to undermine the Galactic Empire's objectives in brutal battles that raged from Geonosis to Jedha."
     },
     {
@@ -67,6 +70,7 @@
       "caption": "Cavern Angels Veteran",
       "initiative": 2,
       "limited": 1,
+      "xws": "edriotwotubes",
       "ability": "Before you activate, if you are focused, you may perform an action.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/27/b9/27b93e13-e3e0-4557-b49d-2f65a27d078b/swz02_a1_edrio-tt.png"
     },
@@ -75,6 +79,7 @@
       "caption": "Red Leader",
       "initiative": 4,
       "limited": 1,
+      "xws": "garvendreis-2",
       "ability": "After you spend a focus token, you may choose 1 friendly ship at range 1-3. That ship gains 1 focus token.",
       "image": "https://i.imgur.com/yWESWzU.png"
     },
@@ -83,6 +88,7 @@
       "caption": "Red Six",
       "initiative": 4,
       "limited": 1,
+      "xws": "jekporkins",
       "ability": "After you receive a stress token, you may roll 1 attack die to remove it. On a [Hit] result, suffer 1 [Hit] damage.",
       "image": "https://i.imgur.com/Ny4gBBN.png"
     },
@@ -91,6 +97,7 @@
       "caption": "Enigmatic Gunslinger",
       "initiative": 4,
       "limited": 1,
+      "xws": "kullbeesperado",
       "ability": "After you perform a [Barrel Roll] or [Boost] action, you may flip your equipped [Configuration] upgrade card.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/e1/54/e154a590-eedd-44fe-b8b0-ad6e89b85295/swz02_a1_kullbee.png"
     },
@@ -99,6 +106,7 @@
       "caption": "Rebel Alliance Defector",
       "initiative": 3,
       "limited": 1,
+      "xws": "leevantenza",
       "ability": "After you perform a [Barrel Roll] or [Boost] action, you may perform a red [Evade] action.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/4a/e5/4ae59c94-8324-41c2-8a4e-7656b95addb9/swz02_a1_leevan-tenza.png"
     },
@@ -107,6 +115,7 @@
       "caption": "Red Five",
       "initiative": 5,
       "limited": 1,
+      "xws": "lukeskywalker",
       "ability": "After you become the defender (before dice are rolled), you may recover 1 [Force].",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/b5/45/b545a9e9-fe15-45c9-9885-ab7fc6e01964/swz01_a5_xwing_diagram.png",
       "force": {
@@ -118,6 +127,7 @@
       "name": "Red Squadron Veteran",
       "initiative": 3,
       "limited": 0,
+      "xws": "redsquadronveteran",
       "text": "Created as an elite starfighter squad, Red Squadron includes some of the best pilots in the Rebel Alliance.",
       "image": "https://i.imgur.com/JZtZB1m.jpg"
     },
@@ -126,6 +136,7 @@
       "caption": "Corona Four",
       "initiative": 5,
       "limited": 1,
+      "xws": "thanekyrell",
       "ability": "While you perform an attack, you may spend 1 [Focus], [Hit], or [Critical Hit] result to look at the defender's facedown damage cards, choose 1, and expose it.",
       "image": "https://i.imgur.com/FlJuNDr.png"
     },
@@ -134,6 +145,7 @@
       "caption": "Red Two",
       "initiative": 6,
       "limited": 1,
+      "xws": "wedgeantilles",
       "ability": "While you perform an attack, the defender rolls 1 fewer defense die.",
       "image": "https://i.imgur.com/Dn3gjxq.png"
     }

--- a/data/pilots/rebel-alliance/tie-ln-fighter.json
+++ b/data/pilots/rebel-alliance/tie-ln-fighter.json
@@ -41,6 +41,7 @@
       "caption": "Spectre-4",
       "initiative": 2,
       "limited": 1,
+      "xws": "zeborrelios-3",
       "ability": "While you defend, [Critical Hit] results are neutralized before [Hit] results.",
       "image": "https://i.imgur.com/ezuCMJT.jpg"
     },
@@ -49,6 +50,7 @@
       "caption": "Clone Wars Veteran",
       "initiative": 2,
       "limited": 1,
+      "xws": "captainrex",
       "ability": "After you perform an attack, assign the Suppressive Fire condition to the defender.",
       "image": "https://i.imgur.com/SXjax2A.jpg"
     },
@@ -57,6 +59,7 @@
       "caption": "Spectre-6",
       "initiative": 3,
       "limited": 1,
+      "xws": "ezrabridger-3",
       "ability": "While you defend or perform an attack, if you are stressed, you may spend 1 [Force] to change up to 2 of your [Focus] results to [Evade] or [Hit] results.",
       "image": "https://i.imgur.com/K2JnLRE.png",
       "force": {
@@ -69,6 +72,7 @@
       "caption": "Spectre-5",
       "initiative": 3,
       "limited": 1,
+      "xws": "sabinewren-3",
       "ability": "Before you activate, you may perform a [Barrel Roll] or [Boost] action.",
       "image": "https://i.imgur.com/yecurxP.png"
     }

--- a/data/pilots/rebel-alliance/ut-60d-u-wing.json
+++ b/data/pilots/rebel-alliance/ut-60d-u-wing.json
@@ -42,6 +42,7 @@
       "caption": "Cavern Angels Marksman",
       "initiative": 2,
       "limited": 1,
+      "xws": "benthictwotubes",
       "ability": "After you perform a [Focus] action, you may transfer 1 of your focus tokens to a friendly ship at range 1-2.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/b0/b8/b0b8d767-7148-4a42-9072-b2716617a714/swz02_a1_benthic-tt.png"
     },
@@ -49,6 +50,7 @@
       "name": "Blue Squadron Scout",
       "initiative": 2,
       "limited": 0,
+      "xws": "bluesquadronscout",
       "text": "Used for deploying troops under the cover of darkness or into the heat of battle, the UT-60D U-wing fulfills the Rebellion's need for a swift and hardy troop transport.",
       "image": "https://i.imgur.com/kZeAOLv.jpg"
     },
@@ -57,6 +59,7 @@
       "caption": "Imperial Defector",
       "initiative": 4,
       "limited": 1,
+      "xws": "bodhirook",
       "ability": "Friendly ships can acquire locks onto objects at range 0-3 of any friendly ship.",
       "image": "https://i.imgur.com/BesOcL5.jpg"
     },
@@ -65,6 +68,7 @@
       "caption": "Raised by the Rebellion",
       "initiative": 3,
       "limited": 1,
+      "xws": "cassianandor",
       "ability": "At the start of the Activation Phase, you may choose 1 friendly ship at range 1-3. If you do, that ship removes 1 stress token.",
       "image": "https://i.imgur.com/adYRjQV.jpg"
     },
@@ -73,6 +77,7 @@
       "caption": "Blue Eight",
       "initiative": 2,
       "limited": 1,
+      "xws": "hefftobber",
       "ability": "After an enemy ship executes a maneuver, if it is at range 0, you may perform an action.",
       "image": "https://i.imgur.com/Ti4Ak00.jpg"
     },
@@ -81,6 +86,7 @@
       "caption": "Cavern Angels Spotter",
       "initiative": 3,
       "limited": 1,
+      "xws": "magvayarro",
       "ability": "While a friendly ship at range 0-2 defends, the attacker cannot reroll more than 1 attack die.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/30/0c/300c137c-0c8f-41d0-8582-29601bf2ea38/swz02_a1_magva.png"
     },
@@ -88,6 +94,7 @@
       "name": "Partisan Renegade",
       "initiative": 1,
       "limited": 1,
+      "xws": "partisanrenegade",
       "text": "Saw Gerrera's partisans were first established to oppose Separatist forces on Onderon during the Clone Wars and continued to wage war against galactic tyranny as the Empire rose to power."
     },
     {
@@ -95,6 +102,7 @@
       "caption": "Obsessive Outlaw",
       "initiative": 4,
       "limited": 1,
+      "xws": "sawgerrera",
       "ability": "While a damaged friendly ship at range 0-3 performs an attack, it may reroll 1 attack die.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/75/f3/75f36fb9-66dc-4f90-9bfe-b032aa311e66/swz02_a1_saw-gerrera.png"
     }

--- a/data/pilots/rebel-alliance/vcx-100-light-freighter.json
+++ b/data/pilots/rebel-alliance/vcx-100-light-freighter.json
@@ -50,6 +50,7 @@
       "caption": "Spectre-3",
       "initiative": 2,
       "limited": 1,
+      "xws": "chopper",
       "ability": "At the start of the Engagement Phase, each enemy ship at range 0 gains 2 jam tokens.",
       "image": "https://i.imgur.com/Iwvr07I.jpg"
     },
@@ -58,6 +59,7 @@
       "caption": "Spectre-2",
       "initiative": 5,
       "limited": 1,
+      "xws": "herasyndulla-2",
       "ability": "After you reveal a red or blue maneuver, you may set your dial to another maneuver of the same difficulty.",
       "image": "https://i.imgur.com/TUvH0aN.png"
     },
@@ -66,6 +68,7 @@
       "caption": "Spectre-1",
       "initiative": 3,
       "limited": 1,
+      "xws": "kananjarrus",
       "ability": "While a friendly ship in your firing arc defends, you may spend 1 [Force]. If you do, the attacker rolls 1 fewer attack die.",
       "image": "https://i.imgur.com/qOPVRTj.jpg",
       "force": {
@@ -77,6 +80,7 @@
       "name": "Lothal Rebel",
       "initiative": 2,
       "limited": 0,
+      "xws": "lothalrebel",
       "text": "Another successful Corellian Engineering Corporation freighter design, the VCX-100 is larger than the ubiquitous YT-series, boasting more living space and customizability.",
       "image": "https://i.imgur.com/PwUPatz.png"
     }

--- a/data/pilots/rebel-alliance/yt-2400-light-freighter.json
+++ b/data/pilots/rebel-alliance/yt-2400-light-freighter.json
@@ -50,6 +50,7 @@
       "caption": "Dry-Witted Droid",
       "initiative": 3,
       "limited": 1,
+      "xws": "leebo",
       "ability": "After you defend or perform an attack, if you spent a calculate token, gain 1 calculate token.",
       "image": "https://i.imgur.com/1JwTtlv.jpg"
     },
@@ -58,6 +59,7 @@
       "caption": "Hotshot Mercenary",
       "initiative": 5,
       "limited": 1,
+      "xws": "dashrendar",
       "ability": "While you move, you ignore obstacles.",
       "image": "https://i.imgur.com/mInRUGj.png"
     },
@@ -65,6 +67,7 @@
       "name": "Wild Space Fringer",
       "initiative": 1,
       "limited": 0,
+      "xws": "wildspacefringer",
       "text": "Although stock YT-2400 light freighters have plenty of room for cargo, that space is often annexed to support modified weapon systems and oversized engines.",
       "image": "https://i.imgur.com/oGHjCqq.png"
     }

--- a/data/pilots/rebel-alliance/z-95-af4-headhunter.json
+++ b/data/pilots/rebel-alliance/z-95-af4-headhunter.json
@@ -45,6 +45,7 @@
       "caption": "Intelligence Chief",
       "initiative": 5,
       "limited": 1,
+      "xws": "airencracken",
       "ability": "After you perform an attack, you may choose 1 friendly ship at range 1. That ship may perform an action, treating it as red.",
       "image": "https://i.imgur.com/7bVSVq4.jpg"
     },
@@ -52,6 +53,7 @@
       "name": "Bandit Squadron Pilot",
       "initiative": 1,
       "limited": 0,
+      "xws": "banditsquadronpilot",
       "text": "The Z-95 Headhunter was the primary inspiration for Incom Corporation's exemplary T-65 X-wing starfighter. Though it is considered outdated by modern standards, it remains a versatile and potent snub fighter.",
       "image": "https://i.imgur.com/pq9fX05.png"
     },
@@ -60,6 +62,7 @@
       "caption": "Team Player",
       "initiative": 4,
       "limited": 1,
+      "xws": "lieutenantblount",
       "ability": "While you perform a primary attack, if there is at least 1 other friendly ship at range 0-1 of the defender, you may roll 1 additional attack die.",
       "image": "https://i.imgur.com/Yzh5H1z.jpg"
     },
@@ -67,6 +70,7 @@
       "name": "Tala Squadron Pilot",
       "initiative": 2,
       "limited": 0,
+      "xws": "talasquadronpilot",
       "text": "The AF4 series is the latest in a long line of Headhunter designs. Cheap and relatively durable, it is a favorite among independent outfits like the Rebellion.",
       "image": "https://i.imgur.com/R6W7mLY.jpg"
     }

--- a/data/pilots/scum-and-villainy/aggressor-assault-fighter.json
+++ b/data/pilots/scum-and-villainy/aggressor-assault-fighter.json
@@ -50,6 +50,7 @@
       "caption": "Aggressive Automaton",
       "initiative": 4,
       "limited": 1,
+      "xws": "ig88a",
       "ability": "At the start of the Engagement Phase, you may choose 1 friendly ship with [Calculate] on its action bar at range 1-3. If you do, transfer 1 of your calculate tokens to it.",
       "image": "https://i.imgur.com/bcp5bKd.png"
     },
@@ -58,6 +59,7 @@
       "caption": "Brutal Battledroid",
       "initiative": 4,
       "limited": 1,
+      "xws": "ig88b",
       "ability": "After you perform an attack that misses, you may perform a bonus [Cannon] attack.",
       "image": "https://i.imgur.com/80YX2ED.png"
     },
@@ -66,6 +68,7 @@
       "caption": "Conniving Contraption",
       "initiative": 4,
       "limited": 1,
+      "xws": "ig88c",
       "ability": "After you perform a [Boost] action, you may perform an [Evade] action.",
       "image": "https://i.imgur.com/y9o9rYI.png"
     },
@@ -74,6 +77,7 @@
       "caption": "Deadly Device",
       "initiative": 4,
       "limited": 1,
+      "xws": "ig88d",
       "ability": "While you execute a Segnor's Loop ([Segnor's Loop Left] or [Segnor's Loop Right]) maneuver, you may use another template of the same speed instead: either the turn ([Turn Left] or [Turn Right]) of the same direction or the straight ([Straight]) template.",
       "image": "https://i.imgur.com/N0oZPdn.png"
     }

--- a/data/pilots/scum-and-villainy/btl-a4-y-wing.json
+++ b/data/pilots/scum-and-villainy/btl-a4-y-wing.json
@@ -43,6 +43,7 @@
       "name": "Crymorah Goon",
       "initiative": 1,
       "limited": 0,
+      "xws": "crymorahgoon",
       "text": "Though far from nimble, the Y-wing's heavy hull, substantial shielding, and turret-mounted cannons make it an excellent patrol craft.",
       "image": "https://i.imgur.com/k9OOfbZ.jpg"
     },
@@ -51,12 +52,14 @@
       "caption": "Pirate Lord",
       "initiative": 4,
       "limited": 1,
+      "xws": "drearenthal",
       "ability": "While a friendly non-limited ship performs an attack, if the defender is in your firing arc, the attacker may reroll 1 attack die."
     },
     {
       "name": "Hired Gun",
       "initiative": 2,
       "limited": 0,
+      "xws": "hiredgun",
       "text": "Just the mention of Imperial credits can bring a host of less-than-trustworthy individuals to your side.",
       "image": "https://i.imgur.com/kCQaRyo.png"
     },
@@ -65,6 +68,7 @@
       "caption": "Callous Corsair",
       "initiative": 5,
       "limited": 1,
+      "xws": "kavil",
       "ability": "While you perform a non-[Front Arc] attack, roll 1 additional attack die.",
       "image": "https://i.imgur.com/r5fZmK6.jpg"
     }

--- a/data/pilots/scum-and-villainy/customized-yt-1300-light-freighter.json
+++ b/data/pilots/scum-and-villainy/customized-yt-1300-light-freighter.json
@@ -55,7 +55,7 @@
       "caption": "Droid Revolutionary",
       "initiative": 2,
       "limited": 1,
-      "xws": "l337-2",
+      "xws": "l337",
       "ability": "If you are not shielded, decrease the difficulty of your bank ([Bank Left] and [Bank Right]) maneuvers.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/a8/f4/a8f42e81-3eef-49d2-9887-8d71ae70cabc/swz04_l3-37.png"
     },

--- a/data/pilots/scum-and-villainy/customized-yt-1300-light-freighter.json
+++ b/data/pilots/scum-and-villainy/customized-yt-1300-light-freighter.json
@@ -46,6 +46,7 @@
       "caption": "The Corellian Kid",
       "initiative": 6,
       "limited": 1,
+      "xws": "hansolo",
       "ability": "Whlie you defend or perform a primary attack, if the attack is obstructed by an obstacle, you may roll 1 additional die.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/ee/b4/eeb48172-25f2-461e-979a-18b835b834a4/swz04_han-solo.png"
     },
@@ -54,6 +55,7 @@
       "caption": "Droid Revolutionary",
       "initiative": 2,
       "limited": 1,
+      "xws": "l337-2",
       "ability": "If you are not shielded, decrease the difficulty of your bank ([Bank Left] and [Bank Right]) maneuvers.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/a8/f4/a8f42e81-3eef-49d2-9887-8d71ae70cabc/swz04_l3-37.png"
     },
@@ -62,6 +64,7 @@
       "caption": "Smooth-talking Gambler",
       "initiative": 4,
       "limited": 1,
+      "xws": "landocalrissian",
       "ability": "After you roll dice, if you are not stressed, you may gain 1 stress token to reroll all of your blank results.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/8a/97/8a977269-7a61-47b4-9a89-b51c03de8dc5/swz04_a1_pilot-card_lando.png"
     }

--- a/data/pilots/scum-and-villainy/escape-craft.json
+++ b/data/pilots/scum-and-villainy/escape-craft.json
@@ -52,6 +52,12 @@
       "charges": {
         "value": 3,
         "recovers": 0
+      },
+      "shipOverride": {
+        "ability": {
+          "name": "Rigged Energy Cells",
+          "text": "During the System Phase, if you are not docked, lose 1 [Charge]. At the end of the Activation Phase, if you have 0 [Charge], you are destroyed. Before you are removed, each ship at range 0-1 suffers 1 [Critical Hit] damage."
+        }
       }
     },
     {
@@ -59,7 +65,7 @@
       "caption": "Droid Revolutionary",
       "initiative": 2,
       "limited": 1,
-      "xws": "l337",
+      "xws": "l337-2",
       "ability": "If you are not shielded, decrease the difficulty of your bank ([Bank Left] and [Bank Right]) maneuvers.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/c5/b0/c5b059ab-d58e-469c-b484-44caad6c8989/swz04_l3-37-escape-craft.png"
     },

--- a/data/pilots/scum-and-villainy/escape-craft.json
+++ b/data/pilots/scum-and-villainy/escape-craft.json
@@ -46,6 +46,7 @@
       "caption": "Set to Blow",
       "initiative": 1,
       "limited": 1,
+      "xws": "autopilotdrone",
       "text": "Sometimes, manufacturer's warnings are made to be broken.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/6c/7f/6c7fa1cf-0e5e-45a0-998f-1aa45e9962fd/swz04_autopilot-drone.png",
       "charges": {
@@ -58,6 +59,7 @@
       "caption": "Droid Revolutionary",
       "initiative": 2,
       "limited": 1,
+      "xws": "l337",
       "ability": "If you are not shielded, decrease the difficulty of your bank ([Bank Left] and [Bank Right]) maneuvers.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/c5/b0/c5b059ab-d58e-469c-b484-44caad6c8989/swz04_l3-37-escape-craft.png"
     },
@@ -66,6 +68,7 @@
       "caption": "Skillful Outlaw",
       "initiative": 3,
       "limited": 1,
+      "xws": "outerrimpioneer",
       "ability": "Friendly ships at range 0-1 can perform attacks at range 0 of obstacles.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/1a/0d/1a0db6ff-cf52-453e-bcfb-7508c03b2359/swz04_outer-rim-pioneer.png"
     }

--- a/data/pilots/scum-and-villainy/fang-fighter.json
+++ b/data/pilots/scum-and-villainy/fang-fighter.json
@@ -46,6 +46,7 @@
       "caption": "Skull Leader",
       "initiative": 6,
       "limited": 1,
+      "xws": "fennrau",
       "ability": "While you defend or perform an attack, if the attack range is 1, you may roll 1 additional die.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/dc/98/dc9801d4-6dfc-40c7-bba4-d5d0ee3e9141/swz17_fenn-rau.png"
     },
@@ -54,6 +55,7 @@
       "caption": "Skull Squadron Ace",
       "initiative": 4,
       "limited": 1,
+      "xws": "joyrekkoff",
       "ability": "While you perform an attack, you may spend 1 [Charge] from an equipped [Torpedo] upgrade. If you do, the defender rolls 1 fewer defense die.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/58/d2/58d2c4e1-db42-45fd-8799-69e0fde2c6f5/swz17_joy-rekkoff.png"
     },
@@ -62,6 +64,7 @@
       "caption": "Skilled Commando",
       "initiative": 4,
       "limited": 1,
+      "xws": "kadsolus",
       "ability": "After you fully execute a red maneuver, gain 2 focus tokens.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/ba/79/ba79d3eb-de1d-4c07-ae03-15c28539ee2a/swz17_kad-solus.png"
     },
@@ -70,6 +73,7 @@
       "caption": "Mandalorian Mentor",
       "initiative": 5,
       "limited": 1,
+      "xws": "oldteroch",
       "ability": "At the start of the Engagement Phase, you may choose 1 enemy ship at range 1. If you do and you are in its [Front Arc], it removes all of its green tokens.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/66/2a/662af49d-0a41-43e9-972c-871bef1b6fe2/swz17_old-teroch.png"
     },
@@ -77,6 +81,7 @@
       "name": "Skull Squadron Pilot",
       "initiative": 4,
       "limited": 0,
+      "xws": "skullsquadronpilot",
       "text": "The aces of Skull Squadron favor an aggressive approach, using their craft's pivot wing technology to achieve unmatched agility in the pursuit of their quarry.",
       "image": "https://i.imgur.com/9fXccsv.jpg"
     },
@@ -84,6 +89,7 @@
       "name": "Zealous Recruit",
       "initiative": 1,
       "limited": 0,
+      "xws": "zealousrecruit",
       "text": "Mandalorian Fang Fighter pilots must master the Concordia Faceoff maneuver, leveraging their ships' narrow attack profile to execute deadly head-on charges.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/96/90/9690e1b6-13fe-412c-aaea-b6edc987489b/swz17_zealous-recruit.png"
     }

--- a/data/pilots/scum-and-villainy/firespray-class-patrol-craft.json
+++ b/data/pilots/scum-and-villainy/firespray-class-patrol-craft.json
@@ -51,6 +51,7 @@
       "caption": "Notorious Bounty Hunter",
       "initiative": 5,
       "limited": 1,
+      "xws": "bobafett",
       "ability": "While you defend or perform an attack, you may reroll 1 of your dice for each enemy ship at range 0-1.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/12/a4/12a4f0af-510a-4f3e-8eb8-744ab23088cc/swz16_boba-fett.png"
     },
@@ -58,6 +59,7 @@
       "name": "Bounty Hunter",
       "initiative": 2,
       "limited": 0,
+      "xws": "bountyhunter",
       "text": "The Firespray-class patrol craft is infamous for its association with the deadly bounty hunters Jango Fett and Boba Fett, who packed their craft with countless deadly armaments.",
       "image": "https://i.imgur.com/ijynRyj.jpg"
     },
@@ -66,6 +68,7 @@
       "caption": "Shipping Magnate",
       "initiative": 4,
       "limited": 1,
+      "xws": "emonazzameen",
       "ability": "If you would drop a device using a [1 [Straight]] template, you may use the [3 [Turn Left]], [3 [Straight]], or [3 [Turn Right]] template instead.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/92/43/92434ad6-cac6-4a31-8e23-509b9559181d/swz16_emon-azzameen.png"
     },
@@ -74,6 +77,7 @@
       "caption": "Captain of the Binayre Pirates",
       "initiative": 4,
       "limited": 1,
+      "xws": "kathscarlet",
       "ability": "While you perform a primary attack, if there is at least 1 friendly non-limited ship at range 0 of the defender, roll 1 additional attack die.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/be/71/be7149e6-a385-4f79-b8eb-38329c0ba8c9/swz16_kath-scarlet.png"
     },
@@ -82,6 +86,7 @@
       "caption": "Icy Professional",
       "initiative": 3,
       "limited": 1,
+      "xws": "koshkafrost",
       "ability": "While you defend or perform an attack, if the enemy ship is stressed, you may reroll 1 of your dice.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/60/03/60031d7d-a625-4946-8e35-fcc82abfcd2d/swz16_koshka-frost.png"
     },
@@ -90,6 +95,7 @@
       "caption": "Imperial Deserter",
       "initiative": 3,
       "limited": 1,
+      "xws": "krassistrelix",
       "ability": "You can perform [Front Arc] special attacks from your [Rear Arc]. While you perform a special attack, you may reroll 1 attack die.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/f7/bb/f7bb3a41-d175-4ec7-b0fb-3bf79bba8245/swz16_krassis-trelix.png"
     }

--- a/data/pilots/scum-and-villainy/g-1a-starfighter.json
+++ b/data/pilots/scum-and-villainy/g-1a-starfighter.json
@@ -46,6 +46,7 @@
       "caption": "Reprogrammed Protocol Droid",
       "initiative": 3,
       "limited": 1,
+      "xws": "4lom",
       "ability": "After you fully execute a red maneuver, gain 1 calculate token. At the start of the End Phase, you may choose 1 ship at range 0-1. If you do, transfer 1 of your stress tokens to that ship.",
       "image": "https://i.imgur.com/Jbxrnua.png"
     },
@@ -53,6 +54,7 @@
       "name": "Gand Findsman",
       "initiative": 1,
       "limited": 0,
+      "xws": "gandfindsman",
       "text": "The legendary Findsmen of Gand worship enshrouding mists of their home planet, using signs, augurs, and mystical rituals to track their quarry.",
       "image": "https://i.imgur.com/yYVXjCS.png"
     },
@@ -61,6 +63,7 @@
       "caption": "Meditative Gand",
       "initiative": 3,
       "limited": 1,
+      "xws": "zuckuss",
       "ability": "While you perform a primary attack, you may roll 1 additional attack die. If you do, the defender rolls 1 additional defense die.",
       "image": "https://i.imgur.com/7FoHkE4.jpg"
     }

--- a/data/pilots/scum-and-villainy/hwk-290-light-freighter.json
+++ b/data/pilots/scum-and-villainy/hwk-290-light-freighter.json
@@ -44,6 +44,7 @@
       "caption": "Outer Rim Mercenary",
       "initiative": 4,
       "limited": 1,
+      "xws": "dacebonearm",
       "ability": "After an enemy ship at range 0-3 receives at least 1 ion token, you may spend 3 [Charge]. If you do, that ship gains 2 additional ion tokens.",
       "image": "https://i.imgur.com/Gecc5xw.png",
       "charges": {
@@ -56,6 +57,7 @@
       "caption": "Tethan Resister",
       "initiative": 3,
       "limited": 1,
+      "xws": "palobgodalhi",
       "ability": "At the start of the Engagement Phase, you may choose 1 enemy ship in your firing arc at range 0-2. If you do, transfer 1 focus or evade token from that ship to yourself.",
       "image": "https://i.imgur.com/UkY22MH.png"
     },
@@ -63,6 +65,7 @@
       "name": "Spice Runner",
       "initiative": 1,
       "limited": 0,
+      "xws": "spicerunner",
       "text": "Though its cargo space is limited compared to other light freighters, the small, swift HWK-290 is a favorite choice of smugglers who specialize in discreetly transporting precious goods.",
       "image": "https://i.imgur.com/PvrCwn6.png"
     },
@@ -71,6 +74,7 @@
       "caption": "Mercenary Miner",
       "initiative": 2,
       "limited": 1,
+      "xws": "torkilmux",
       "ability": "At the start of the Engagement Phase, you may choose 1 ship in your firing arc. If you do, that ship engages at initiative 0 instead of its normal initiative value this round.",
       "image": "https://i.imgur.com/Gecc5xw.png"
     }

--- a/data/pilots/scum-and-villainy/jumpmaster-5000.json
+++ b/data/pilots/scum-and-villainy/jumpmaster-5000.json
@@ -44,6 +44,7 @@
       "name": "Contracted Scout",
       "initiative": 2,
       "limited": 0,
+      "xws": "contractedscout",
       "text": "Built for long-distance reconnaissance and plotting new hyperspace routes, the lightly armed JumpMaster 5000 is often extensively retrofitted with custom upgrades.",
       "image": "https://i.imgur.com/FEZzvV0.png"
     },
@@ -52,6 +53,7 @@
       "caption": "Vengeful Corellian",
       "initiative": 6,
       "limited": 1,
+      "xws": "dengar",
       "ability": "After you defend, if the attcker is in your [Front Arc], you may spend 1 [Charge] to perform a bonus attack against the attacker.",
       "image": "https://i.imgur.com/Pli4hOp.png",
       "charges": {
@@ -64,6 +66,7 @@
       "caption": "Graceful Aruzan",
       "initiative": 3,
       "limited": 1,
+      "xws": "manaroo",
       "ability": "At the start of the Engagement Phase, you may choose a friendly ship at range 0-1. If you do, transfer all green tokens assigned to you to that ship.",
       "image": "https://i.imgur.com/Jmm6wZQ.jpg"
     },
@@ -72,6 +75,7 @@
       "caption": "Escape Artist",
       "initiative": 4,
       "limited": 1,
+      "xws": "teltrevura",
       "ability": "If you would be destroyed, you may spend 1 [Charge]. If you do, discard all of your damage cards, suffer 5 [Hit] damage, and place yourself in reserves instead. At the start of the next planning phase, place yourself within range 1 of your player edge.",
       "image": "https://i.imgur.com/FeUMuVx.jpg",
       "charges": {

--- a/data/pilots/scum-and-villainy/kihraxz-fighter.json
+++ b/data/pilots/scum-and-villainy/kihraxz-fighter.json
@@ -44,6 +44,7 @@
       "name": "Black Sun Ace",
       "initiative": 3,
       "limited": 0,
+      "xws": "blacksunace",
       "text": "The Kihraxz assault fighter was developed specifically for the Black Sun crime syndicate, whose highly paid ace pilots demanded a nimble, powerful ship to match their skills.",
       "image": "https://i.imgur.com/ZYRFasJ.jpg"
     },
@@ -52,6 +53,7 @@
       "caption": "Aggressive Opportunist",
       "initiative": 3,
       "limited": 1,
+      "xws": "captainjostero",
       "ability": "After an enemy ship suffers damage, if it is not defending, you may perform a bonus attack against that ship.",
       "image": "https://i.imgur.com/67wUh8L.jpg"
     },
@@ -59,6 +61,7 @@
       "name": "Cartel Marauder",
       "initiative": 2,
       "limited": 0,
+      "xws": "cartelmarauder",
       "text": "The versatile Kihraxz was modeled after Incom's popular X-wing starfighter, but an array of aftermarket modification kits ensure a wide variety of designs.",
       "image": "https://i.imgur.com/kdQmuom.png"
     },
@@ -67,6 +70,7 @@
       "caption": "The Hunter",
       "initiative": 4,
       "limited": 1,
+      "xws": "graz",
       "ability": "While you defend, if you are behind the attacker, roll 1 additional defense die. While you perform an attack, if you are behind the defender roll 1 additional attack die.",
       "image": "https://i.imgur.com/OXH2wCn.jpg"
     },
@@ -75,6 +79,7 @@
       "caption": "Scourge of Tansarii Point",
       "initiative": 5,
       "limited": 1,
+      "xws": "talonbanecobra",
       "ability": "While you defend at attack range 3 or perform an attack at range 1, roll 1 additional die.",
       "image": "https://i.imgur.com/AWCWeti.png"
     },
@@ -83,6 +88,7 @@
       "caption": "Storied Bounty Hunter",
       "initiative": 4,
       "limited": 1,
+      "xws": "viktorhel",
       "ability": "After you defend, if you did not roll exactly 2 defense dice, the attack gains 1 stress token.",
       "image": "https://i.imgur.com/alrLzq1.jpg"
     }

--- a/data/pilots/scum-and-villainy/lancer-class-pursuit-craft.json
+++ b/data/pilots/scum-and-villainy/lancer-class-pursuit-craft.json
@@ -50,6 +50,7 @@
       "caption": "Force of Her Own",
       "initiative": 4,
       "limited": 1,
+      "xws": "asajjventress",
       "ability": "At the start of the Engagement Phase, you may choose 1 enemy ship in your [Single Turret Arc] at range 0-2 and spend 1 [Force] token. If you do, that ship gains 1 stress token unless it removes 1 green token.",
       "image": "https://i.imgur.com/QNxgpV2.png",
       "force": {
@@ -62,6 +63,7 @@
       "caption": "Black Sun Contractor",
       "initiative": 5,
       "limited": 1,
+      "xws": "ketsuonyo",
       "ability": "At the start of the Engagement Phase, you may choose 1 ship in both your [Front Arc] and [Single Turret Arc] at range 0-1. If you do, that ship gains 1 tractor token.",
       "image": "https://i.imgur.com/9F0QVHS.jpg"
     },
@@ -70,6 +72,7 @@
       "caption": "Artistic Saboteur",
       "initiative": 3,
       "limited": 1,
+      "xws": "sabinewren-2",
       "ability": "While you defend, if the attacker is in your [Single Turret Arc] at range 0-2, you may add 1 [Focus] result to your dice results.",
       "image": "https://i.imgur.com/DzAs19y.jpg"
     },
@@ -77,6 +80,7 @@
       "name": "Shadowport Hunter",
       "initiative": 2,
       "limited": 0,
+      "xws": "shadowporthunter",
       "text": "Crime syndicates augment the lethal skills of their loyal contractors with the best technology available, like the fast and formidable Lancer-class pursuit craft.",
       "image": "https://i.imgur.com/2kjsK1O.png"
     }

--- a/data/pilots/scum-and-villainy/m12-l-kimogila-fighter.json
+++ b/data/pilots/scum-and-villainy/m12-l-kimogila-fighter.json
@@ -48,6 +48,7 @@
       "name": "Cartel Executioner",
       "initiative": 3,
       "limited": 0,
+      "xws": "cartelexecutioner",
       "text": "Many veteran pilots in the service of the Hutt kajidics and other criminal operations choose the M12-L Kimogila for its firepower and dreaded reputation alike.",
       "image": "https://i.imgur.com/pMzEnFO.png"
     },
@@ -56,6 +57,7 @@
       "caption": "Returned from the Grave",
       "initiative": 3,
       "limited": 1,
+      "xws": "dalanoberos",
       "ability": "At the start of the Engagement Phase, you may choose 1 shielded ship in your [Bullseye Arc] and spend 1 [Charge]. If you do, that ship loses 1 shield and you recover 1 shield.",
       "image": "https://i.imgur.com/3SB3ZdP.jpg",
       "charges": {
@@ -68,6 +70,7 @@
       "caption": "Rodian Freelancer",
       "initiative": 4,
       "limited": 1,
+      "xws": "toranikulda",
       "ability": "After you perform an attack, each enemy ship in your [Bullseye Arc] suffers 1 [Hit] damage unless it removes 1 green token.",
       "image": "https://i.imgur.com/NVYYF9t.jpg"
     }

--- a/data/pilots/scum-and-villainy/m3-a-interceptor.json
+++ b/data/pilots/scum-and-villainy/m3-a-interceptor.json
@@ -48,6 +48,7 @@
       "name": "Cartel Spacer",
       "initiative": 1,
       "limited": 0,
+      "xws": "cartelspacer",
       "text": "MandalMotors' M3-A 'Scyk' Inteceptor is purchased in large quantities by the Hutt Cartel and the Car'das smugglers due to its low cost and customizability.",
       "image": "https://i.imgur.com/R5Wa2QC.png"
     },
@@ -56,6 +57,7 @@
       "caption": "Tansarii Point Crime Lord",
       "initiative": 4,
       "limited": 1,
+      "xws": "genesisred",
       "ability": "After you acquire a lock, you must remove all of your focus and evade tokens. Then gain the same number of focus and evade tokens that the locked ship has.",
       "image": "https://i.imgur.com/J3HT3lm.jpg"
     },
@@ -64,6 +66,7 @@
       "caption": "Tansarii Point Boss",
       "initiative": 2,
       "limited": 1,
+      "xws": "inaldra",
       "ability": "While you defend or perform an attack, you may suffer 1 [Hit] damage to reroll any number of your dice.",
       "image": "https://i.imgur.com/InCjYYa.jpg"
     },
@@ -72,6 +75,7 @@
       "caption": "Car'das Enforcer",
       "initiative": 3,
       "limited": 1,
+      "xws": "laetinashera",
       "ability": "After you defend or perform an attack, if the attack missed, gain 1 evade token.",
       "image": "https://i.imgur.com/vsstiQo.jpg"
     },
@@ -80,6 +84,7 @@
       "caption": "Fortune Seeker",
       "initiative": 3,
       "limited": 1,
+      "xws": "quinnjast",
       "ability": "At the start of the Engagement Phase, you may gain 1 disarm token to recover 1 [Charge] on 1 of your equipped upgrades.",
       "image": "https://i.imgur.com/iRMmmNF.jpg"
     },
@@ -88,6 +93,7 @@
       "caption": "Flight Instructor",
       "initiative": 5,
       "limited": 1,
+      "xws": "serissu",
       "ability": "While a friendly ship at range 0-1 defends, it may reroll 1 of its dice.",
       "image": "https://i.imgur.com/LOJ9OWn.jpg"
     },
@@ -96,6 +102,7 @@
       "caption": "Incurable Optimist",
       "initiative": 1,
       "limited": 1,
+      "xws": "sunnybounder",
       "ability": "While you defend or perform an attack, after you roll or reroll your dice, if you have the same result on each of your dice, you may add 1 matching result.",
       "image": "https://i.imgur.com/VzDyCnd.jpg"
     },
@@ -103,6 +110,7 @@
       "name": "Tansarii Point Veteran",
       "initiative": 3,
       "limited": 0,
+      "xws": "tansariipointveteran",
       "text": "The defeat of Black Sun ace Talonbane Cobra by Car'das smugglers turned the tide of the Battle of Tansarii Point Station. Survivors of the clash are respected throughout the sector.",
       "image": "https://i.imgur.com/lFYeL8f.jpg"
     }

--- a/data/pilots/scum-and-villainy/quadrijet-transfer-spacetug.json
+++ b/data/pilots/scum-and-villainy/quadrijet-transfer-spacetug.json
@@ -47,6 +47,7 @@
       "caption": "Missing Sheriff of Nima Outpost",
       "initiative": 4,
       "limited": 1,
+      "xws": "constablezuvio",
       "ability": "If you would drop a device, you may launch it using a [1 [Straight]] template instead.",
       "image": "https://i.imgur.com/7a7O9wm.jpg"
     },
@@ -54,6 +55,7 @@
       "name": "Jakku Gunrunner",
       "initiative": 1,
       "limited": 0,
+      "xws": "jakkugunrunner",
       "text": "The Quadrijet transfer spacetug, commonly called a \"Quadjumper\" is nimble in space and atmosphere alike, making it popular among both smugglers and explorers.",
       "image": "https://i.imgur.com/HT0F6Yv.png"
     },
@@ -62,6 +64,7 @@
       "caption": "The Scavenger",
       "initiative": 2,
       "limited": 1,
+      "xws": "sarcoplank",
       "ability": "While you defend, you may treat your agility value as equal to the speed of the maneuver you executed this round.",
       "image": "https://i.imgur.com/vCOYuiJ.jpg"
     },
@@ -70,6 +73,7 @@
       "caption": "Miserly Portion Master",
       "initiative": 2,
       "limited": 1,
+      "xws": "unkarplutt",
       "ability": "At the start of the Engagement Phase, if there are one or more other ships at range 0, you and each other ship at range 0 gain 1 tractor token.",
       "image": "https://i.imgur.com/VCf87Ha.png"
     }

--- a/data/pilots/scum-and-villainy/scurrg-h-6-bomber.json
+++ b/data/pilots/scum-and-villainy/scurrg-h-6-bomber.json
@@ -45,6 +45,7 @@
       "caption": "Captain of the Lok Revenants",
       "initiative": 5,
       "limited": 1,
+      "xws": "captainnym",
       "ability": "Before a friendly bomb or mine would detonate, you may spend 1 [Charge] to prevent it from detonating. While you defend against an attack obstructed by a bomb or mine, roll 1 additional defense die.",
       "image": "https://i.imgur.com/K6HMkzW.jpg",
       "charges": {
@@ -56,6 +57,7 @@
       "name": "Lok Revenant",
       "initiative": 2,
       "limited": 0,
+      "xws": "lokrevenant",
       "text": "The Nubian Design Collective crafted the Scurrg H-6 Bomber with combat versatility in mind, arming it with powerful shields and a bristling array of destructive weaponry.",
       "image": "https://i.imgur.com/oA7Cb6x.png"
     },
@@ -64,6 +66,7 @@
       "caption": "Cunning Commander",
       "initiative": 3,
       "limited": 1,
+      "xws": "solsixxa",
       "ability": "If you would drop a device using a [1 [Straight]] template, you may drop it using any other speed 1 template instead.",
       "image": "https://i.imgur.com/K5fOl1Z.jpg"
     }

--- a/data/pilots/scum-and-villainy/starviper-class-attack-platform.json
+++ b/data/pilots/scum-and-villainy/starviper-class-attack-platform.json
@@ -48,6 +48,7 @@
       "name": "Black Sun Assassin",
       "initiative": 3,
       "limited": 0,
+      "xws": "blacksunassassin",
       "text": "Although assassinations can be handled with a shot in the dark or a dire substance added to a drink, a flaming shuttle tumbling from the sky sends a special kind of message.",
       "image": "https://i.imgur.com/UHxIn6d.jpg"
     },
@@ -55,6 +56,7 @@
       "name": "Black Sun Enforcer",
       "initiative": 2,
       "limited": 0,
+      "xws": "blacksunenforcer",
       "text": "Prince Xizor himself collaborated with MandalMotors to design the StarViper-class attack platform, one of the most formidable starfighters in the galaxy.",
       "image": "https://i.imgur.com/JK3Fwdu.png"
     },
@@ -63,6 +65,7 @@
       "caption": "Elite Bounty Hunter",
       "initiative": 4,
       "limited": 1,
+      "xws": "dalanoberos-2",
       "ability": "After you fully execute a maneuver, you ay gain 1 stress token to rotate your ship 90˚.",
       "image": "https://i.imgur.com/AK9lYGC.jpg"
     },
@@ -71,6 +74,7 @@
       "caption": "Prince Xizor's Bodyguard",
       "initiative": 5,
       "limited": 1,
+      "xws": "guri",
       "ability": "At the start of the Engagement Phase, if there is at least 1 enemy ship at range 0-1, you may gain 1 focus token.",
       "image": "https://i.imgur.com/ber6srQ.png"
     },
@@ -79,6 +83,7 @@
       "caption": "Black Sun Kingpin",
       "initiative": 4,
       "limited": 1,
+      "xws": "princexizor",
       "ability": "While you defend, after the Neutralize Results step, another friendly ship at range 0-1 and in the attack arc may suffer 1 [Hit] or [Critical Hit] damage. If it does, cancel 1 matching result.",
       "image": "https://i.imgur.com/kgLm5yQ.png"
     }

--- a/data/pilots/scum-and-villainy/yv-666-light-freighter.json
+++ b/data/pilots/scum-and-villainy/yv-666-light-freighter.json
@@ -44,6 +44,7 @@
       "caption": "Fearsome Hunter",
       "initiative": 4,
       "limited": 1,
+      "xws": "bossk",
       "ability": "While you perform a primary attack, after the Neutralize Results step, you may spend 1 [Critical Hit] result to add 2 [Hit] results.",
       "image": "https://i.imgur.com/CKPzcSB.png"
     },
@@ -52,6 +53,7 @@
       "caption": "Martial Artist",
       "initiative": 3,
       "limited": 1,
+      "xws": "lattsrazzi",
       "ability": "At the start of the Engagement Phase, you may choose a ship at range 1 and spend a lock you have on that ship. If you do, that ship gains 1 tractor token.",
       "image": "https://i.imgur.com/sqpKyIj.jpg"
     },
@@ -60,6 +62,7 @@
       "caption": "Criminal Mastermind",
       "initiative": 4,
       "limited": 1,
+      "xws": "moraloeval",
       "ability": "If you would flee, you may spend 1 [Charge]. If you do, place yourself in reserves instead. At the start of the next Planning Phase, place youself within range 1 of the edge of the play area that you fled from.",
       "image": "https://i.imgur.com/kn89diB.png",
       "charges": {
@@ -72,6 +75,7 @@
       "caption": "Fearsome Hunter",
       "initiative": 2,
       "limited": 0,
+      "xws": "trandoshanslaver",
       "text": "The spacious triple-decker design of the YV-666 makes it popular among bounty hunters and slavers, who often retrofit an entire deck for prisoner transport.",
       "image": "https://i.imgur.com/oL3jSvG.png"
     }

--- a/data/pilots/scum-and-villainy/z-95-af4-headhunter.json
+++ b/data/pilots/scum-and-villainy/z-95-af4-headhunter.json
@@ -44,6 +44,7 @@
       "name": "Binayre Pirate",
       "initiative": 1,
       "limited": 0,
+      "xws": "binayrepirate",
       "text": "Operating from the Double Worlds, Talus and Tralus, Kath Scarlet's gang of smugglers and pirates would never be described as reputable or dependable - even by other criminals.",
       "image": "https://i.imgur.com/6omMe5j.png"
     },
@@ -51,6 +52,7 @@
       "name": "Black Sun Soldier",
       "initiative": 3,
       "limited": 0,
+      "xws": "blacksunsoldier",
       "text": "The vast and influential Black Sun crime syndicate can always find a use for talented pilots, provided they aren't particular about how they earn their credits.",
       "image": "https://i.imgur.com/UzPH9n1.jpg"
     },
@@ -59,6 +61,7 @@
       "caption": "Imposing Marauder",
       "initiative": 3,
       "limited": 1,
+      "xws": "kaatoleeachos",
       "ability": "At the start of the Engagement Phase, you may choose 1 friendly ship at range 0-2. If you do, transfer 1 focus or evade token from that ship to yourself.",
       "image": "https://i.imgur.com/Y5W8G9t.jpg"
     },
@@ -67,6 +70,7 @@
       "caption": "Hunt Saboteur",
       "initiative": 4,
       "limited": 1,
+      "xws": "ndrusuhlak",
       "ability": "While you perform a primary attack, if there are no other friendly ships at range 0-2, roll 1 additional attack die."
     },
     {
@@ -74,6 +78,7 @@
       "caption": "Contingency Plan",
       "initiative": 0,
       "limited": 1,
+      "xws": "nashtahpup",
       "ability": "You can deploy only via emergency deployment, and you have the name, initiative, pilot ability, and ship [Charge] of the friendly, destroyed Hound's Tooth."
     }
   ]

--- a/data/pilots/scum-and-villainy/z-95-af4-headhunter.json
+++ b/data/pilots/scum-and-villainy/z-95-af4-headhunter.json
@@ -79,7 +79,13 @@
       "initiative": 0,
       "limited": 1,
       "xws": "nashtahpup",
-      "ability": "You can deploy only via emergency deployment, and you have the name, initiative, pilot ability, and ship [Charge] of the friendly, destroyed Hound's Tooth."
+      "ability": "You can deploy only via emergency deployment, and you have the name, initiative, pilot ability, and ship [Charge] of the friendly, destroyed Hound's Tooth.",
+      "shipOverride": {
+        "ability": {
+          "name": "Escape Craft",
+          "text": "Setup: Requires the Hound's Tooth. You must begin the game docked with the Hound's Tooth."
+        }
+      }
     }
   ]
 }

--- a/data/upgrades/astromech-droid.json
+++ b/data/upgrades/astromech-droid.json
@@ -6,6 +6,7 @@
       {
         "title": "\"Chopper\"",
         "type": "Astromech Droid",
+        "xws": "chopper",
         "ability": "Action: Spend 1 non-recurring [Charge] from another equipped upgrade to recover 1 shield. Action: Spend 2 shields to recover 1 non-recurring [Charge] on an equipped upgrade.",
         "slots": [
           "Astromech Droid"
@@ -20,6 +21,7 @@
       {
         "title": "\"Genius\"",
         "type": "Astromech Droid",
+        "xws": "genius",
         "ability": "After you fully execute a maneuver, if you have not dropped or launched a device this round, you may drop 1 bomb.",
         "slots": [
           "Astromech Droid"
@@ -34,6 +36,7 @@
       {
         "title": "R2 Astromech",
         "type": "Astromech Droid",
+        "xws": "r2astromech",
         "ability": "After you reveal your dial, you may spend 1 [Charge] and gain 1 disarm token to recover 1 shield.",
         "slots": [
           "Astromech Droid"
@@ -52,6 +55,7 @@
       {
         "title": "R2-D2",
         "type": "Astromech Droid",
+        "xws": "r2d2",
         "ability": "After you reveal your dial, you may spend 1 [Charge] and gain 1 disarm token to recover 1 shield.",
         "slots": [
           "Astromech Droid"
@@ -70,6 +74,7 @@
       {
         "title": "R3 Astromech",
         "type": "Astromech Droid",
+        "xws": "r3astromech",
         "ability": "You can maintain up to 2 locks. Each lock must be on a different object. After you perform a [Lock] action, you may acquire a lock.",
         "slots": [
           "Astromech Droid"
@@ -84,6 +89,7 @@
       {
         "title": "R4 Astromech",
         "type": "Astromech Droid",
+        "xws": "r4astromech",
         "ability": "Decrease the difficulty of your speed 1-2 basic maneuvers ([Turn Left], [Bank Left], [Straight], [Bank Right], [Turn Right]).",
         "slots": [
           "Astromech Droid"
@@ -98,6 +104,7 @@
       {
         "title": "R5 Astromech",
         "type": "Astromech Droid",
+        "xws": "r5astromech",
         "ability": "Action: Spend 1 [Charge] to repair 1 facedown damage card. Action: Repair 1 faceup Ship damage card.",
         "slots": [
           "Astromech Droid"
@@ -116,6 +123,7 @@
       {
         "title": "R5-D8",
         "type": "Astromech Droid",
+        "xws": "r5d8",
         "ability": "Action: Spend 1 [Charge] to repair 1 facedown damage card. Action: Repair 1 faceup Ship damage card.",
         "slots": [
           "Astromech Droid"
@@ -134,6 +142,7 @@
       {
         "title": "R5-P8",
         "type": "Astromech Droid",
+        "xws": "r5p8",
         "ability": "While you perform an attack against a defender in your [Front Arc], you mayspend 1 [Charge] to reroll 1 attack die. If the rerolled results is a [Critical Hit], suffer 1 [Critical Hit] damage.",
         "slots": [
           "Astromech Droid"
@@ -152,6 +161,7 @@
       {
         "title": "R5-TK",
         "type": "Astromech Droid",
+        "xws": "r5tk",
         "ability": "You can perform attacks against friendly ships.",
         "slots": [
           "Astromech Droid"

--- a/data/upgrades/cannon.json
+++ b/data/upgrades/cannon.json
@@ -6,6 +6,7 @@
       {
         "title": "Heavy Laser Cannon",
         "type": "Cannon",
+        "xws": "heavylasercannon",
         "ability": "Attack: After the Modify Attack Dice step, change all [Critical Hit] results to [Hit] results.",
         "slots": [
           "Cannon"
@@ -26,6 +27,7 @@
       {
         "title": "Ion Cannon",
         "type": "Cannon",
+        "xws": "ioncannon",
         "ability": "Attack: If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
         "slots": [
           "Cannon"
@@ -46,6 +48,7 @@
       {
         "title": "Jamming Beam",
         "type": "Cannon",
+        "xws": "jammingbeam",
         "ability": "Attack: If this attack hits, all [Hit]/[Critical Hit] results inflict jam tokens instead of damage.",
         "slots": [
           "Cannon"
@@ -66,6 +69,7 @@
       {
         "title": "Tractor Beam",
         "type": "Cannon",
+        "xws": "tractorbeam",
         "ability": "Attack: If this attack hits, all [Hit]/[Critical Hit] results inflict tractor tokens instead of damage.",
         "slots": [
           "Cannon"

--- a/data/upgrades/configuration.json
+++ b/data/upgrades/configuration.json
@@ -6,6 +6,7 @@
       {
         "title": "Os-1 Arsenal Loadout",
         "type": "Configuration",
+        "xws": "os1arsenalloadout",
         "ability": "While you have exactly 1 disarm token, you can still perform [Torpedo] and [Missile] attacks against targets you have locked. If you do, you cannot spend you lock during the attack. Add [Torpedo] and [Missile] slots.",
         "slots": [
           "Configuration"
@@ -20,6 +21,7 @@
       {
         "title": "Pivot Wing (Closed)",
         "type": "Configuration",
+        "xws": "pivotwingclosed",
         "ability": "While you defend, roll 1 fewer defense die. After you execute a [0 [Stationary]] maneuver, you may rotate your ship 90˚ or 180˚. Before you activate, you may flip this card.",
         "slots": [
           "Configuration"
@@ -28,6 +30,7 @@
       {
         "title": "Pivot Wing (Open)",
         "type": "Configuration",
+        "xws": "pivotwingopen",
         "ability": "Before you activate, you may flip this card.",
         "slots": [
           "Configuration"
@@ -42,6 +45,7 @@
       {
         "title": "Servomotor S-foils (Closed)",
         "type": "Configuration",
+        "xws": "servomotorsfoilsclosed",
         "ability": "While you perform a primary attack, roll 1 fewer attack die. Before you activate, you may flip this card.",
         "slots": [
           "Configuration"
@@ -64,6 +68,7 @@
       {
         "title": "Servomotor S-foils (Open)",
         "type": "Configuration",
+        "xws": "servomotorsfoilsopen",
         "ability": "Before you activate, you may flip this card.",
         "slots": [
           "Configuration"
@@ -78,6 +83,7 @@
       {
         "title": "Xg-1 Assault Configuration",
         "type": "Configuration",
+        "xws": "xg1assaultconfiguration",
         "ability": "While you have exactly 1 disarm token, uou can still perform [Cannon] attacks. While you perform a [Cannon] attack while disarmed, roll a maximum of 3 attack dice. Add [Cannon] slot.",
         "slots": [
           "Configuration"

--- a/data/upgrades/crew.json
+++ b/data/upgrades/crew.json
@@ -6,6 +6,7 @@
       {
         "title": "\"Chopper\"",
         "type": "Crew",
+        "xws": "chopper",
         "ability": "During the Perform Action step, you may perofrm 1 action, even while stressed. Adter you perform an action while stressed, suffer 1 [Hit] damage unless you expose 1 of your damage cards.",
         "slots": [
           "Crew"
@@ -20,6 +21,7 @@
       {
         "title": "\"Zeb\" Orrelios",
         "type": "Crew",
+        "xws": "zeborrelios",
         "ability": "You can perform primary attacks at range 0. Enemy ships at range 0 can perform primary attacks against you.",
         "slots": [
           "Crew"
@@ -34,6 +36,7 @@
       {
         "title": "0-0-0",
         "type": "Crew",
+        "xws": "000",
         "ability": "At the start of the Engagement Phase, you may choose 1 enemy ship at range 0-1. If you do, you gain 1 calculate token unless that ship chooses to gain 1 stress token.",
         "slots": [
           "Crew"
@@ -48,6 +51,7 @@
       {
         "title": "4-LOM",
         "type": "Crew",
+        "xws": "4lom",
         "ability": "While you perform an attack, after rolling attack dice, you may name a type of green token. If you do, gain 2 ion tokens and, during this attack, the defender cannot spend tokens of the named type.",
         "slots": [
           "Crew"
@@ -62,6 +66,7 @@
       {
         "title": "Admiral Sloane",
         "type": "Crew",
+        "xws": "admiralsloane",
         "ability": "After another friendly ship at range 0-3 defends, if it is destroyed, the attacker gains 2 stress tokens. While a friendly ship at range 0-3 performs an attack against a stressed ship, it may reroll 1 attack die.",
         "slots": [
           "Crew"
@@ -76,6 +81,7 @@
       {
         "title": "Agent Kallus",
         "type": "Crew",
+        "xws": "agentkallus",
         "ability": "Setup: Assign the Hunted condition to 1 enemy ship. While you perform an attack against th eship with the Hunted condition, you may change 1 of your [Focus] results to a [Hit] result.",
         "slots": [
           "Crew"
@@ -90,6 +96,7 @@
       {
         "title": "Baze Malbus",
         "type": "Crew",
+        "xws": "bazemalbus",
         "ability": "While you perform a [Focus] action, you may treat it as red. If you do, gain 1 additional focus token for each enemy ship at range 0-1 to a mazimum of 2.",
         "slots": [
           "Crew"
@@ -104,6 +111,7 @@
       {
         "title": "Boba Fett",
         "type": "Crew",
+        "xws": "bobafett",
         "ability": "Setup: Start in reserve. At the end of Setup, place yourself at range 0 of an obstacle and beyond range 3 of an enemy ship.",
         "slots": [
           "Crew"
@@ -118,6 +126,7 @@
       {
         "title": "C-3PO",
         "type": "Crew",
+        "xws": "c3po",
         "ability": "Before rolling defense dice, you may spend 1 calculate token to guess aloud a number 1 or higher. If you do, and you roll exactly that many [Evade] results, add 1 [Evade] result. Adter you perform the [Calculate] action, gain 1 calculate token.",
         "slots": [
           "Crew"
@@ -138,6 +147,7 @@
       {
         "title": "Cad Bane",
         "type": "Crew",
+        "xws": "cadbane",
         "ability": "After you drop or launch a device, you may perform a red [Boost] action.",
         "slots": [
           "Crew"
@@ -152,6 +162,7 @@
       {
         "title": "Cassian Andor",
         "type": "Crew",
+        "xws": "cassianandor",
         "ability": "During the System Phase, you may choose 1 enemy ship at range 1-2 and guess aloud a bearing and speed, then look at that ship's dial. If the chosen ship's bearing and speed match your guess, you may set your dial to another maneuver.",
         "slots": [
           "Crew"
@@ -166,6 +177,7 @@
       {
         "title": "Chewbacca",
         "type": "Crew",
+        "xws": "chewbacca-2",
         "ability": "At the start of the End Phase, you may spend 1 focus token to repair 1 of your faceup damage cards.",
         "slots": [
           "Crew"
@@ -180,6 +192,7 @@
       {
         "title": "Chewbacca",
         "type": "Crew",
+        "xws": "chewbacca",
         "ability": "At the start of the Engagement Phase, you may spend 2 [Charge] to repair 1 faceup damage card.",
         "slots": [
           "Crew"
@@ -198,6 +211,7 @@
       {
         "title": "Ciena Ree",
         "type": "Crew",
+        "xws": "cienaree",
         "ability": "After you perform a [Coordinate] action, if the ship you coordinated performed a [Barrel Roll] or [Boost] action, it may gain 1 stress token to rotate 90˚.",
         "slots": [
           "Crew"
@@ -212,6 +226,7 @@
       {
         "title": "Cikatro Vizago",
         "type": "Crew",
+        "xws": "cikatrovizago",
         "ability": "During the End Phase, you may choose 2 [UNKNOWN-ILLICIT] upgrades equipped to friendly ships at range 0-1. If you do, you may exchange these upgrades. End of Game: Return all [UNKNOWN-ILLICIT] upgrades to their original ships.",
         "slots": [
           "Crew"
@@ -226,6 +241,7 @@
       {
         "title": "Darth Vader",
         "type": "Crew",
+        "xws": "darthvader",
         "ability": "At the start of the Engagement Phase, you may choose 1 ship in your firing arc at range 0-2 and spend 1 [Force]. If you do, that ship suffers 1 [Hit] damage unless it chooses to remove 1 green token.",
         "slots": [
           "Crew"
@@ -244,6 +260,7 @@
       {
         "title": "Death Troopers",
         "type": "Crew",
+        "xws": "deathtroopers",
         "ability": "During the Activation Phase, enemy ships at range 0-1 cannot remove stress tokens.",
         "slots": [
           "Crew",
@@ -259,6 +276,7 @@
       {
         "title": "Director Krennic",
         "type": "Crew",
+        "xws": "directorkrennic",
         "ability": "Setup: Before placing forces, assign the Optimized Prototype condition to another friendly ship.",
         "slots": [
           "Crew"
@@ -279,6 +297,7 @@
       {
         "title": "Emperor Palpatine",
         "type": "Crew",
+        "xws": "emperorpalpatine",
         "ability": "While another friendly ship defends or performs an attack, you may spend 1 [Force] to modify 1 of its dice as though that ship had spent 1 [Force].",
         "slots": [
           "Crew",
@@ -298,6 +317,7 @@
       {
         "title": "Freelance Slicer",
         "type": "Crew",
+        "xws": "freelanceslicer",
         "ability": "While you defend, before attack dice are rolled, you may spend a lock you have on the attacker to roll 1 attack die. If you do, the attacker gains 1 [UNKNOWN-JAM] token. Then, on a [Hit] or [Critical Hit] result, gain 1 [UNKNOWN-JAM] token.",
         "slots": [
           "Crew"
@@ -312,6 +332,7 @@
       {
         "title": "GNK \"Gonk\" Droid",
         "type": "Crew",
+        "xws": "gnkgonkdroid",
         "ability": "Setup: Lose 1 [Charge]. Action: Recover 1 [Charge]. Action: Spend 1 [Charge] to recover 1 shield.",
         "slots": [
           "Crew"
@@ -330,6 +351,7 @@
       {
         "title": "Grand Inquisitor",
         "type": "Crew",
+        "xws": "grandinquisitor",
         "ability": "After an enemy ship at range 0-2 reveals its dial, you may spend 1 [Force] to perform 1 white action on your action bar, treating that action as red.",
         "slots": [
           "Crew"
@@ -348,6 +370,7 @@
       {
         "title": "Grand Moff Tarkin",
         "type": "Crew",
+        "xws": "grandmofftarkin",
         "ability": "During the System Phase, you may spend 2 [Charge]. If you do, each friendly ship may acquire a lock on a ship that you have locked.",
         "slots": [
           "Crew"
@@ -366,6 +389,7 @@
       {
         "title": "Han Solo",
         "type": "Crew",
+        "xws": "hansolo",
         "ability": "Before you engage, you may perform a red [Focus] action.",
         "slots": [
           "Crew"
@@ -380,6 +404,7 @@
       {
         "title": "Hera Syndulla",
         "type": "Crew",
+        "xws": "herasyndulla",
         "ability": "You can execute red maneuvers even while stressed. After you fully execute a red maneuver, if you ahve 3 or more stress tokens, remove 1 stress token and suffer 1 [Hit] damage.",
         "slots": [
           "Crew"
@@ -394,6 +419,7 @@
       {
         "title": "IG-88D",
         "type": "Crew",
+        "xws": "ig88d",
         "ability": "You have the pilot ability of each other friendly ship with the IG-2000 upgrade. After you perform a [Calculate] action, gain 1 calculate token.",
         "slots": [
           "Crew"
@@ -414,6 +440,7 @@
       {
         "title": "ISB Slicer",
         "type": "Crew",
+        "xws": "isbslicer",
         "ability": "During the End Phase, enemy ships at range 1-2 cannot remove jam tokens.",
         "slots": [
           "Crew"
@@ -428,6 +455,7 @@
       {
         "title": "Informant",
         "type": "Crew",
+        "xws": "informant",
         "ability": "Setup: After placing forces, choose 1 enemy ship and assign the Listening Device condition to it.",
         "slots": [
           "Crew"
@@ -442,6 +470,7 @@
       {
         "title": "Jabba the Hutt",
         "type": "Crew",
+        "xws": "jabbathehutt",
         "ability": "During the End Phase, you may choose 1 friendly ship at range 0-2 and spend 1 [Charge]. If you do, that ship recovers 1 [Charge] on 1 of its equipped [UNKNOWN-ILLICIT] upgrades.",
         "slots": [
           "Crew",
@@ -461,6 +490,7 @@
       {
         "title": "Jyn Erso",
         "type": "Crew",
+        "xws": "jynerso",
         "ability": "If a friendly ship at range 0-3 would gain a focus token, it may gain 1 evade token instead.",
         "slots": [
           "Crew"
@@ -475,6 +505,7 @@
       {
         "title": "Kanan Jarrus",
         "type": "Crew",
+        "xws": "kananjarrus",
         "ability": "After a friendly ship at range 0-2 fully executes a white maneuver, you may spend 1 [Force] to remove 1 stress token from that ship.",
         "slots": [
           "Crew"
@@ -493,6 +524,7 @@
       {
         "title": "Ketsu Onyo",
         "type": "Crew",
+        "xws": "ketsuonyo",
         "ability": "At the start of the End Phase, you may choose 1 enemy ship at range 0-2 in your firing arc. If you do, that ship does not remove its tractor tokens.",
         "slots": [
           "Crew"
@@ -507,6 +539,7 @@
       {
         "title": "L3-37",
         "type": "Crew",
+        "xws": "l337",
         "ability": "Setup: Equip this side faceup. While you defend, you may flip this card. If you do, the attack must reroll all attack dice.",
         "slots": [
           "Crew"
@@ -519,6 +552,7 @@
       {
         "title": "L3-37's Programming",
         "type": "Configuration",
+        "xws": "l337sprogramming",
         "ability": "If you are not shielded, decrease the difficulty of your bank ([Bank Left] and [Bank Right]) maneuvers.",
         "slots": [
           "Configuration"
@@ -533,6 +567,7 @@
       {
         "title": "Lando Calrissian",
         "type": "Crew",
+        "xws": "landocalrissian",
         "ability": "Action: Roll 2 defense dice. For each [Focus] result, gain 1 focus token. For each [Evade] result, game 1 evade token. If both results are blank, the opposing player chooses focus or evade. You gain 1 token of that type.",
         "slots": [
           "Crew"
@@ -547,6 +582,7 @@
       {
         "title": "Lando Calrissian",
         "type": "Crew",
+        "xws": "landocalrissian-2",
         "ability": "After you roll dice, you may spend 1 green token to reroll up to 2 of your results.",
         "slots": [
           "Crew"
@@ -561,6 +597,7 @@
       {
         "title": "Latts Razzi",
         "type": "Crew",
+        "xws": "lattsrazzi",
         "ability": "While you defend, if the attacker is stressed, you may remove 1 stress from the attacker to change 1 of your blank/[Focus] results to an [Evade] result.",
         "slots": [
           "Crew"
@@ -575,6 +612,7 @@
       {
         "title": "Leia Organa",
         "type": "Crew",
+        "xws": "leiaorgana",
         "ability": "At the start of the Activation Phase, you may spend 3 [Charge]. During this phase, each friendly ship reduces the difficulty of its red maneuvers.",
         "slots": [
           "Crew"
@@ -593,6 +631,7 @@
       {
         "title": "Magva Yarro",
         "type": "Crew",
+        "xws": "magvayarro",
         "ability": "After you defend, if the attack hit, you may acquire a lock on the attacker.",
         "slots": [
           "Crew"
@@ -607,6 +646,7 @@
       {
         "title": "Maul",
         "type": "Crew",
+        "xws": "maul",
         "ability": "After you suffer damage, you may gain 1 stress token to recover 1 [Force]. You can equip \"Dark Side\" upgades.",
         "slots": [
           "Crew"
@@ -625,6 +665,7 @@
       {
         "title": "Minister Tua",
         "type": "Crew",
+        "xws": "ministertua",
         "ability": "At the start of the Engagement Phase, if you are damaged, you may perform a red [UNKNOWN-REINFORCE] action.",
         "slots": [
           "Crew"
@@ -639,6 +680,7 @@
       {
         "title": "Moff Jerjerrod",
         "type": "Crew",
+        "xws": "moffjerjerrod",
         "ability": "During the System Phase, you may spend 2 [Charge]. If you do, choose the (1 [Bank Left]), (1 [Straight]), or (1 [Bank Right]) template. Each friendly ship may perform a red [Boost] action using that template.",
         "slots": [
           "Crew"
@@ -657,6 +699,7 @@
       {
         "title": "Nien Nunb",
         "type": "Crew",
+        "xws": "niennunb",
         "ability": "Decrease the difficulty of your bank maneuvers [[Bank Left] and [Bank Right]].",
         "slots": [
           "Crew"
@@ -671,6 +714,7 @@
       {
         "title": "Novice Technician",
         "type": "Crew",
+        "xws": "novicetechnician",
         "ability": "At the end of the round, you may roll 1 attack die to repair 1 faceup damage card. Then, on a [Hit] result, expose 1 damage card.",
         "slots": [
           "Crew"
@@ -685,6 +729,7 @@
       {
         "title": "Perceptive Copilot",
         "type": "Crew",
+        "xws": "perceptivecopilot",
         "ability": "After you perform a [Focus] action, gain 1 focus token.",
         "slots": [
           "Crew"
@@ -699,6 +744,7 @@
       {
         "title": "Qi'ra",
         "type": "Crew",
+        "xws": "qira",
         "ability": "While you move and perform attacks, you ignore all obstacles that you are locking.",
         "slots": [
           "Crew"
@@ -713,6 +759,7 @@
       {
         "title": "R2-D2",
         "type": "Crew",
+        "xws": "r2d2",
         "ability": "During the End Phase, if you are damaged and not shielded, you may roll 1 attack die to recover 1 shield. On a [Hit] result, expose 1 of your damage cards.",
         "slots": [
           "Crew"
@@ -727,6 +774,7 @@
       {
         "title": "Sabine Wren",
         "type": "Crew",
+        "xws": "sabinewren",
         "ability": "Setup: Place 1 ion, 1 jam, 1 stress, and 1 tractor token on this card. After a ship suffers the effect of a friendly bomb, you may remove 1 ion, jam, stress, or tractor token from this card. If you do, that ship gains a matching token.",
         "slots": [
           "Crew"
@@ -741,6 +789,7 @@
       {
         "title": "Saw Gerrera",
         "type": "Crew",
+        "xws": "sawgerrera",
         "ability": "While you perform an attack, you may suffer 1 [Hit] damage to change all of your [Focus] results to [Critical Hit] results.",
         "slots": [
           "Crew"
@@ -755,6 +804,7 @@
       {
         "title": "Seasoned Navigator",
         "type": "Crew",
+        "xws": "seasonednavigator",
         "ability": "After you reveal your dial, you may set your dial to another non-red maneuver of the same speed. While you execute that maneuver, increase its difficulty.",
         "slots": [
           "Crew"
@@ -769,6 +819,7 @@
       {
         "title": "Seventh Sister",
         "type": "Crew",
+        "xws": "seventhsister",
         "ability": "If an enemy ship at range 0-1 would gain a stress token, you may spend 1 [Force] to have it gain 1 jam or tractor token instead.",
         "slots": [
           "Crew"
@@ -787,6 +838,7 @@
       {
         "title": "Tactical Officer",
         "type": "Crew",
+        "xws": "tacticalofficer",
         "text": "In the chaos of a starfighter battle, a single order can mean the difference between a victory and a massacre.",
         "slots": [
           "Crew"
@@ -807,6 +859,7 @@
       {
         "title": "Tobias Beckett",
         "type": "Crew",
+        "xws": "tobiasbeckett",
         "ability": "Setup: After placing forces, you may choose 1 obstacle in the play area. If you do, place it anywhere in the play area beyond range 2 of any board edge or ship and beyond range 1 of other obstacles.",
         "slots": [
           "Crew"
@@ -821,6 +874,7 @@
       {
         "title": "Unkar Plutt",
         "type": "Crew",
+        "xws": "unkarplutt",
         "ability": "After you partially excute a maneuver, you may suffer 1 [Hit] damage to perform 1 white action.",
         "slots": [
           "Crew"
@@ -835,6 +889,7 @@
       {
         "title": "Zuckuss",
         "type": "Crew",
+        "xws": "zuckuss",
         "ability": "While you perform an attack, if ou are not stressed, you may choose 1 defense die and gain 1 stress token. If you do, the defender must reroll that die.",
         "slots": [
           "Crew"

--- a/data/upgrades/device.json
+++ b/data/upgrades/device.json
@@ -6,6 +6,7 @@
       {
         "title": "Bomblet Generator",
         "type": "Device",
+        "xws": "bombletgenerator",
         "ability": "Bomb During the System Phase, you may spend 1 [Charge] to drop a Bomblet with the [1 [Straight]] templete. At the start of the Activation Phase, you may spend 1 shield to recover 2 [Charge].",
         "slots": [
           "Device",
@@ -25,6 +26,7 @@
       {
         "title": "Conner Nets",
         "type": "Device",
+        "xws": "connernets",
         "ability": "Mine During the System Phase, you may spend 1 [Charge] to drop a Conner Net using the [1 [Straight]] template. This card's [Charge] cannot be recovered.",
         "slots": [
           "Device"
@@ -43,6 +45,7 @@
       {
         "title": "Proton Bombs",
         "type": "Device",
+        "xws": "protonbombs",
         "ability": "Bomb During the System Phase, you may spend 1 [Charge] to drop a Proton Bomb using the [1 [Straight]] template.",
         "slots": [
           "Device"
@@ -61,6 +64,7 @@
       {
         "title": "Proximity Mines",
         "type": "Device",
+        "xws": "proximitymines",
         "ability": "Mine During the System Phase, you may spend 1 [Charge] to drop a Proximity Mine using the [1 [Straight]] template. This card's [Charge] cannot be recovered.",
         "slots": [
           "Device"
@@ -79,6 +83,7 @@
       {
         "title": "Seismic Charges",
         "type": "Device",
+        "xws": "seismiccharges",
         "ability": "Bomb Suring the System Phase, you may spend 1 [Charge] to drop a Seismic Charge with the [1 [Straight]] template.",
         "slots": [
           "Device"

--- a/data/upgrades/force.json
+++ b/data/upgrades/force.json
@@ -6,6 +6,7 @@
       {
         "title": "Heightened Perception",
         "type": "Force",
+        "xws": "heightenedperception",
         "ability": "At the start of the Engagement Phase, you may spend 1 [Force]. If you do, engage at initiative 7 instead of your standard initiative value this phase.",
         "slots": [
           "Force"
@@ -20,6 +21,7 @@
       {
         "title": "Instinctive Aim",
         "type": "Force",
+        "xws": "instinctiveaim",
         "ability": "While you perform a special attack, you may spend 1 [Force] to ignore the [Focus] or [Lock] requirement.",
         "slots": [
           "Force"
@@ -34,6 +36,7 @@
       {
         "title": "Sense",
         "type": "Force",
+        "xws": "sense",
         "ability": "During the System Phase, you may choose 1 ship at range 0-1 and look at its dial. If you spend 1 [Force], you may choose a ship at range 0-3 instead.",
         "slots": [
           "Force"
@@ -48,6 +51,7 @@
       {
         "title": "Supernatural Reflexes",
         "type": "Force",
+        "xws": "supernaturalreflexes",
         "ability": "Before you activate, you may spend 1 [Force] to perform a [Barrel Roll] or [Boost] action. Then, if you performed an action you do not have on your action bar, suffer 1 [Hit] damage.",
         "slots": [
           "Force"

--- a/data/upgrades/gunner.json
+++ b/data/upgrades/gunner.json
@@ -6,6 +6,7 @@
       {
         "title": "BT-1",
         "type": "Gunner",
+        "xws": "bt1",
         "ability": "While you perform an attack, you may change 1 [Hit] result to a [Critical Hit] result for each stress token the defender has.",
         "slots": [
           "Gunner"
@@ -20,6 +21,7 @@
       {
         "title": "Bistan",
         "type": "Gunner",
+        "xws": "bistan",
         "ability": "After you perform a primary attack, if you are focused, you may perform a bonus [Turret] attack against a shipe you have not already attacked this round.",
         "slots": [
           "Gunner"
@@ -34,6 +36,7 @@
       {
         "title": "Bossk",
         "type": "Gunner",
+        "xws": "bossk",
         "ability": "After you perform a primary attack that misses, if you are not stressedm you must receive 1 stress token to perform a bonus primary attack against the same target.",
         "slots": [
           "Gunner"
@@ -48,6 +51,7 @@
       {
         "title": "Dengar",
         "type": "Gunner",
+        "xws": "dengar",
         "ability": "After you defend, if the attacker is in your firing arc, you may spend 1 [Charge]. If you do, roll 1 attack die unless the attacker chooses to remove 1 green token. On a [Hit] or [Critical Hit] result, the attacker suffers 1 [Hit] damage.",
         "slots": [
           "Gunner"
@@ -66,6 +70,7 @@
       {
         "title": "Ezra Bridger",
         "type": "Gunner",
+        "xws": "ezrabridger",
         "ability": "After you perform a primary attack, you may spend 1 [Force] to perform a bonus [Turret] attack from a [Turret] you have not attacked from this round. If you do and you are stressed, you may reroll 1 attack die.",
         "slots": [
           "Gunner"
@@ -84,6 +89,7 @@
       {
         "title": "Fifth Brother",
         "type": "Gunner",
+        "xws": "fifthbrother",
         "ability": "While you perform an attack, you may spend 1 [Force] to change 1 of your [Focus] results to a [Critical Hit] result.",
         "slots": [
           "Gunner"
@@ -102,6 +108,7 @@
       {
         "title": "Greedo",
         "type": "Gunner",
+        "xws": "greedo",
         "ability": "While you perform an attack, you may spend 1 [Charge] to change 1 [Hit] result to a [Critical Hit] result. While you defend, if your [Charge] is active, the attacker may change 1 [Hit] result to a [Critical Hit] result.",
         "slots": [
           "Gunner"
@@ -120,6 +127,7 @@
       {
         "title": "Han Solo",
         "type": "Gunner",
+        "xws": "hansolo",
         "ability": "During the Engagement Phase, at initiative 7, you may perform a [Turret] attack. You cannot attack from that [Turret] again this round.",
         "slots": [
           "Gunner"
@@ -134,6 +142,7 @@
       {
         "title": "Hotshot Gunner",
         "type": "Gunner",
+        "xws": "hotshotgunner",
         "ability": "While you perform a [Turret] attack, after the Modify Defense Dice step, the defender removes 1 focus or calculate token.",
         "slots": [
           "Gunner"
@@ -148,6 +157,7 @@
       {
         "title": "Luke Skywalker",
         "type": "Gunner",
+        "xws": "lukeskywalker",
         "ability": "At the start of the Engagement Phase, you may spend 1 [Force] to rotate your [Turret] indicator.",
         "slots": [
           "Gunner"
@@ -166,6 +176,7 @@
       {
         "title": "Skilled Bombardier",
         "type": "Gunner",
+        "xws": "skilledbombardier",
         "ability": "If you would drop or launch a device, you may use a template of the same bearing with a speed 1 higher or lower.",
         "slots": [
           "Gunner"
@@ -180,6 +191,7 @@
       {
         "title": "Veteran Tail Gunner",
         "type": "Gunner",
+        "xws": "veterantailgunner",
         "ability": "After you perform a primary [Front Arc] attack, you may perform a bonus primary [Rear Arc] attack.",
         "slots": [
           "Gunner"
@@ -194,6 +206,7 @@
       {
         "title": "Veteran Turret Gunner",
         "type": "Gunner",
+        "xws": "veteranturretgunner",
         "ability": "After you perform a primary attack, you may perform a bonus [Turret] attack using a [Turret] you did not already attack from this round.",
         "slots": [
           "Gunner"

--- a/data/upgrades/illicit.json
+++ b/data/upgrades/illicit.json
@@ -6,6 +6,7 @@
       {
         "title": "Cloaking Device",
         "type": "Illicit",
+        "xws": "cloakingdevice",
         "ability": "Action: Spend 1 [Charge] to perform a [Cloak] action. At the start of the Planning Phase, roll 1 attack die. On a [Focus] result, decloak or discard your cloak token.",
         "slots": [
           "Illicit"
@@ -24,6 +25,7 @@
       {
         "title": "Contraband Cybernetics",
         "type": "Illicit",
+        "xws": "contrabandcybernetics",
         "ability": "Before you activate, you may spend 1 [Charge]. If you do, until the end of the round, you can perform actions and execute red maneuvers, even while stressed.",
         "slots": [
           "Illicit"
@@ -42,6 +44,7 @@
       {
         "title": "Deadman's Switch",
         "type": "Illicit",
+        "xws": "deadmansswitch",
         "ability": "After you are destroyed, each other ship at range 0-1 suffers 1 [Hit] damage.",
         "slots": [
           "Illicit"
@@ -56,6 +59,7 @@
       {
         "title": "Feedback Array",
         "type": "Illicit",
+        "xws": "feedbackarray",
         "ability": "Before you engage, you may gain 1 ion token and 1 disarm token. If you do, each ship at range 0 suffers 1 [Hit] damage.",
         "slots": [
           "Illicit"
@@ -70,6 +74,7 @@
       {
         "title": "Inertial Dampeners",
         "type": "Illicit",
+        "xws": "inertialdampeners",
         "ability": "Before you would execute a maneuver, you may spend 1 shield. If you do, execute a white [0 [Stationary]] instead of the maneuver you revealed, then gain 1 stress token.",
         "slots": [
           "Illicit"
@@ -84,6 +89,7 @@
       {
         "title": "Rigged Cargo Chute",
         "type": "Illicit",
+        "xws": "riggedcargochute",
         "ability": "Action: Spend 1 [Charge]. Drop 1 loose cargo using the [1 [Straight]] template.",
         "slots": [
           "Illicit"

--- a/data/upgrades/missile.json
+++ b/data/upgrades/missile.json
@@ -6,6 +6,7 @@
       {
         "title": "Barrage Rockets",
         "type": "Missile",
+        "xws": "barragerockets",
         "ability": "Attack ([Focus]): Spend 1 [Charge]. If the defender is in your [Bullseye Arc], you may spend 1 or mroe [Charge] to reroll that many attack dice.",
         "slots": [
           "Missile"
@@ -30,6 +31,7 @@
       {
         "title": "Cluster Missiles",
         "type": "Missile",
+        "xws": "clustermissiles",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. After this attack, you may perform this attack as a bonus attack against a different target at range 0-1 of the defender, ignoring the [Lock] requirement.",
         "slots": [
           "Missile"
@@ -54,6 +56,7 @@
       {
         "title": "Concussion Missiles",
         "type": "Missile",
+        "xws": "concussionmissiles",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. After this attack hits, each ship at range 0-1 of the defender exposes 1 of its damage cards.",
         "slots": [
           "Missile"
@@ -78,6 +81,7 @@
       {
         "title": "Homing Missiles",
         "type": "Missile",
+        "xws": "homingmissiles",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. After you declare the defender, the defender may choose to suffer 1 [Hit] damage. If it does, skip the Attack and Defense Dice steps and the attack is treated as hitting.",
         "slots": [
           "Missile"
@@ -102,6 +106,7 @@
       {
         "title": "Ion Missiles",
         "type": "Missile",
+        "xws": "ionmissiles",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
         "slots": [
           "Missile"
@@ -126,6 +131,7 @@
       {
         "title": "Proton Rockets",
         "type": "Missile",
+        "xws": "protonrockets",
         "ability": "Attack ([Focus]): Spend 1 [Charge].",
         "slots": [
           "Missile"

--- a/data/upgrades/modification.json
+++ b/data/upgrades/modification.json
@@ -6,6 +6,7 @@
       {
         "title": "Ablative Plating",
         "type": "Modification",
+        "xws": "ablativeplating",
         "ability": "Before you would suffer damage from an obstacle or from a friendly bomb detonating, you may spend 1 [Charge]. If you do, prevent 1 damage.",
         "slots": [
           "Modification"
@@ -24,6 +25,7 @@
       {
         "title": "Advanced SLAM",
         "type": "Modification",
+        "xws": "advancedslam",
         "ability": "After you perform a [Slam] action, if you fully executed that maneuver, you may perform a white action on your action bar, treating that action as red.",
         "slots": [
           "Modification"
@@ -38,6 +40,7 @@
       {
         "title": "Afterburners",
         "type": "Modification",
+        "xws": "afterburners",
         "ability": "After you fully execute a speed 3-5 maneuver, you may spend 1 [Charge] to perform a [Boost] action, even while stressed.",
         "slots": [
           "Modification"
@@ -56,6 +59,7 @@
       {
         "title": "Electronic Baffle",
         "type": "Modification",
+        "xws": "electronicbaffle",
         "ability": "During the End Phase, you may suffer 1 [Hit] damage to remove 1 red token.",
         "slots": [
           "Modification"
@@ -70,6 +74,7 @@
       {
         "title": "Engine Upgrade",
         "type": "Modification",
+        "xws": "engineupgrade",
         "text": "Large military forces such as the Galactic Empire have standardized engines, but individual pilots and small organizations often replace the power couplings add thrusters, or use high-performance fuel to get extra push out of their engines.",
         "slots": [
           "Modification"
@@ -90,6 +95,7 @@
       {
         "title": "Hull Upgrade",
         "type": "Modification",
+        "xws": "hullupgrade",
         "text": "For those who cannot afford an enhanced shield generator, bolting additional plates onto the hull of a ship can serve as an adequate substitute.",
         "slots": [
           "Modification"
@@ -104,6 +110,7 @@
       {
         "title": "Munitions Failsafe",
         "type": "Modification",
+        "xws": "munitionsfailsafe",
         "ability": "While you perform a [Torpedo] or [Missile] attack, after rolling attack dice, you may cancel all dice results to recover 1 [Charge] you spent as a cost for the attack.",
         "slots": [
           "Modification"
@@ -118,6 +125,7 @@
       {
         "title": "Shield Upgrade",
         "type": "Modification",
+        "xws": "shieldupgrade",
         "text": "Deflector shields are a substantial line of defense on most starships beyond the lightest fighters. While enhancing a ship's shield capacity can be costly, all but the most confident or reckless pilots see the value in this sort of investment.",
         "slots": [
           "Modification"
@@ -132,6 +140,7 @@
       {
         "title": "Static Discharge Vanes",
         "type": "Modification",
+        "xws": "staticdischargevanes",
         "ability": "If you would gain an ion or jam token, you may choose a ship at range 0-1. If you do, gain 1 stress token and transfer 1 ion or jam token to that ship.",
         "slots": [
           "Modification"
@@ -146,6 +155,7 @@
       {
         "title": "Stealth Device",
         "type": "Modification",
+        "xws": "stealthdevice",
         "ability": "While you defend, if your [Charge] is active, roll 1 additional defense die. After you suffer damage, lost 1 [Charge].",
         "slots": [
           "Modification"
@@ -164,6 +174,7 @@
       {
         "title": "Tactical Scrambler",
         "type": "Modification",
+        "xws": "tacticalscrambler",
         "ability": "While you obstruct an enemy ship's attack, the defender rolls 1 additional defense die.",
         "slots": [
           "Modification"

--- a/data/upgrades/system.json
+++ b/data/upgrades/system.json
@@ -6,6 +6,7 @@
       {
         "title": "Advanced Sensors",
         "type": "System",
+        "xws": "advancedsensors",
         "ability": "After you reveal your dial, you may perform 1 action. If you do, you cannot perform another action during your activation.",
         "slots": [
           "System"
@@ -20,6 +21,7 @@
       {
         "title": "Collision Detector",
         "type": "System",
+        "xws": "collisiondetector",
         "ability": "While you boost or barrel roll, you can move through and overlap obstacles. After you move through or overlap an obstacle, you may spend 1 [Charge] to ignore its effects ntie the end of the round.",
         "slots": [
           "System"
@@ -38,6 +40,7 @@
       {
         "title": "Fire-Control System",
         "type": "System",
+        "xws": "firecontrolsystem",
         "ability": "While you perform an attack, if you have a lock on the defender, you may reroll 1 attack die. If you do, you cannot spend your lock during this attack.",
         "slots": [
           "System"
@@ -52,6 +55,7 @@
       {
         "title": "Trajectory Simulator",
         "type": "System",
+        "xws": "trajectorysimulator",
         "ability": "During the System Phase, if you would drop or launch a bomb, you may launch it using the (5 [Straight]) tempplate instead.",
         "slots": [
           "System"

--- a/data/upgrades/talent.json
+++ b/data/upgrades/talent.json
@@ -6,6 +6,7 @@
       {
         "title": "Crack Shot",
         "type": "Talent",
+        "xws": "crackshot",
         "ability": "While you perform a primary attack, if the defender is in your [Bullseye Arc], before the Neutralize Results step, you may spend 1 [Charge] to cancel 1 [Evade] result.",
         "slots": [
           "Talent"
@@ -24,6 +25,7 @@
       {
         "title": "Daredevil",
         "type": "Talent",
+        "xws": "daredevil",
         "ability": "While you perform a while [Boost] action, you may treat it as red to use the 91[Turn Left]] or [1 [Turn Right]] template instead.",
         "slots": [
           "Talent"
@@ -38,6 +40,7 @@
       {
         "title": "Debris Gambit",
         "type": "Talent",
+        "xws": "debrisgambit",
         "ability": "While you perform a red [Evade] action, if there is an obstacle at range 0-1, treat the action as white instead.",
         "slots": [
           "Talent"
@@ -58,6 +61,7 @@
       {
         "title": "Elusive",
         "type": "Talent",
+        "xws": "elusive",
         "ability": "While you defend, you may spend 1 [Charge] to reroll 1 defense die. After you fully execute a red maneuver, recover 1 [Charge].",
         "slots": [
           "Talent"
@@ -76,6 +80,7 @@
       {
         "title": "Expert Handling",
         "type": "Talent",
+        "xws": "experthandling",
         "text": "While heavy fighters can often be coaxed into a barrel roll, seasoned pilots know how to do it without putting undue stress on their craft or leaving themselves open to attack.",
         "slots": [
           "Talent"
@@ -96,6 +101,7 @@
       {
         "title": "Fearless",
         "type": "Talent",
+        "xws": "fearless",
         "ability": "While you perform a [Front Arc] primary attack, if the attack range is 1 and you are in the defender's [Front Arc], you may change 1 of your results to a [Hit] result.",
         "slots": [
           "Talent"
@@ -110,6 +116,7 @@
       {
         "title": "Intimidation",
         "type": "Talent",
+        "xws": "intimidation",
         "ability": "While an enemy ship at range 0 defends, it rolls 1 fewer defense die.",
         "slots": [
           "Talent"
@@ -124,6 +131,7 @@
       {
         "title": "Juke",
         "type": "Talent",
+        "xws": "juke",
         "ability": "While you perform an attack, if you are evading, you may change 1 of the defender's [Evade] results to a [Focus] result.",
         "slots": [
           "Talent"
@@ -138,6 +146,7 @@
       {
         "title": "Lone Wolf",
         "type": "Talent",
+        "xws": "lonewolf",
         "ability": "While you defend or perform an attack, if there are no other friendly ships at range 0-2, you may spend 1 [Charge] to reroll 1 of your dice.",
         "slots": [
           "Talent"
@@ -156,6 +165,7 @@
       {
         "title": "Marksmanship",
         "type": "Talent",
+        "xws": "marksmanship",
         "ability": "While you perform an attack, if the defender is in your [Bullseye Arc], you may change 1 [Hit] result to a [Critical Hit] result.",
         "slots": [
           "Talent"
@@ -170,6 +180,7 @@
       {
         "title": "Outmaneuver",
         "type": "Talent",
+        "xws": "outmaneuver",
         "ability": "While you perform a [Front Arc] arrack, if you are not in the defender's firing arc, the defender rolls 1 fewer defense die.",
         "slots": [
           "Talent"
@@ -184,6 +195,7 @@
       {
         "title": "Predator",
         "type": "Talent",
+        "xws": "predator",
         "ability": "While you perform a primary attack, if the defender is in your [Bullseye Arc], you may reroll 1 attack die.",
         "slots": [
           "Talent"
@@ -198,6 +210,7 @@
       {
         "title": "Ruthless",
         "type": "Talent",
+        "xws": "ruthless",
         "ability": "While you perform an attack, you may choose another friendly ship at range 0-1 of the defender. If you do, that ship suffers 1 [Hit] damage and you may change 1 of your die results to a [Hit] result.",
         "slots": [
           "Talent"
@@ -212,6 +225,7 @@
       {
         "title": "Saturation Salvo",
         "type": "Talent",
+        "xws": "saturationsalvo",
         "ability": "While you perform a [Torpedo] or [Missile] attack, you may spend 1 charge from that upgrade. If you do, choose two defence dice. The defender must reroll those dice.",
         "slots": [
           "Talent"
@@ -226,6 +240,7 @@
       {
         "title": "Selfless",
         "type": "Talent",
+        "xws": "selfless",
         "ability": "Whlie another friendly ship at range 0-1 defends, before the Neutralize Results step, if you are in the attack arc, you may suffer 1 [Critical Hit] damage to cancel 1 [Critical Hit] result.",
         "slots": [
           "Talent"
@@ -240,6 +255,7 @@
       {
         "title": "Squad Leader",
         "type": "Talent",
+        "xws": "squadleader",
         "ability": "While you coordinate, the ship you choose can perform an action only if that action is also on your action bar.",
         "slots": [
           "Talent"
@@ -260,6 +276,7 @@
       {
         "title": "Swarm Tactics",
         "type": "Talent",
+        "xws": "swarmtactics",
         "ability": "At the start of the Engagement Phase, you may choose 1 friendly ship at range 1. If you do, that ship treats its initiative as equal to yours until the end of the round.",
         "slots": [
           "Talent"
@@ -274,6 +291,7 @@
       {
         "title": "Trick Shot",
         "type": "Talent",
+        "xws": "trickshot",
         "ability": "While you perform an attack that is obstructed by an obstacle, roll 1 additional attack die.",
         "slots": [
           "Talent"

--- a/data/upgrades/title.json
+++ b/data/upgrades/title.json
@@ -6,6 +6,7 @@
       {
         "title": "Andrasta",
         "type": "Title",
+        "xws": "andrasta",
         "ability": "Add [Device] slot.",
         "slots": [
           "Title"
@@ -26,6 +27,7 @@
       {
         "title": "Dauntless",
         "type": "Title",
+        "xws": "dauntless",
         "ability": "After you partially execute a maneuver, you may perform 1 white action, treating that action as red.",
         "slots": [
           "Title"
@@ -40,6 +42,7 @@
       {
         "title": "Ghost",
         "type": "Title",
+        "xws": "ghost",
         "ability": "You can dock 1 attack shuttle or Sheathipede-class shuttle. Your docked ships can deploy only from your rear guides.",
         "slots": [
           "Title"
@@ -54,6 +57,7 @@
       {
         "title": "Havoc",
         "type": "Title",
+        "xws": "havoc",
         "ability": "Remove [Crew] slot. Add [System] and [Astromech Droid] slots.",
         "slots": [
           "Title"
@@ -68,6 +72,7 @@
       {
         "title": "Hound's Tooth",
         "type": "Title",
+        "xws": "houndstooth",
         "ability": "1 Z-95 AF4 headhunter can dock with you.",
         "slots": [
           "Title"
@@ -82,6 +87,7 @@
       {
         "title": "IG-2000",
         "type": "Title",
+        "xws": "ig2000",
         "ability": "You have the pilot ability of each other friendly ship with the IG-2000 upgrade.",
         "slots": [
           "Title"
@@ -96,6 +102,7 @@
       {
         "title": "Lando's Millennium Falcon",
         "type": "Title",
+        "xws": "landosmillenniumfalcon",
         "ability": "1 Escape Craft may dock with you. While you have an Escape Craft docked, you may spend its shields as if they were on your ship card. While you perform a primary attack against a stressed ship, roll 1 additional attack die.",
         "slots": [
           "Title"
@@ -110,6 +117,7 @@
       {
         "title": "Marauder",
         "type": "Title",
+        "xws": "marauder",
         "ability": "While you perform a primary [Rear Arc] attack,, you may reroll 1 attack die. Add [UNKNOWN-GUNNER] slot.",
         "slots": [
           "Title"
@@ -124,6 +132,7 @@
       {
         "title": "Millennium Falcon",
         "type": "Title",
+        "xws": "millenniumfalcon",
         "ability": "While you defend, if you are evading, you may reroll 1 defense die.",
         "slots": [
           "Title"
@@ -144,6 +153,7 @@
       {
         "title": "Mist Hunter",
         "type": "Title",
+        "xws": "misthunter",
         "ability": "Add [Cannon] slot.",
         "slots": [
           "Title"
@@ -164,6 +174,7 @@
       {
         "title": "Moldy Crow",
         "type": "Title",
+        "xws": "moldycrow",
         "ability": "Gain a [Front Arc] primary weapon with a value of \"3.\" During the End Phase, do not remove up to 2 focus tokens.",
         "slots": [
           "Title"
@@ -178,6 +189,7 @@
       {
         "title": "Outrider",
         "type": "Title",
+        "xws": "outrider",
         "ability": "While you perform an obstructed attack, the defender rolls 1 fewer defense die. After you fully execute a maneuver, if you moved through or overlapped an obstacle, you may remove 1 of your red or orange tokens.",
         "slots": [
           "Title"
@@ -192,6 +204,7 @@
       {
         "title": "Phantom",
         "type": "Title",
+        "xws": "phantom",
         "ability": "You can dock at range 0-1.",
         "slots": [
           "Title"
@@ -206,6 +219,7 @@
       {
         "title": "Punishing One",
         "type": "Title",
+        "xws": "punishingone",
         "ability": "When you perform a primary attack, if the defender is in your [Front Arc], roll 1 additional attack die. Remove [Crew] slot. Add [Astromech Droid] slot.",
         "slots": [
           "Title"
@@ -220,6 +234,7 @@
       {
         "title": "ST-321",
         "type": "Title",
+        "xws": "st321",
         "ability": "After you perform a [Coordinate] action, you may choose an enemy ship at range 0-3 of the ship you coordinated. If you do, acquire a lock on that enemy ship, ignoring range restrictions.",
         "slots": [
           "Title"
@@ -234,6 +249,7 @@
       {
         "title": "Shadow Caster",
         "type": "Title",
+        "xws": "shadowcaster",
         "ability": "After you perform an attack that hits, if the defender is in your [Single Turret Arc] and your [Front Arc], the defender gains 1 tractor token.",
         "slots": [
           "Title"
@@ -248,6 +264,7 @@
       {
         "title": "Slave I",
         "type": "Title",
+        "xws": "slavei",
         "ability": "After you reveal a turn, ([Turn Left] or [Turn Right]) or bank ([Bank Left] or [Bank Right]) maneuver, you may gain 1 stress token. If you do, set your dial to the maneuver of the same speed and bearing in the other direction. Add [Torpedo] slot.",
         "slots": [
           "Title"
@@ -262,6 +279,7 @@
       {
         "title": "Virago",
         "type": "Title",
+        "xws": "virago",
         "ability": "During the End Phase, you may spend 1 [Charge] to perform a red [Boost] action. Add [UNKNOWN-MODIFICATION] slot.",
         "slots": [
           "Title"

--- a/data/upgrades/torpedo.json
+++ b/data/upgrades/torpedo.json
@@ -6,6 +6,7 @@
       {
         "title": "Adv. Proton Torpedoes",
         "type": "Torpedo",
+        "xws": "advprotontorpedoes",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. Change 1 [Hit] result to a [Critical Hit] result.",
         "slots": [
           "Torpedo"
@@ -30,6 +31,7 @@
       {
         "title": "Ion Torpedoes",
         "type": "Torpedo",
+        "xws": "iontorpedoes",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
         "slots": [
           "Torpedo"
@@ -54,6 +56,7 @@
       {
         "title": "Proton Torpedoes",
         "type": "Torpedo",
+        "xws": "protontorpedoes",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. Change 1 [Hit] result to a [Critical Hit] result.",
         "slots": [
           "Torpedo"

--- a/data/upgrades/turret.json
+++ b/data/upgrades/turret.json
@@ -6,6 +6,7 @@
       {
         "title": "Dorsal Turret",
         "type": "Turret",
+        "xws": "dorsalturret",
         "ability": "Attack",
         "slots": [
           "Turret"
@@ -32,6 +33,7 @@
       {
         "title": "Ion Cannot Turret",
         "type": "Turret",
+        "xws": "ioncannotturret",
         "ability": "Attack: If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
         "slots": [
           "Turret"


### PR DESCRIPTION
Added a proposal for XWS ids. 

Ids are generated as follows:
1. Take the English-language name as printed on the card
2. Lowercase the name
3. Convert non-ASCII characters to closest ASCII equivalent (to remove umlauts, etc.)
4. Remove non-alphanumeric characters
5. Check for collisions; If there’s a collision add a numeric identifier. (`sabinewren` -> `sabinewren-2`)
6. Check for collisions; If there’s a collision increase the numeric identifier until there is no collision. (`sabinewren-2` -> `sabinewren-3`)

Initial ordering has been done as follows:
1. Order alphabetically by ship name
2. Order by initiative
3. Order alphabetically by pilot name