### PR TITLE
Fix: Single xws id for dual cards

### DIFF
--- a/data/upgrades/astromech.json
+++ b/data/upgrades/astromech.json
@@ -2,11 +2,11 @@
   {
     "name": "\"Chopper\"",
     "limited": 1,
+    "xws": "chopper",
     "sides": [
       {
         "title": "\"Chopper\"",
         "type": "Astromech",
-        "xws": "chopper",
         "ability": "Action: Spend 1 non-recurring [Charge] from another equipped upgrade to recover 1 shield. Action: Spend 2 shields to recover 1 non-recurring [Charge] on an equipped upgrade.",
         "slots": [
           "Astromech"
@@ -17,11 +17,11 @@
   {
     "name": "\"Genius\"",
     "limited": 1,
+    "xws": "genius",
     "sides": [
       {
         "title": "\"Genius\"",
         "type": "Astromech",
-        "xws": "genius",
         "ability": "After you fully execute a maneuver, if you have not dropped or launched a device this round, you may drop 1 bomb.",
         "slots": [
           "Astromech"
@@ -32,11 +32,11 @@
   {
     "name": "R2 Astromech",
     "limited": 0,
+    "xws": "r2astromech",
     "sides": [
       {
         "title": "R2 Astromech",
         "type": "Astromech",
-        "xws": "r2astromech",
         "ability": "After you reveal your dial, you may spend 1 [Charge] and gain 1 disarm token to recover 1 shield.",
         "slots": [
           "Astromech"
@@ -51,11 +51,11 @@
   {
     "name": "R2-D2",
     "limited": 1,
+    "xws": "r2d2",
     "sides": [
       {
         "title": "R2-D2",
         "type": "Astromech",
-        "xws": "r2d2",
         "ability": "After you reveal your dial, you may spend 1 [Charge] and gain 1 disarm token to recover 1 shield.",
         "slots": [
           "Astromech"
@@ -70,11 +70,11 @@
   {
     "name": "R3 Astromech",
     "limited": 0,
+    "xws": "r3astromech",
     "sides": [
       {
         "title": "R3 Astromech",
         "type": "Astromech",
-        "xws": "r3astromech",
         "ability": "You can maintain up to 2 locks. Each lock must be on a different object. After you perform a [Lock] action, you may acquire a lock.",
         "slots": [
           "Astromech"
@@ -85,11 +85,11 @@
   {
     "name": "R4 Astromech",
     "limited": 0,
+    "xws": "r4astromech",
     "sides": [
       {
         "title": "R4 Astromech",
         "type": "Astromech",
-        "xws": "r4astromech",
         "ability": "Decrease the difficulty of your speed 1-2 basic maneuvers ([Turn Left], [Bank Left], [Straight], [Bank Right], [Turn Right]).",
         "slots": [
           "Astromech"
@@ -100,11 +100,11 @@
   {
     "name": "R5 Astromech",
     "limited": 0,
+    "xws": "r5astromech",
     "sides": [
       {
         "title": "R5 Astromech",
         "type": "Astromech",
-        "xws": "r5astromech",
         "ability": "Action: Spend 1 [Charge] to repair 1 facedown damage card. Action: Repair 1 faceup Ship damage card.",
         "slots": [
           "Astromech"
@@ -119,11 +119,11 @@
   {
     "name": "R5-D8",
     "limited": 1,
+    "xws": "r5d8",
     "sides": [
       {
         "title": "R5-D8",
         "type": "Astromech",
-        "xws": "r5d8",
         "ability": "Action: Spend 1 [Charge] to repair 1 facedown damage card. Action: Repair 1 faceup Ship damage card.",
         "slots": [
           "Astromech"
@@ -138,11 +138,11 @@
   {
     "name": "R5-P8",
     "limited": 1,
+    "xws": "r5p8",
     "sides": [
       {
         "title": "R5-P8",
         "type": "Astromech",
-        "xws": "r5p8",
         "ability": "While you perform an attack against a defender in your [Front Arc], you may spend 1 [Charge] to reroll 1 attack die. If the rerolled results is a [Critical Hit], suffer 1 [Critical Hit] damage.",
         "slots": [
           "Astromech"
@@ -157,11 +157,11 @@
   {
     "name": "R5-TK",
     "limited": 1,
+    "xws": "r5tk",
     "sides": [
       {
         "title": "R5-TK",
         "type": "Astromech",
-        "xws": "r5tk",
         "ability": "You can perform attacks against friendly ships.",
         "slots": [
           "Astromech"

--- a/data/upgrades/cannon.json
+++ b/data/upgrades/cannon.json
@@ -2,11 +2,11 @@
   {
     "name": "Heavy Laser Cannon",
     "limited": 0,
+    "xws": "heavylasercannon",
     "sides": [
       {
         "title": "Heavy Laser Cannon",
         "type": "Cannon",
-        "xws": "heavylasercannon",
         "ability": "Attack: After the Modify Attack Dice step, change all [Critical Hit] results to [Hit] results.",
         "slots": [
           "Cannon"
@@ -23,11 +23,11 @@
   {
     "name": "Ion Cannon",
     "limited": 0,
+    "xws": "ioncannon",
     "sides": [
       {
         "title": "Ion Cannon",
         "type": "Cannon",
-        "xws": "ioncannon",
         "ability": "Attack: If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
         "slots": [
           "Cannon"
@@ -44,11 +44,11 @@
   {
     "name": "Jamming Beam",
     "limited": 0,
+    "xws": "jammingbeam",
     "sides": [
       {
         "title": "Jamming Beam",
         "type": "Cannon",
-        "xws": "jammingbeam",
         "ability": "Attack: If this attack hits, all [Hit]/[Critical Hit] results inflict jam tokens instead of damage.",
         "slots": [
           "Cannon"
@@ -65,11 +65,11 @@
   {
     "name": "Tractor Beam",
     "limited": 0,
+    "xws": "tractorbeam",
     "sides": [
       {
         "title": "Tractor Beam",
         "type": "Cannon",
-        "xws": "tractorbeam",
         "ability": "Attack: If this attack hits, all [Hit]/[Critical Hit] results inflict tractor tokens instead of damage.",
         "slots": [
           "Cannon"

--- a/data/upgrades/configuration.json
+++ b/data/upgrades/configuration.json
@@ -2,11 +2,11 @@
   {
     "name": "Integrated S-foils",
     "limited": 0,
+    "xws": "integratedsfoils",
     "sides": [
       {
         "title": "Integrated S-foils (Closed)",
         "type": "Configuration",
-        "xws": "integratedsfoilsclosed",
         "ability": "???",
         "slots": [
           "Configuration"
@@ -15,7 +15,6 @@
       {
         "title": "Integrated S-foils (Open)",
         "type": "Configuration",
-        "xws": "integratedsfoilsopen",
         "ability": "???",
         "slots": [
           "Configuration"
@@ -26,11 +25,11 @@
   {
     "name": "Os-1 Arsenal Loadout",
     "limited": 0,
+    "xws": "os1arsenalloadout",
     "sides": [
       {
         "title": "Os-1 Arsenal Loadout",
         "type": "Configuration",
-        "xws": "os1arsenalloadout",
         "ability": "While you have exactly 1 disarm token, you can still perform [Torpedo] and [Missile] attacks against targets you have locked. If you do, you cannot spend you lock during the attack. Add [Torpedo] and [Missile] slots.",
         "slots": [
           "Configuration"
@@ -41,11 +40,11 @@
   {
     "name": "Pivot Wing",
     "limited": 0,
+    "xws": "pivotwing",
     "sides": [
       {
         "title": "Pivot Wing (Closed)",
         "type": "Configuration",
-        "xws": "pivotwingclosed",
         "ability": "While you defend, roll 1 fewer defense die. After you execute a [0 [Stationary]] maneuver, you may rotate your ship 90˚ or 180˚. Before you activate, you may flip this card.",
         "slots": [
           "Configuration"
@@ -54,7 +53,6 @@
       {
         "title": "Pivot Wing (Open)",
         "type": "Configuration",
-        "xws": "pivotwingopen",
         "ability": "Before you activate, you may flip this card.",
         "slots": [
           "Configuration"
@@ -65,11 +63,11 @@
   {
     "name": "Servomotor S-foils",
     "limited": 0,
+    "xws": "servomotorsfoils",
     "sides": [
       {
         "title": "Servomotor S-foils (Closed)",
         "type": "Configuration",
-        "xws": "servomotorsfoilsclosed",
         "ability": "While you perform a primary attack, roll 1 fewer attack die. Before you activate, you may flip this card.",
         "slots": [
           "Configuration"
@@ -92,7 +90,6 @@
       {
         "title": "Servomotor S-foils (Open)",
         "type": "Configuration",
-        "xws": "servomotorsfoilsopen",
         "ability": "Before you activate, you may flip this card.",
         "slots": [
           "Configuration"
@@ -103,11 +100,11 @@
   {
     "name": "Xg-1 Assault Configuration",
     "limited": 0,
+    "xws": "xg1assaultconfiguration",
     "sides": [
       {
         "title": "Xg-1 Assault Configuration",
         "type": "Configuration",
-        "xws": "xg1assaultconfiguration",
         "ability": "While you have exactly 1 disarm token, uou can still perform [Cannon] attacks. While you perform a [Cannon] attack while disarmed, roll a maximum of 3 attack dice. Add [Cannon] slot.",
         "slots": [
           "Configuration"

--- a/data/upgrades/crew.json
+++ b/data/upgrades/crew.json
@@ -2,11 +2,11 @@
   {
     "name": "\"Chopper\"",
     "limited": 1,
+    "xws": "chopper-crew",
     "sides": [
       {
         "title": "\"Chopper\"",
         "type": "Crew",
-        "xws": "chopper-crew",
         "ability": "During the Perform Action step, you may perofrm 1 action, even while stressed. Adter you perform an action while stressed, suffer 1 [Hit] damage unless you expose 1 of your damage cards.",
         "slots": [
           "Crew"
@@ -17,11 +17,11 @@
   {
     "name": "\"Zeb\" Orrelios",
     "limited": 1,
+    "xws": "zeborrelios",
     "sides": [
       {
         "title": "\"Zeb\" Orrelios",
         "type": "Crew",
-        "xws": "zeborrelios",
         "ability": "You can perform primary attacks at range 0. Enemy ships at range 0 can perform primary attacks against you.",
         "slots": [
           "Crew"
@@ -32,11 +32,11 @@
   {
     "name": "0-0-0",
     "limited": 1,
+    "xws": "000",
     "sides": [
       {
         "title": "0-0-0",
         "type": "Crew",
-        "xws": "000",
         "ability": "At the start of the Engagement Phase, you may choose 1 enemy ship at range 0-1. If you do, you gain 1 calculate token unless that ship chooses to gain 1 stress token.",
         "slots": [
           "Crew"
@@ -47,11 +47,11 @@
   {
     "name": "4-LOM",
     "limited": 1,
+    "xws": "4lom",
     "sides": [
       {
         "title": "4-LOM",
         "type": "Crew",
-        "xws": "4lom",
         "ability": "While you perform an attack, after rolling attack dice, you may name a type of green token. If you do, gain 2 ion tokens and, during this attack, the defender cannot spend tokens of the named type.",
         "slots": [
           "Crew"
@@ -62,11 +62,11 @@
   {
     "name": "Admiral Sloane",
     "limited": 1,
+    "xws": "admiralsloane",
     "sides": [
       {
         "title": "Admiral Sloane",
         "type": "Crew",
-        "xws": "admiralsloane",
         "ability": "After another friendly ship at range 0-3 defends, if it is destroyed, the attacker gains 2 stress tokens. While a friendly ship at range 0-3 performs an attack against a stressed ship, it may reroll 1 attack die.",
         "slots": [
           "Crew"
@@ -77,11 +77,11 @@
   {
     "name": "Agent Kallus",
     "limited": 1,
+    "xws": "agentkallus",
     "sides": [
       {
         "title": "Agent Kallus",
         "type": "Crew",
-        "xws": "agentkallus",
         "ability": "Setup: Assign the Hunted condition to 1 enemy ship. While you perform an attack against th eship with the Hunted condition, you may change 1 of your [Focus] results to a [Hit] result.",
         "slots": [
           "Crew"
@@ -92,11 +92,11 @@
   {
     "name": "Baze Malbus",
     "limited": 1,
+    "xws": "bazemalbus",
     "sides": [
       {
         "title": "Baze Malbus",
         "type": "Crew",
-        "xws": "bazemalbus",
         "ability": "While you perform a [Focus] action, you may treat it as red. If you do, gain 1 additional focus token for each enemy ship at range 0-1 to a mazimum of 2.",
         "slots": [
           "Crew"
@@ -107,11 +107,11 @@
   {
     "name": "Boba Fett",
     "limited": 1,
+    "xws": "bobafett",
     "sides": [
       {
         "title": "Boba Fett",
         "type": "Crew",
-        "xws": "bobafett",
         "ability": "Setup: Start in reserve. At the end of Setup, place yourself at range 0 of an obstacle and beyond range 3 of an enemy ship.",
         "slots": [
           "Crew"
@@ -122,11 +122,11 @@
   {
     "name": "C-3PO",
     "limited": 1,
+    "xws": "c3po",
     "sides": [
       {
         "title": "C-3PO",
         "type": "Crew",
-        "xws": "c3po",
         "ability": "Before rolling defense dice, you may spend 1 calculate token to guess aloud a number 1 or higher. If you do, and you roll exactly that many [Evade] results, add 1 [Evade] result. Adter you perform the [Calculate] action, gain 1 calculate token.",
         "slots": [
           "Crew"
@@ -143,11 +143,11 @@
   {
     "name": "Cad Bane",
     "limited": 1,
+    "xws": "cadbane",
     "sides": [
       {
         "title": "Cad Bane",
         "type": "Crew",
-        "xws": "cadbane",
         "ability": "After you drop or launch a device, you may perform a red [Boost] action.",
         "slots": [
           "Crew"
@@ -158,11 +158,11 @@
   {
     "name": "Captain Phasma",
     "limited": 1,
+    "xws": "captainphasma",
     "sides": [
       {
         "title": "Captain Phasma",
         "type": "Crew",
-        "xws": "captainphasma",
         "ability": "At the...",
         "slots": [
           "Crew"
@@ -173,11 +173,11 @@
   {
     "name": "Cassian Andor",
     "limited": 1,
+    "xws": "cassianandor",
     "sides": [
       {
         "title": "Cassian Andor",
         "type": "Crew",
-        "xws": "cassianandor",
         "ability": "During the System Phase, you may choose 1 enemy ship at range 1-2 and guess aloud a bearing and speed, then look at that ship's dial. If the chosen ship's bearing and speed match your guess, you may set your dial to another maneuver.",
         "slots": [
           "Crew"
@@ -188,11 +188,11 @@
   {
     "name": "Chewbacca",
     "limited": 1,
+    "xws": "chewbacca",
     "sides": [
       {
         "title": "Chewbacca",
         "type": "Crew",
-        "xws": "chewbacca",
         "ability": "At the start of the Engagement Phase, you may spend 2 [Charge] to repair 1 faceup damage card.",
         "slots": [
           "Crew"
@@ -207,11 +207,11 @@
   {
     "name": "Chewbacca",
     "limited": 1,
+    "xws": "chewbacca-crew",
     "sides": [
       {
         "title": "Chewbacca",
         "type": "Crew",
-        "xws": "chewbacca-crew",
         "ability": "At the start of the End Phase, you may spend 1 focus token to repair 1 of your faceup damage cards.",
         "slots": [
           "Crew"
@@ -222,11 +222,11 @@
   {
     "name": "Ciena Ree",
     "limited": 1,
+    "xws": "cienaree",
     "sides": [
       {
         "title": "Ciena Ree",
         "type": "Crew",
-        "xws": "cienaree",
         "ability": "After you perform a [Coordinate] action, if the ship you coordinated performed a [Barrel Roll] or [Boost] action, it may gain 1 stress token to rotate 90˚.",
         "slots": [
           "Crew"
@@ -237,11 +237,11 @@
   {
     "name": "Cikatro Vizago",
     "limited": 1,
+    "xws": "cikatrovizago",
     "sides": [
       {
         "title": "Cikatro Vizago",
         "type": "Crew",
-        "xws": "cikatrovizago",
         "ability": "During the End Phase, you may choose 2 [Illicit] upgrades equipped to friendly ships at range 0-1. If you do, you may exchange these upgrades. End of Game: Return all [Illicit] upgrades to their original ships.",
         "slots": [
           "Crew"
@@ -252,11 +252,11 @@
   {
     "name": "Darth Vader",
     "limited": 1,
+    "xws": "darthvader",
     "sides": [
       {
         "title": "Darth Vader",
         "type": "Crew",
-        "xws": "darthvader",
         "ability": "At the start of the Engagement Phase, you may choose 1 ship in your firing arc at range 0-2 and spend 1 [Force]. If you do, that ship suffers 1 [Hit] damage unless it chooses to remove 1 green token.",
         "slots": [
           "Crew"
@@ -271,11 +271,11 @@
   {
     "name": "Death Troopers",
     "limited": 1,
+    "xws": "deathtroopers",
     "sides": [
       {
         "title": "Death Troopers",
         "type": "Crew",
-        "xws": "deathtroopers",
         "ability": "During the Activation Phase, enemy ships at range 0-1 cannot remove stress tokens.",
         "slots": [
           "Crew",
@@ -287,11 +287,11 @@
   {
     "name": "Director Krennic",
     "limited": 1,
+    "xws": "directorkrennic",
     "sides": [
       {
         "title": "Director Krennic",
         "type": "Crew",
-        "xws": "directorkrennic",
         "ability": "Setup: Before placing forces, assign the Optimized Prototype condition to another friendly ship.",
         "slots": [
           "Crew"
@@ -308,11 +308,11 @@
   {
     "name": "Emperor Palpatine",
     "limited": 1,
+    "xws": "emperorpalpatine",
     "sides": [
       {
         "title": "Emperor Palpatine",
         "type": "Crew",
-        "xws": "emperorpalpatine",
         "ability": "While another friendly ship defends or performs an attack, you may spend 1 [Force] to modify 1 of its dice as though that ship had spent 1 [Force].",
         "slots": [
           "Crew",
@@ -328,11 +328,11 @@
   {
     "name": "Freelance Slicer",
     "limited": 0,
+    "xws": "freelanceslicer",
     "sides": [
       {
         "title": "Freelance Slicer",
         "type": "Crew",
-        "xws": "freelanceslicer",
         "ability": "While you defend, before attack dice are rolled, you may spend a lock you have on the attacker to roll 1 attack die. If you do, the attacker gains 1 [Jam] token. Then, on a [Hit] or [Critical Hit] result, gain 1 [Jam] token.",
         "slots": [
           "Crew"
@@ -343,11 +343,11 @@
   {
     "name": "GNK \"Gonk\" Droid",
     "limited": 0,
+    "xws": "gnkgonkdroid",
     "sides": [
       {
         "title": "GNK \"Gonk\" Droid",
         "type": "Crew",
-        "xws": "gnkgonkdroid",
         "ability": "Setup: Lose 1 [Charge]. Action: Recover 1 [Charge]. Action: Spend 1 [Charge] to recover 1 shield.",
         "slots": [
           "Crew"
@@ -362,11 +362,11 @@
   {
     "name": "Grand Inquisitor",
     "limited": 1,
+    "xws": "grandinquisitor",
     "sides": [
       {
         "title": "Grand Inquisitor",
         "type": "Crew",
-        "xws": "grandinquisitor",
         "ability": "After an enemy ship at range 0-2 reveals its dial, you may spend 1 [Force] to perform 1 white action on your action bar, treating that action as red.",
         "slots": [
           "Crew"
@@ -381,11 +381,11 @@
   {
     "name": "Grand Moff Tarkin",
     "limited": 1,
+    "xws": "grandmofftarkin",
     "sides": [
       {
         "title": "Grand Moff Tarkin",
         "type": "Crew",
-        "xws": "grandmofftarkin",
         "ability": "During the System Phase, you may spend 2 [Charge]. If you do, each friendly ship may acquire a lock on a ship that you have locked.",
         "slots": [
           "Crew"
@@ -400,11 +400,11 @@
   {
     "name": "Hera Syndulla",
     "limited": 1,
+    "xws": "herasyndulla",
     "sides": [
       {
         "title": "Hera Syndulla",
         "type": "Crew",
-        "xws": "herasyndulla",
         "ability": "You can execute red maneuvers even while stressed. After you fully execute a red maneuver, if you ahve 3 or more stress tokens, remove 1 stress token and suffer 1 [Hit] damage.",
         "slots": [
           "Crew"
@@ -415,11 +415,11 @@
   {
     "name": "IG-88D",
     "limited": 1,
+    "xws": "ig88d",
     "sides": [
       {
         "title": "IG-88D",
         "type": "Crew",
-        "xws": "ig88d",
         "ability": "You have the pilot ability of each other friendly ship with the IG-2000 upgrade. After you perform a [Calculate] action, gain 1 calculate token.",
         "slots": [
           "Crew"
@@ -436,11 +436,11 @@
   {
     "name": "ISB Slicer",
     "limited": 0,
+    "xws": "isbslicer",
     "sides": [
       {
         "title": "ISB Slicer",
         "type": "Crew",
-        "xws": "isbslicer",
         "ability": "During the End Phase, enemy ships at range 1-2 cannot remove jam tokens.",
         "slots": [
           "Crew"
@@ -451,11 +451,11 @@
   {
     "name": "Informant",
     "limited": 1,
+    "xws": "informant",
     "sides": [
       {
         "title": "Informant",
         "type": "Crew",
-        "xws": "informant",
         "ability": "Setup: After placing forces, choose 1 enemy ship and assign the Listening Device condition to it.",
         "slots": [
           "Crew"
@@ -466,11 +466,11 @@
   {
     "name": "Jabba the Hutt",
     "limited": 1,
+    "xws": "jabbathehutt",
     "sides": [
       {
         "title": "Jabba the Hutt",
         "type": "Crew",
-        "xws": "jabbathehutt",
         "ability": "During the End Phase, you may choose 1 friendly ship at range 0-2 and spend 1 [Charge]. If you do, that ship recovers 1 [Charge] on 1 of its equipped [Illicit] upgrades.",
         "slots": [
           "Crew",
@@ -486,11 +486,11 @@
   {
     "name": "Jyn Erso",
     "limited": 1,
+    "xws": "jynerso",
     "sides": [
       {
         "title": "Jyn Erso",
         "type": "Crew",
-        "xws": "jynerso",
         "ability": "If a friendly ship at range 0-3 would gain a focus token, it may gain 1 evade token instead.",
         "slots": [
           "Crew"
@@ -501,11 +501,11 @@
   {
     "name": "Kanan Jarrus",
     "limited": 1,
+    "xws": "kananjarrus",
     "sides": [
       {
         "title": "Kanan Jarrus",
         "type": "Crew",
-        "xws": "kananjarrus",
         "ability": "After a friendly ship at range 0-2 fully executes a white maneuver, you may spend 1 [Force] to remove 1 stress token from that ship.",
         "slots": [
           "Crew"
@@ -520,11 +520,11 @@
   {
     "name": "Ketsu Onyo",
     "limited": 1,
+    "xws": "ketsuonyo",
     "sides": [
       {
         "title": "Ketsu Onyo",
         "type": "Crew",
-        "xws": "ketsuonyo",
         "ability": "At the start of the End Phase, you may choose 1 enemy ship at range 0-2 in your firing arc. If you do, that ship does not remove its tractor tokens.",
         "slots": [
           "Crew"
@@ -535,11 +535,11 @@
   {
     "name": "L3-37",
     "limited": 1,
+    "xws": "l337",
     "sides": [
       {
         "title": "L3-37",
         "type": "Crew",
-        "xws": "l337",
         "ability": "Setup: Equip this side faceup. While you defend, you may flip this card. If you do, the attack must reroll all attack dice.",
         "slots": [
           "Crew"
@@ -552,7 +552,6 @@
       {
         "title": "L3-37's Programming",
         "type": "Configuration",
-        "xws": "l337sprogramming",
         "ability": "If you are not shielded, decrease the difficulty of your bank ([Bank Left] and [Bank Right]) maneuvers.",
         "slots": [
           "Configuration"
@@ -563,11 +562,11 @@
   {
     "name": "Lando Calrissian",
     "limited": 1,
+    "xws": "landocalrissian-crew",
     "sides": [
       {
         "title": "Lando Calrissian",
         "type": "Crew",
-        "xws": "landocalrissian-crew",
         "ability": "After you roll dice, you may spend 1 green token to reroll up to 2 of your results.",
         "slots": [
           "Crew"
@@ -578,11 +577,11 @@
   {
     "name": "Lando Calrissian",
     "limited": 1,
+    "xws": "landocalrissian",
     "sides": [
       {
         "title": "Lando Calrissian",
         "type": "Crew",
-        "xws": "landocalrissian",
         "ability": "Action: Roll 2 defense dice. For each [Focus] result, gain 1 focus token. For each [Evade] result, gain 1 evade token. If both results are blank, the opposing player chooses focus or evade. You gain 1 token of that type.",
         "slots": [
           "Crew"
@@ -593,11 +592,11 @@
   {
     "name": "Latts Razzi",
     "limited": 1,
+    "xws": "lattsrazzi",
     "sides": [
       {
         "title": "Latts Razzi",
         "type": "Crew",
-        "xws": "lattsrazzi",
         "ability": "While you defend, if the attacker is stressed, you may remove 1 stress from the attacker to change 1 of your blank/[Focus] results to an [Evade] result.",
         "slots": [
           "Crew"
@@ -608,11 +607,11 @@
   {
     "name": "Leia Organa",
     "limited": 1,
+    "xws": "leiaorgana",
     "sides": [
       {
         "title": "Leia Organa",
         "type": "Crew",
-        "xws": "leiaorgana",
         "ability": "At the start of the Activation Phase, you may spend 3 [Charge]. During this phase, each friendly ship reduces the difficulty of its red maneuvers.",
         "slots": [
           "Crew"
@@ -627,11 +626,11 @@
   {
     "name": "Magva Yarro",
     "limited": 1,
+    "xws": "magvayarro",
     "sides": [
       {
         "title": "Magva Yarro",
         "type": "Crew",
-        "xws": "magvayarro",
         "ability": "After you defend, if the attack hit, you may acquire a lock on the attacker.",
         "slots": [
           "Crew"
@@ -642,11 +641,11 @@
   {
     "name": "Maul",
     "limited": 1,
+    "xws": "maul",
     "sides": [
       {
         "title": "Maul",
         "type": "Crew",
-        "xws": "maul",
         "ability": "After you suffer damage, you may gain 1 stress token to recover 1 [Force]. You can equip \"Dark Side\" upgades.",
         "slots": [
           "Crew"
@@ -661,11 +660,11 @@
   {
     "name": "Minister Tua",
     "limited": 1,
+    "xws": "ministertua",
     "sides": [
       {
         "title": "Minister Tua",
         "type": "Crew",
-        "xws": "ministertua",
         "ability": "At the start of the Engagement Phase, if you are damaged, you may perform a red [Reinforce] action.",
         "slots": [
           "Crew"
@@ -676,11 +675,11 @@
   {
     "name": "Moff Jerjerrod",
     "limited": 1,
+    "xws": "moffjerjerrod",
     "sides": [
       {
         "title": "Moff Jerjerrod",
         "type": "Crew",
-        "xws": "moffjerjerrod",
         "ability": "During the System Phase, you may spend 2 [Charge]. If you do, choose the (1 [Bank Left]), (1 [Straight]), or (1 [Bank Right]) template. Each friendly ship may perform a red [Boost] action using that template.",
         "slots": [
           "Crew"
@@ -695,11 +694,11 @@
   {
     "name": "Nien Nunb",
     "limited": 1,
+    "xws": "niennunb",
     "sides": [
       {
         "title": "Nien Nunb",
         "type": "Crew",
-        "xws": "niennunb",
         "ability": "Decrease the difficulty of your bank maneuvers [[Bank Left] and [Bank Right]].",
         "slots": [
           "Crew"
@@ -710,11 +709,11 @@
   {
     "name": "Novice Technician",
     "limited": 0,
+    "xws": "novicetechnician",
     "sides": [
       {
         "title": "Novice Technician",
         "type": "Crew",
-        "xws": "novicetechnician",
         "ability": "At the end of the round, you may roll 1 attack die to repair 1 faceup damage card. Then, on a [Hit] result, expose 1 damage card.",
         "slots": [
           "Crew"
@@ -725,11 +724,11 @@
   {
     "name": "Perceptive Copilot",
     "limited": 0,
+    "xws": "perceptivecopilot",
     "sides": [
       {
         "title": "Perceptive Copilot",
         "type": "Crew",
-        "xws": "perceptivecopilot",
         "ability": "After you perform a [Focus] action, gain 1 focus token.",
         "slots": [
           "Crew"
@@ -740,11 +739,11 @@
   {
     "name": "Qi'ra",
     "limited": 1,
+    "xws": "qira",
     "sides": [
       {
         "title": "Qi'ra",
         "type": "Crew",
-        "xws": "qira",
         "ability": "While you move and perform attacks, you ignore all obstacles that you are locking.",
         "slots": [
           "Crew"
@@ -755,11 +754,11 @@
   {
     "name": "R2-D2",
     "limited": 1,
+    "xws": "r2d2-crew",
     "sides": [
       {
         "title": "R2-D2",
         "type": "Crew",
-        "xws": "r2d2-crew",
         "ability": "During the End Phase, if you are damaged and not shielded, you may roll 1 attack die to recover 1 shield. On a [Hit] result, expose 1 of your damage cards.",
         "slots": [
           "Crew"
@@ -770,11 +769,11 @@
   {
     "name": "Rose Tico",
     "limited": 1,
+    "xws": "rosetico",
     "sides": [
       {
         "title": "Rose Tico",
         "type": "Crew",
-        "xws": "rosetico",
         "ability": "???",
         "slots": [
           "Crew"
@@ -785,11 +784,11 @@
   {
     "name": "Sabine Wren",
     "limited": 1,
+    "xws": "sabinewren",
     "sides": [
       {
         "title": "Sabine Wren",
         "type": "Crew",
-        "xws": "sabinewren",
         "ability": "Setup: Place 1 ion, 1 jam, 1 stress, and 1 tractor token on this card. After a ship suffers the effect of a friendly bomb, you may remove 1 ion, jam, stress, or tractor token from this card. If you do, that ship gains a matching token.",
         "slots": [
           "Crew"
@@ -800,11 +799,11 @@
   {
     "name": "Saw Gerrera",
     "limited": 1,
+    "xws": "sawgerrera",
     "sides": [
       {
         "title": "Saw Gerrera",
         "type": "Crew",
-        "xws": "sawgerrera",
         "ability": "While you perform an attack, you may suffer 1 [Hit] damage to change all of your [Focus] results to [Critical Hit] results.",
         "slots": [
           "Crew"
@@ -815,11 +814,11 @@
   {
     "name": "Seasoned Navigator",
     "limited": 0,
+    "xws": "seasonednavigator",
     "sides": [
       {
         "title": "Seasoned Navigator",
         "type": "Crew",
-        "xws": "seasonednavigator",
         "ability": "After you reveal your dial, you may set your dial to another non-red maneuver of the same speed. While you execute that maneuver, increase its difficulty.",
         "slots": [
           "Crew"
@@ -830,11 +829,11 @@
   {
     "name": "Seventh Sister",
     "limited": 1,
+    "xws": "seventhsister",
     "sides": [
       {
         "title": "Seventh Sister",
         "type": "Crew",
-        "xws": "seventhsister",
         "ability": "If an enemy ship at range 0-1 would gain a stress token, you may spend 1 [Force] to have it gain 1 jam or tractor token instead.",
         "slots": [
           "Crew"
@@ -849,11 +848,11 @@
   {
     "name": "Supreme Leader Snoke",
     "limited": 1,
+    "xws": "supremeleadersnoke",
     "sides": [
       {
         "title": "Supreme Leader Snoke",
         "type": "Crew",
-        "xws": "supremeleadersnoke",
         "ability": "During the System... you may...",
         "slots": [
           "Crew",
@@ -865,11 +864,11 @@
   {
     "name": "Tactical Officer",
     "limited": 0,
+    "xws": "tacticalofficer",
     "sides": [
       {
         "title": "Tactical Officer",
         "type": "Crew",
-        "xws": "tacticalofficer",
         "text": "In the chaos of a starfighter battle, a single order can mean the difference between a victory and a massacre.",
         "slots": [
           "Crew"
@@ -886,11 +885,11 @@
   {
     "name": "Tobias Beckett",
     "limited": 1,
+    "xws": "tobiasbeckett",
     "sides": [
       {
         "title": "Tobias Beckett",
         "type": "Crew",
-        "xws": "tobiasbeckett",
         "ability": "Setup: After placing forces, you may choose 1 obstacle in the play area. If you do, place it anywhere in the play area beyond range 2 of any board edge or ship and beyond range 1 of other obstacles.",
         "slots": [
           "Crew"
@@ -901,11 +900,11 @@
   {
     "name": "Unkar Plutt",
     "limited": 1,
+    "xws": "unkarplutt",
     "sides": [
       {
         "title": "Unkar Plutt",
         "type": "Crew",
-        "xws": "unkarplutt",
         "ability": "After you partially excute a maneuver, you may suffer 1 [Hit] damage to perform 1 white action.",
         "slots": [
           "Crew"
@@ -916,11 +915,11 @@
   {
     "name": "Zuckuss",
     "limited": 1,
+    "xws": "zuckuss",
     "sides": [
       {
         "title": "Zuckuss",
         "type": "Crew",
-        "xws": "zuckuss",
         "ability": "While you perform an attack, if ou are not stressed, you may choose 1 defense die and gain 1 stress token. If you do, the defender must reroll that die.",
         "slots": [
           "Crew"

--- a/data/upgrades/device.json
+++ b/data/upgrades/device.json
@@ -2,11 +2,11 @@
   {
     "name": "Bomblet Generator",
     "limited": 0,
+    "xws": "bombletgenerator",
     "sides": [
       {
         "title": "Bomblet Generator",
         "type": "Device",
-        "xws": "bombletgenerator",
         "ability": "Bomb During the System Phase, you may spend 1 [Charge] to drop a Bomblet with the [1 [Straight]] templete. At the start of the Activation Phase, you may spend 1 shield to recover 2 [Charge].",
         "slots": [
           "Device",
@@ -22,11 +22,11 @@
   {
     "name": "Conner Nets",
     "limited": 0,
+    "xws": "connernets",
     "sides": [
       {
         "title": "Conner Nets",
         "type": "Device",
-        "xws": "connernets",
         "ability": "Mine During the System Phase, you may spend 1 [Charge] to drop a Conner Net using the [1 [Straight]] template. This card's [Charge] cannot be recovered.",
         "slots": [
           "Device"
@@ -41,11 +41,11 @@
   {
     "name": "Proton Bombs",
     "limited": 0,
+    "xws": "protonbombs",
     "sides": [
       {
         "title": "Proton Bombs",
         "type": "Device",
-        "xws": "protonbombs",
         "ability": "Bomb During the System Phase, you may spend 1 [Charge] to drop a Proton Bomb using the [1 [Straight]] template.",
         "slots": [
           "Device"
@@ -60,11 +60,11 @@
   {
     "name": "Proximity Mines",
     "limited": 0,
+    "xws": "proximitymines",
     "sides": [
       {
         "title": "Proximity Mines",
         "type": "Device",
-        "xws": "proximitymines",
         "ability": "Mine During the System Phase, you may spend 1 [Charge] to drop a Proximity Mine using the [1 [Straight]] template. This card's [Charge] cannot be recovered.",
         "slots": [
           "Device"
@@ -79,11 +79,11 @@
   {
     "name": "Seismic Charges",
     "limited": 0,
+    "xws": "seismiccharges",
     "sides": [
       {
         "title": "Seismic Charges",
         "type": "Device",
-        "xws": "seismiccharges",
         "ability": "Bomb During the System Phase, you may spend 1 [Charge] to drop a Seismic Charge with the [1 [Straight]] template.",
         "slots": [
           "Device"

--- a/data/upgrades/force-power.json
+++ b/data/upgrades/force-power.json
@@ -2,11 +2,11 @@
   {
     "name": "Heightened Perception",
     "limited": 0,
+    "xws": "heightenedperception",
     "sides": [
       {
         "title": "Heightened Perception",
         "type": "Force Power",
-        "xws": "heightenedperception",
         "ability": "At the start of the Engagement Phase, you may spend 1 [Force]. If you do, engage at initiative 7 instead of your standard initiative value this phase.",
         "slots": [
           "Force Power"
@@ -17,11 +17,11 @@
   {
     "name": "Instinctive Aim",
     "limited": 0,
+    "xws": "instinctiveaim",
     "sides": [
       {
         "title": "Instinctive Aim",
         "type": "Force Power",
-        "xws": "instinctiveaim",
         "ability": "While you perform a special attack, you may spend 1 [Force] to ignore the [Focus] or [Lock] requirement.",
         "slots": [
           "Force Power"
@@ -32,11 +32,11 @@
   {
     "name": "Sense",
     "limited": 0,
+    "xws": "sense",
     "sides": [
       {
         "title": "Sense",
         "type": "Force Power",
-        "xws": "sense",
         "ability": "During the System Phase, you may choose 1 ship at range 0-1 and look at its dial. If you spend 1 [Force], you may choose a ship at range 0-3 instead.",
         "slots": [
           "Force Power"
@@ -47,11 +47,11 @@
   {
     "name": "Supernatural Reflexes",
     "limited": 0,
+    "xws": "supernaturalreflexes",
     "sides": [
       {
         "title": "Supernatural Reflexes",
         "type": "Force Power",
-        "xws": "supernaturalreflexes",
         "ability": "Before you activate, you may spend 1 [Force] to perform a [Barrel Roll] or [Boost] action. Then, if you performed an action you do not have on your action bar, suffer 1 [Hit] damage.",
         "slots": [
           "Force Power"

--- a/data/upgrades/gunner.json
+++ b/data/upgrades/gunner.json
@@ -2,11 +2,11 @@
   {
     "name": "Agile Gunner",
     "limited": 0,
+    "xws": "agilegunner",
     "sides": [
       {
         "title": "Agile Gunner",
         "type": "Gunner",
-        "xws": "agilegunner",
         "ability": "During the End Phase, you may rotate your [Single Turret Arc] indicator.",
         "slots": [
           "Gunner"
@@ -17,11 +17,11 @@
   {
     "name": "BT-1",
     "limited": 1,
+    "xws": "bt1",
     "sides": [
       {
         "title": "BT-1",
         "type": "Gunner",
-        "xws": "bt1",
         "ability": "While you perform an attack, you may change 1 [Hit] result to a [Critical Hit] result for each stress token the defender has.",
         "slots": [
           "Gunner"
@@ -32,11 +32,11 @@
   {
     "name": "Bistan",
     "limited": 1,
+    "xws": "bistan",
     "sides": [
       {
         "title": "Bistan",
         "type": "Gunner",
-        "xws": "bistan",
         "ability": "After you perform a primary attack, if you are focused, you may perform a bonus [Turret] attack against a shipe you have not already attacked this round.",
         "slots": [
           "Gunner"
@@ -47,11 +47,11 @@
   {
     "name": "Bossk",
     "limited": 1,
+    "xws": "bossk",
     "sides": [
       {
         "title": "Bossk",
         "type": "Gunner",
-        "xws": "bossk",
         "ability": "After you perform a primary attack that misses, if you are not stressedm you must receive 1 stress token to perform a bonus primary attack against the same target.",
         "slots": [
           "Gunner"
@@ -62,11 +62,11 @@
   {
     "name": "Dengar",
     "limited": 1,
+    "xws": "dengar",
     "sides": [
       {
         "title": "Dengar",
         "type": "Gunner",
-        "xws": "dengar",
         "ability": "After you defend, if the attacker is in your firing arc, you may spend 1 [Charge]. If you do, roll 1 attack die unless the attacker chooses to remove 1 green token. On a [Hit] or [Critical Hit] result, the attacker suffers 1 [Hit] damage.",
         "slots": [
           "Gunner"
@@ -81,11 +81,11 @@
   {
     "name": "Ezra Bridger",
     "limited": 1,
+    "xws": "ezrabridger",
     "sides": [
       {
         "title": "Ezra Bridger",
         "type": "Gunner",
-        "xws": "ezrabridger",
         "ability": "After you perform a primary attack, you may spend 1 [Force] to perform a bonus [Turret] attack from a [Turret] you have not attacked from this round. If you do and you are stressed, you may reroll 1 attack die.",
         "slots": [
           "Gunner"
@@ -100,11 +100,11 @@
   {
     "name": "Fifth Brother",
     "limited": 1,
+    "xws": "fifthbrother",
     "sides": [
       {
         "title": "Fifth Brother",
         "type": "Gunner",
-        "xws": "fifthbrother",
         "ability": "While you perform an attack, you may spend 1 [Force] to change 1 of your [Focus] results to a [Critical Hit] result.",
         "slots": [
           "Gunner"
@@ -119,11 +119,11 @@
   {
     "name": "Finn",
     "limited": 1,
+    "xws": "finn",
     "sides": [
       {
         "title": "Finn",
         "type": "Gunner",
-        "xws": "finn",
         "ability": "While you defend or perform a primary attack, if the enemy is in your [Front Arc], you may add 1 blank result to your roll... ..can be rerolled or otherwise...",
         "slots": [
           "Gunner"
@@ -134,11 +134,11 @@
   {
     "name": "Greedo",
     "limited": 1,
+    "xws": "greedo",
     "sides": [
       {
         "title": "Greedo",
         "type": "Gunner",
-        "xws": "greedo",
         "ability": "While you perform an attack, you may spend 1 [Charge] to change 1 [Hit] result to a [Critical Hit] result. While you defend, if your [Charge] is active, the attacker may change 1 [Hit] result to a [Critical Hit] result.",
         "slots": [
           "Gunner"
@@ -153,11 +153,11 @@
   {
     "name": "Han Solo",
     "limited": 1,
+    "xws": "hansolo",
     "sides": [
       {
         "title": "Han Solo",
         "type": "Gunner",
-        "xws": "hansolo",
         "ability": "During the Engagement Phase, at initiative 7, you may perform a [Turret] attack. You cannot attack from that [Turret] again this round.",
         "slots": [
           "Gunner"
@@ -168,11 +168,11 @@
   {
     "name": "Han Solo",
     "limited": 1,
+    "xws": "hansolo-gunner",
     "sides": [
       {
         "title": "Han Solo",
         "type": "Gunner",
-        "xws": "hansolo-gunner",
         "ability": "Before you engage, you may perform a red [Focus] action.",
         "slots": [
           "Gunner"
@@ -183,11 +183,11 @@
   {
     "name": "Hotshot Gunner",
     "limited": 0,
+    "xws": "hotshotgunner",
     "sides": [
       {
         "title": "Hotshot Gunner",
         "type": "Gunner",
-        "xws": "hotshotgunner",
         "ability": "While you perform a [Turret] attack, after the Modify Defense Dice step, the defender removes 1 focus or calculate token.",
         "slots": [
           "Gunner"
@@ -198,11 +198,11 @@
   {
     "name": "Luke Skywalker",
     "limited": 1,
+    "xws": "lukeskywalker",
     "sides": [
       {
         "title": "Luke Skywalker",
         "type": "Gunner",
-        "xws": "lukeskywalker",
         "ability": "At the start of the Engagement Phase, you may spend 1 [Force] to rotate your [Turret] indicator.",
         "slots": [
           "Gunner"
@@ -217,11 +217,11 @@
   {
     "name": "Skilled Bombardier",
     "limited": 0,
+    "xws": "skilledbombardier",
     "sides": [
       {
         "title": "Skilled Bombardier",
         "type": "Gunner",
-        "xws": "skilledbombardier",
         "ability": "If you would drop or launch a device, you may use a template of the same bearing with a speed 1 higher or lower.",
         "slots": [
           "Gunner"
@@ -232,11 +232,11 @@
   {
     "name": "Special Forces Gunner",
     "limited": 0,
+    "xws": "specialforcesgunner",
     "sides": [
       {
         "title": "Special Forces Gunner",
         "type": "Gunner",
-        "xws": "specialforcesgunner",
         "ability": "...e you perform a primary [Front Arc] attack, ...your [Single Turret Arc] is in your [Front Arc], you may roll 1 additional attack die. ...er you perform a primary [Front Arc] attack, ...our [Single Turret Arc] is in your [Rear Arc], you may perform a bonus primary [Single Turret Arc] attack.",
         "slots": [
           "Gunner"
@@ -247,11 +247,11 @@
   {
     "name": "Veteran Tail Gunner",
     "limited": 0,
+    "xws": "veterantailgunner",
     "sides": [
       {
         "title": "Veteran Tail Gunner",
         "type": "Gunner",
-        "xws": "veterantailgunner",
         "ability": "After you perform a primary [Front Arc] attack, you may perform a bonus primary [Rear Arc] attack.",
         "slots": [
           "Gunner"
@@ -262,11 +262,11 @@
   {
     "name": "Veteran Turret Gunner",
     "limited": 0,
+    "xws": "veteranturretgunner",
     "sides": [
       {
         "title": "Veteran Turret Gunner",
         "type": "Gunner",
-        "xws": "veteranturretgunner",
         "ability": "After you perform a primary attack, you may perform a bonus [Turret] attack using a [Turret] you did not already attack from this round.",
         "slots": [
           "Gunner"

--- a/data/upgrades/illicit.json
+++ b/data/upgrades/illicit.json
@@ -2,11 +2,11 @@
   {
     "name": "Cloaking Device",
     "limited": 1,
+    "xws": "cloakingdevice",
     "sides": [
       {
         "title": "Cloaking Device",
         "type": "Illicit",
-        "xws": "cloakingdevice",
         "ability": "Action: Spend 1 [Charge] to perform a [Cloak] action. At the start of the Planning Phase, roll 1 attack die. On a [Focus] result, decloak or discard your cloak token.",
         "slots": [
           "Illicit"
@@ -21,11 +21,11 @@
   {
     "name": "Contraband Cybernetics",
     "limited": 0,
+    "xws": "contrabandcybernetics",
     "sides": [
       {
         "title": "Contraband Cybernetics",
         "type": "Illicit",
-        "xws": "contrabandcybernetics",
         "ability": "Before you activate, you may spend 1 [Charge]. If you do, until the end of the round, you can perform actions and execute red maneuvers, even while stressed.",
         "slots": [
           "Illicit"
@@ -40,11 +40,11 @@
   {
     "name": "Deadman's Switch",
     "limited": 0,
+    "xws": "deadmansswitch",
     "sides": [
       {
         "title": "Deadman's Switch",
         "type": "Illicit",
-        "xws": "deadmansswitch",
         "ability": "After you are destroyed, each other ship at range 0-1 suffers 1 [Hit] damage.",
         "slots": [
           "Illicit"
@@ -55,11 +55,11 @@
   {
     "name": "Feedback Array",
     "limited": 0,
+    "xws": "feedbackarray",
     "sides": [
       {
         "title": "Feedback Array",
         "type": "Illicit",
-        "xws": "feedbackarray",
         "ability": "Before you engage, you may gain 1 ion token and 1 disarm token. If you do, each ship at range 0 suffers 1 [Hit] damage.",
         "slots": [
           "Illicit"
@@ -70,11 +70,11 @@
   {
     "name": "Inertial Dampeners",
     "limited": 0,
+    "xws": "inertialdampeners",
     "sides": [
       {
         "title": "Inertial Dampeners",
         "type": "Illicit",
-        "xws": "inertialdampeners",
         "ability": "Before you would execute a maneuver, you may spend 1 shield. If you do, execute a white [0 [Stationary]] instead of the maneuver you revealed, then gain 1 stress token.",
         "slots": [
           "Illicit"
@@ -85,11 +85,11 @@
   {
     "name": "Rigged Cargo Chute",
     "limited": 0,
+    "xws": "riggedcargochute",
     "sides": [
       {
         "title": "Rigged Cargo Chute",
         "type": "Illicit",
-        "xws": "riggedcargochute",
         "ability": "Action: Spend 1 [Charge]. Drop 1 loose cargo using the [1 [Straight]] template.",
         "slots": [
           "Illicit"

--- a/data/upgrades/missile.json
+++ b/data/upgrades/missile.json
@@ -2,11 +2,11 @@
   {
     "name": "Barrage Rockets",
     "limited": 0,
+    "xws": "barragerockets",
     "sides": [
       {
         "title": "Barrage Rockets",
         "type": "Missile",
-        "xws": "barragerockets",
         "ability": "Attack ([Focus]): Spend 1 [Charge]. If the defender is in your [Bullseye Arc], you may spend 1 or mroe [Charge] to reroll that many attack dice.",
         "slots": [
           "Missile"
@@ -27,11 +27,11 @@
   {
     "name": "Cluster Missiles",
     "limited": 0,
+    "xws": "clustermissiles",
     "sides": [
       {
         "title": "Cluster Missiles",
         "type": "Missile",
-        "xws": "clustermissiles",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. After this attack, you may perform this attack as a bonus attack against a different target at range 0-1 of the defender, ignoring the [Lock] requirement.",
         "slots": [
           "Missile"
@@ -52,11 +52,11 @@
   {
     "name": "Concussion Missiles",
     "limited": 0,
+    "xws": "concussionmissiles",
     "sides": [
       {
         "title": "Concussion Missiles",
         "type": "Missile",
-        "xws": "concussionmissiles",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. After this attack hits, each ship at range 0-1 of the defender exposes 1 of its damage cards.",
         "slots": [
           "Missile"
@@ -77,11 +77,11 @@
   {
     "name": "Homing Missiles",
     "limited": 0,
+    "xws": "homingmissiles",
     "sides": [
       {
         "title": "Homing Missiles",
         "type": "Missile",
-        "xws": "homingmissiles",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. After you declare the defender, the defender may choose to suffer 1 [Hit] damage. If it does, skip the Attack and Defense Dice steps and the attack is treated as hitting.",
         "slots": [
           "Missile"
@@ -102,11 +102,11 @@
   {
     "name": "Ion Missiles",
     "limited": 0,
+    "xws": "ionmissiles",
     "sides": [
       {
         "title": "Ion Missiles",
         "type": "Missile",
-        "xws": "ionmissiles",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
         "slots": [
           "Missile"
@@ -127,11 +127,11 @@
   {
     "name": "Proton Rockets",
     "limited": 0,
+    "xws": "protonrockets",
     "sides": [
       {
         "title": "Proton Rockets",
         "type": "Missile",
-        "xws": "protonrockets",
         "ability": "Attack ([Focus]): Spend 1 [Charge].",
         "slots": [
           "Missile"

--- a/data/upgrades/modification.json
+++ b/data/upgrades/modification.json
@@ -2,11 +2,11 @@
   {
     "name": "Ablative Plating",
     "limited": 0,
+    "xws": "ablativeplating",
     "sides": [
       {
         "title": "Ablative Plating",
         "type": "Modification",
-        "xws": "ablativeplating",
         "ability": "Before you would suffer damage from an obstacle or from a friendly bomb detonating, you may spend 1 [Charge]. If you do, prevent 1 damage.",
         "slots": [
           "Modification"
@@ -21,11 +21,11 @@
   {
     "name": "Advanced SLAM",
     "limited": 0,
+    "xws": "advancedslam",
     "sides": [
       {
         "title": "Advanced SLAM",
         "type": "Modification",
-        "xws": "advancedslam",
         "ability": "After you perform a [Slam] action, if you fully executed that maneuver, you may perform a white action on your action bar, treating that action as red.",
         "slots": [
           "Modification"
@@ -36,11 +36,11 @@
   {
     "name": "Afterburners",
     "limited": 0,
+    "xws": "afterburners",
     "sides": [
       {
         "title": "Afterburners",
         "type": "Modification",
-        "xws": "afterburners",
         "ability": "After you fully execute a speed 3-5 maneuver, you may spend 1 [Charge] to perform a [Boost] action, even while stressed.",
         "slots": [
           "Modification"
@@ -55,11 +55,11 @@
   {
     "name": "Electronic Baffle",
     "limited": 0,
+    "xws": "electronicbaffle",
     "sides": [
       {
         "title": "Electronic Baffle",
         "type": "Modification",
-        "xws": "electronicbaffle",
         "ability": "During the End Phase, you may suffer 1 [Hit] damage to remove 1 red token.",
         "slots": [
           "Modification"
@@ -70,11 +70,11 @@
   {
     "name": "Engine Upgrade",
     "limited": 0,
+    "xws": "engineupgrade",
     "sides": [
       {
         "title": "Engine Upgrade",
         "type": "Modification",
-        "xws": "engineupgrade",
         "text": "Large military forces such as the Galactic Empire have standardized engines, but individual pilots and small organizations often replace the power couplings add thrusters, or use high-performance fuel to get extra push out of their engines.",
         "slots": [
           "Modification"
@@ -91,11 +91,11 @@
   {
     "name": "Hull Upgrade",
     "limited": 0,
+    "xws": "hullupgrade",
     "sides": [
       {
         "title": "Hull Upgrade",
         "type": "Modification",
-        "xws": "hullupgrade",
         "text": "For those who cannot afford an enhanced shield generator, bolting additional plates onto the hull of a ship can serve as an adequate substitute.",
         "slots": [
           "Modification"
@@ -106,11 +106,11 @@
   {
     "name": "Munitions Failsafe",
     "limited": 0,
+    "xws": "munitionsfailsafe",
     "sides": [
       {
         "title": "Munitions Failsafe",
         "type": "Modification",
-        "xws": "munitionsfailsafe",
         "ability": "While you perform a [Torpedo] or [Missile] attack, after rolling attack dice, you may cancel all dice results to recover 1 [Charge] you spent as a cost for the attack.",
         "slots": [
           "Modification"
@@ -121,11 +121,11 @@
   {
     "name": "Shield Upgrade",
     "limited": 0,
+    "xws": "shieldupgrade",
     "sides": [
       {
         "title": "Shield Upgrade",
         "type": "Modification",
-        "xws": "shieldupgrade",
         "text": "Deflector shields are a substantial line of defense on most starships beyond the lightest fighters. While enhancing a ship's shield capacity can be costly, all but the most confident or reckless pilots see the value in this sort of investment.",
         "slots": [
           "Modification"
@@ -136,11 +136,11 @@
   {
     "name": "Static Discharge Vanes",
     "limited": 0,
+    "xws": "staticdischargevanes",
     "sides": [
       {
         "title": "Static Discharge Vanes",
         "type": "Modification",
-        "xws": "staticdischargevanes",
         "ability": "Before you would gain 1 ion or jam token, if you are not stressed, you may choose another ship at range 0-1 and gain 1 stress token. If you do, the chosen ship gains that ion or jam token instead.",
         "slots": [
           "Modification"
@@ -151,11 +151,11 @@
   {
     "name": "Stealth Device",
     "limited": 0,
+    "xws": "stealthdevice",
     "sides": [
       {
         "title": "Stealth Device",
         "type": "Modification",
-        "xws": "stealthdevice",
         "ability": "While you defend, if your [Charge] is active, roll 1 additional defense die. After you suffer damage, lost 1 [Charge].",
         "slots": [
           "Modification"
@@ -170,11 +170,11 @@
   {
     "name": "Tactical Scrambler",
     "limited": 0,
+    "xws": "tacticalscrambler",
     "sides": [
       {
         "title": "Tactical Scrambler",
         "type": "Modification",
-        "xws": "tacticalscrambler",
         "ability": "While you obstruct an enemy ship's attack, the defender rolls 1 additional defense die.",
         "slots": [
           "Modification"

--- a/data/upgrades/sensor.json
+++ b/data/upgrades/sensor.json
@@ -2,11 +2,11 @@
   {
     "name": "Advanced Sensors",
     "limited": 0,
+    "xws": "advancedsensors",
     "sides": [
       {
         "title": "Advanced Sensors",
         "type": "Sensor",
-        "xws": "advancedsensors",
         "ability": "After you reveal your dial, you may perform 1 action. If you do, you cannot perform another action during your activation.",
         "slots": [
           "Sensor"
@@ -17,11 +17,11 @@
   {
     "name": "Collision Detector",
     "limited": 0,
+    "xws": "collisiondetector",
     "sides": [
       {
         "title": "Collision Detector",
         "type": "Sensor",
-        "xws": "collisiondetector",
         "ability": "While you boost or barrel roll, you can move through and overlap obstacles. After you move through or overlap an obstacle, you may spend 1 [Charge] to ignore its effects ntie the end of the round.",
         "slots": [
           "Sensor"
@@ -36,11 +36,11 @@
   {
     "name": "Fire-Control System",
     "limited": 0,
+    "xws": "firecontrolsystem",
     "sides": [
       {
         "title": "Fire-Control System",
         "type": "Sensor",
-        "xws": "firecontrolsystem",
         "ability": "While you perform an attack, if you have a lock on the defender, you may reroll 1 attack die. If you do, you cannot spend your lock during this attack.",
         "slots": [
           "Sensor"
@@ -51,11 +51,11 @@
   {
     "name": "Trajectory Simulator",
     "limited": 0,
+    "xws": "trajectorysimulator",
     "sides": [
       {
         "title": "Trajectory Simulator",
         "type": "Sensor",
-        "xws": "trajectorysimulator",
         "ability": "During the System Phase, if you would drop or launch a bomb, you may launch it using the (5 [Straight]) tempplate instead.",
         "slots": [
           "Sensor"

--- a/data/upgrades/talent.json
+++ b/data/upgrades/talent.json
@@ -2,11 +2,11 @@
   {
     "name": "Composure",
     "limited": 0,
+    "xws": "composure",
     "sides": [
       {
         "title": "Composure",
         "type": "Talent",
-        "xws": "composure",
         "ability": "After you fail an action, if you have no green tokens, you may perform a [Focus] action.",
         "slots": [
           "Talent"
@@ -17,11 +17,11 @@
   {
     "name": "Crack Shot",
     "limited": 0,
+    "xws": "crackshot",
     "sides": [
       {
         "title": "Crack Shot",
         "type": "Talent",
-        "xws": "crackshot",
         "ability": "While you perform a primary attack, if the defender is in your [Bullseye Arc], before the Neutralize Results step, you may spend 1 [Charge] to cancel 1 [Evade] result.",
         "slots": [
           "Talent"
@@ -36,11 +36,11 @@
   {
     "name": "Daredevil",
     "limited": 0,
+    "xws": "daredevil",
     "sides": [
       {
         "title": "Daredevil",
         "type": "Talent",
-        "xws": "daredevil",
         "ability": "While you perform a while [Boost] action, you may treat it as red to use the [1[Turn Left]] or [1 [Turn Right]] template instead.",
         "slots": [
           "Talent"
@@ -51,11 +51,11 @@
   {
     "name": "Debris Gambit",
     "limited": 0,
+    "xws": "debrisgambit",
     "sides": [
       {
         "title": "Debris Gambit",
         "type": "Talent",
-        "xws": "debrisgambit",
         "ability": "While you perform a red [Evade] action, if there is an obstacle at range 0-1, treat the action as white instead.",
         "slots": [
           "Talent"
@@ -72,11 +72,11 @@
   {
     "name": "Elusive",
     "limited": 0,
+    "xws": "elusive",
     "sides": [
       {
         "title": "Elusive",
         "type": "Talent",
-        "xws": "elusive",
         "ability": "While you defend, you may spend 1 [Charge] to reroll 1 defense die. After you fully execute a red maneuver, recover 1 [Charge].",
         "slots": [
           "Talent"
@@ -91,11 +91,11 @@
   {
     "name": "Expert Handling",
     "limited": 0,
+    "xws": "experthandling",
     "sides": [
       {
         "title": "Expert Handling",
         "type": "Talent",
-        "xws": "experthandling",
         "text": "While heavy fighters can often be coaxed into a barrel roll, seasoned pilots know how to do it without putting undue stress on their craft or leaving themselves open to attack.",
         "slots": [
           "Talent"
@@ -112,11 +112,11 @@
   {
     "name": "Fanatical",
     "limited": 0,
+    "xws": "fanatical",
     "sides": [
       {
         "title": "Fanatical",
         "type": "Talent",
-        "xws": "fanatical",
         "ability": "While you perform a primary attack, if you are not shielded, you may change 1 [Focus] result to a [Hit] result.",
         "slots": [
           "Talent"
@@ -127,11 +127,11 @@
   {
     "name": "Fearless",
     "limited": 0,
+    "xws": "fearless",
     "sides": [
       {
         "title": "Fearless",
         "type": "Talent",
-        "xws": "fearless",
         "ability": "While you perform a [Front Arc] primary attack, if the attack range is 1 and you are in the defender's [Front Arc], you may change 1 of your results to a [Hit] result.",
         "slots": [
           "Talent"
@@ -142,11 +142,11 @@
   {
     "name": "Heroic",
     "limited": 0,
+    "xws": "heroic",
     "sides": [
       {
         "title": "Heroic",
         "type": "Talent",
-        "xws": "heroic",
         "ability": "While you defend or perform an attack, if you have only blank results and have 2 or more results, you may reroll any number of your dice.",
         "slots": [
           "Talent"
@@ -157,11 +157,11 @@
   {
     "name": "Intimidation",
     "limited": 0,
+    "xws": "intimidation",
     "sides": [
       {
         "title": "Intimidation",
         "type": "Talent",
-        "xws": "intimidation",
         "ability": "While an enemy ship at range 0 defends, it rolls 1 fewer defense die.",
         "slots": [
           "Talent"
@@ -172,11 +172,11 @@
   {
     "name": "Juke",
     "limited": 0,
+    "xws": "juke",
     "sides": [
       {
         "title": "Juke",
         "type": "Talent",
-        "xws": "juke",
         "ability": "While you perform an attack, if you are evading, you may change 1 of the defender's [Evade] results to a [Focus] result.",
         "slots": [
           "Talent"
@@ -187,11 +187,11 @@
   {
     "name": "Lone Wolf",
     "limited": 1,
+    "xws": "lonewolf",
     "sides": [
       {
         "title": "Lone Wolf",
         "type": "Talent",
-        "xws": "lonewolf",
         "ability": "While you defend or perform an attack, if there are no other friendly ships at range 0-2, you may spend 1 [Charge] to reroll 1 of your dice.",
         "slots": [
           "Talent"
@@ -206,11 +206,11 @@
   {
     "name": "Marksmanship",
     "limited": 0,
+    "xws": "marksmanship",
     "sides": [
       {
         "title": "Marksmanship",
         "type": "Talent",
-        "xws": "marksmanship",
         "ability": "While you perform an attack, if the defender is in your [Bullseye Arc], you may change 1 [Hit] result to a [Critical Hit] result.",
         "slots": [
           "Talent"
@@ -221,11 +221,11 @@
   {
     "name": "Outmaneuver",
     "limited": 0,
+    "xws": "outmaneuver",
     "sides": [
       {
         "title": "Outmaneuver",
         "type": "Talent",
-        "xws": "outmaneuver",
         "ability": "While you perform a [Front Arc] arrack, if you are not in the defender's firing arc, the defender rolls 1 fewer defense die.",
         "slots": [
           "Talent"
@@ -236,11 +236,11 @@
   {
     "name": "Predator",
     "limited": 0,
+    "xws": "predator",
     "sides": [
       {
         "title": "Predator",
         "type": "Talent",
-        "xws": "predator",
         "ability": "While you perform a primary attack, if the defender is in your [Bullseye Arc], you may reroll 1 attack die.",
         "slots": [
           "Talent"
@@ -251,11 +251,11 @@
   {
     "name": "Ruthless",
     "limited": 0,
+    "xws": "ruthless",
     "sides": [
       {
         "title": "Ruthless",
         "type": "Talent",
-        "xws": "ruthless",
         "ability": "While you perform an attack, you may choose another friendly ship at range 0-1 of the defender. If you do, that ship suffers 1 [Hit] damage and you may change 1 of your die results to a [Hit] result.",
         "slots": [
           "Talent"
@@ -266,11 +266,11 @@
   {
     "name": "Saturation Salvo",
     "limited": 0,
+    "xws": "saturationsalvo",
     "sides": [
       {
         "title": "Saturation Salvo",
         "type": "Talent",
-        "xws": "saturationsalvo",
         "ability": "While you perform a [Torpedo] or [Missile] attack, you may spend 1 charge from that upgrade. If you do, choose two defence dice. The defender must reroll those dice.",
         "slots": [
           "Talent"
@@ -281,11 +281,11 @@
   {
     "name": "Selfless",
     "limited": 0,
+    "xws": "selfless",
     "sides": [
       {
         "title": "Selfless",
         "type": "Talent",
-        "xws": "selfless",
         "ability": "Whlie another friendly ship at range 0-1 defends, before the Neutralize Results step, if you are in the attack arc, you may suffer 1 [Critical Hit] damage to cancel 1 [Critical Hit] result.",
         "slots": [
           "Talent"
@@ -296,11 +296,11 @@
   {
     "name": "Squad Leader",
     "limited": 1,
+    "xws": "squadleader",
     "sides": [
       {
         "title": "Squad Leader",
         "type": "Talent",
-        "xws": "squadleader",
         "ability": "While you coordinate, the ship you choose can perform an action only if that action is also on your action bar.",
         "slots": [
           "Talent"
@@ -317,11 +317,11 @@
   {
     "name": "Swarm Tactics",
     "limited": 0,
+    "xws": "swarmtactics",
     "sides": [
       {
         "title": "Swarm Tactics",
         "type": "Talent",
-        "xws": "swarmtactics",
         "ability": "At the start of the Engagement Phase, you may choose 1 friendly ship at range 1. If you do, that ship treats its initiative as equal to yours until the end of the round.",
         "slots": [
           "Talent"
@@ -332,11 +332,11 @@
   {
     "name": "Trick Shot",
     "limited": 0,
+    "xws": "trickshot",
     "sides": [
       {
         "title": "Trick Shot",
         "type": "Talent",
-        "xws": "trickshot",
         "ability": "While you perform an attack that is obstructed by an obstacle, roll 1 additional attack die.",
         "slots": [
           "Talent"

--- a/data/upgrades/tech.json
+++ b/data/upgrades/tech.json
@@ -2,11 +2,11 @@
   {
     "name": "Advanced Optics",
     "limited": 0,
+    "xws": "advancedoptics",
     "sides": [
       {
         "title": "Advanced Optics",
         "type": "Tech",
-        "xws": "advancedoptics",
         "ability": "While you perform an attack, you may spend 1 focus token to change 1 of your blank results to a [Hit] result.",
         "slots": [
           "Tech"
@@ -17,11 +17,11 @@
   {
     "name": "Ferrosphere Paint",
     "limited": 0,
+    "xws": "ferrospherepaint",
     "sides": [
       {
         "title": "Ferrosphere Paint",
         "type": "Tech",
-        "xws": "ferrospherepaint",
         "ability": "???",
         "slots": [
           "Tech"
@@ -32,11 +32,11 @@
   {
     "name": "Hyperspace Tracking Data",
     "limited": 0,
+    "xws": "hyperspacetrackingdata",
     "sides": [
       {
         "title": "Hyperspace Tracking Data",
         "type": "Tech",
-        "xws": "hyperspacetrackingdata",
         "ability": "Setup: Before placing forces, you may... 0 and 6...",
         "slots": [
           "Tech"
@@ -47,11 +47,11 @@
   {
     "name": "Primed Thrusters",
     "limited": 0,
+    "xws": "primedthrusters",
     "sides": [
       {
         "title": "Primed Thrusters",
         "type": "Tech",
-        "xws": "primedthrusters",
         "ability": "While you have 2 or fewer stress tokens, you can perform [Barrel Roll] and [Boost] actions even while stressed.",
         "slots": [
           "Tech"
@@ -62,11 +62,11 @@
   {
     "name": "Targeting Synchronizer",
     "limited": 0,
+    "xws": "targetingsynchronizer",
     "sides": [
       {
         "title": "Targeting Synchronizer",
         "type": "Tech",
-        "xws": "targetingsynchronizer",
         "ability": "While a friendly ship at range 1-2 performs an attack against a target you have locked, that ship ignores the [Lock] attack requirement.",
         "slots": [
           "Tech"

--- a/data/upgrades/title.json
+++ b/data/upgrades/title.json
@@ -2,11 +2,11 @@
   {
     "name": "Andrasta",
     "limited": 1,
+    "xws": "andrasta",
     "sides": [
       {
         "title": "Andrasta",
         "type": "Title",
-        "xws": "andrasta",
         "ability": "Add [Device] slot.",
         "slots": [
           "Title"
@@ -23,11 +23,11 @@
   {
     "name": "Black One",
     "limited": 1,
+    "xws": "blackone",
     "sides": [
       {
         "title": "Black One",
         "type": "Title",
-        "xws": "blackone",
         "ability": "After you perform a [Slam] acion, lose 1 [Charge]. Then, you may gain 1 ion token to remove 1 disarm token. If your [Charge] is inactive, you cannot perform the [Slam] action.",
         "slots": [
           "Title"
@@ -48,11 +48,11 @@
   {
     "name": "Dauntless",
     "limited": 1,
+    "xws": "dauntless",
     "sides": [
       {
         "title": "Dauntless",
         "type": "Title",
-        "xws": "dauntless",
         "ability": "After you partially execute a maneuver, you may perform 1 white action, treating that action as red.",
         "slots": [
           "Title"
@@ -63,11 +63,11 @@
   {
     "name": "Ghost",
     "limited": 1,
+    "xws": "ghost",
     "sides": [
       {
         "title": "Ghost",
         "type": "Title",
-        "xws": "ghost",
         "ability": "You can dock 1 attack shuttle or Sheathipede-class shuttle. Your docked ships can deploy only from your rear guides.",
         "slots": [
           "Title"
@@ -78,11 +78,11 @@
   {
     "name": "Havoc",
     "limited": 1,
+    "xws": "havoc",
     "sides": [
       {
         "title": "Havoc",
         "type": "Title",
-        "xws": "havoc",
         "ability": "Remove [Crew] slot. Add [Sensor] and [Astromech] slots.",
         "slots": [
           "Title"
@@ -93,11 +93,11 @@
   {
     "name": "Hound's Tooth",
     "limited": 1,
+    "xws": "houndstooth",
     "sides": [
       {
         "title": "Hound's Tooth",
         "type": "Title",
-        "xws": "houndstooth",
         "ability": "1 Z-95 AF4 headhunter can dock with you.",
         "slots": [
           "Title"
@@ -108,11 +108,11 @@
   {
     "name": "IG-2000",
     "limited": 0,
+    "xws": "ig2000",
     "sides": [
       {
         "title": "IG-2000",
         "type": "Title",
-        "xws": "ig2000",
         "ability": "You have the pilot ability of each other friendly ship with the IG-2000 upgrade.",
         "slots": [
           "Title"
@@ -123,11 +123,11 @@
   {
     "name": "Lando's Millennium Falcon",
     "limited": 1,
+    "xws": "landosmillenniumfalcon",
     "sides": [
       {
         "title": "Lando's Millennium Falcon",
         "type": "Title",
-        "xws": "landosmillenniumfalcon",
         "ability": "1 Escape Craft may dock with you. While you have an Escape Craft docked, you may spend its shields as if they were on your ship card. While you perform a primary attack against a stressed ship, roll 1 additional attack die.",
         "slots": [
           "Title"
@@ -138,11 +138,11 @@
   {
     "name": "Marauder",
     "limited": 1,
+    "xws": "marauder",
     "sides": [
       {
         "title": "Marauder",
         "type": "Title",
-        "xws": "marauder",
         "ability": "While you perform a primary [Rear Arc] attack,, you may reroll 1 attack die. Add [Gunner] slot.",
         "slots": [
           "Title"
@@ -153,11 +153,11 @@
   {
     "name": "Millennium Falcon",
     "limited": 1,
+    "xws": "millenniumfalcon",
     "sides": [
       {
         "title": "Millennium Falcon",
         "type": "Title",
-        "xws": "millenniumfalcon",
         "ability": "While you defend, if you are evading, you may reroll 1 defense die.",
         "slots": [
           "Title"
@@ -174,11 +174,11 @@
   {
     "name": "Mist Hunter",
     "limited": 1,
+    "xws": "misthunter",
     "sides": [
       {
         "title": "Mist Hunter",
         "type": "Title",
-        "xws": "misthunter",
         "ability": "Add [Cannon] slot.",
         "slots": [
           "Title"
@@ -195,11 +195,11 @@
   {
     "name": "Moldy Crow",
     "limited": 1,
+    "xws": "moldycrow",
     "sides": [
       {
         "title": "Moldy Crow",
         "type": "Title",
-        "xws": "moldycrow",
         "ability": "Gain a [Front Arc] primary weapon with a value of \"3.\" During the End Phase, do not remove up to 2 focus tokens.",
         "slots": [
           "Title"
@@ -210,11 +210,11 @@
   {
     "name": "Outrider",
     "limited": 1,
+    "xws": "outrider",
     "sides": [
       {
         "title": "Outrider",
         "type": "Title",
-        "xws": "outrider",
         "ability": "While you perform an attack that is obstructed by an obstacle, the defender rolls 1 fewer defense die. After you fully execute a maneuver, if you moved through or overlapped an obstacle, you may remove 1 of your red or orange tokens.",
         "slots": [
           "Title"
@@ -225,11 +225,11 @@
   {
     "name": "Phantom",
     "limited": 1,
+    "xws": "phantom",
     "sides": [
       {
         "title": "Phantom",
         "type": "Title",
-        "xws": "phantom",
         "ability": "You can dock at range 0-1.",
         "slots": [
           "Title"
@@ -240,11 +240,11 @@
   {
     "name": "Punishing One",
     "limited": 1,
+    "xws": "punishingone",
     "sides": [
       {
         "title": "Punishing One",
         "type": "Title",
-        "xws": "punishingone",
         "ability": "When you perform a primary attack, if the defender is in your [Front Arc], roll 1 additional attack die. Remove [Crew] slot. Add [Astromech] slot.",
         "slots": [
           "Title"
@@ -255,11 +255,11 @@
   {
     "name": "ST-321",
     "limited": 1,
+    "xws": "st321",
     "sides": [
       {
         "title": "ST-321",
         "type": "Title",
-        "xws": "st321",
         "ability": "After you perform a [Coordinate] action, you may choose an enemy ship at range 0-3 of the ship you coordinated. If you do, acquire a lock on that enemy ship, ignoring range restrictions.",
         "slots": [
           "Title"
@@ -270,11 +270,11 @@
   {
     "name": "Shadow Caster",
     "limited": 1,
+    "xws": "shadowcaster",
     "sides": [
       {
         "title": "Shadow Caster",
         "type": "Title",
-        "xws": "shadowcaster",
         "ability": "After you perform an attack that hits, if the defender is in your [Single Turret Arc] and your [Front Arc], the defender gains 1 tractor token.",
         "slots": [
           "Title"
@@ -285,11 +285,11 @@
   {
     "name": "Slave I",
     "limited": 1,
+    "xws": "slavei",
     "sides": [
       {
         "title": "Slave I",
         "type": "Title",
-        "xws": "slavei",
         "ability": "After you reveal a turn, ([Turn Left] or [Turn Right]) or bank ([Bank Left] or [Bank Right]) maneuver, you may set your dial to the maneuver of the same speed and bearing in the other direction. Add [Torpedo] slot.",
         "slots": [
           "Title"
@@ -300,11 +300,11 @@
   {
     "name": "Virago",
     "limited": 1,
+    "xws": "virago",
     "sides": [
       {
         "title": "Virago",
         "type": "Title",
-        "xws": "virago",
         "ability": "During the End Phase, you may spend 1 [Charge] to perform a red [Boost] action. Add [Modification] slot.",
         "slots": [
           "Title"

--- a/data/upgrades/torpedo.json
+++ b/data/upgrades/torpedo.json
@@ -2,11 +2,11 @@
   {
     "name": "Adv. Proton Torpedoes",
     "limited": 0,
+    "xws": "advprotontorpedoes",
     "sides": [
       {
         "title": "Adv. Proton Torpedoes",
         "type": "Torpedo",
-        "xws": "advprotontorpedoes",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. Change 1 [Hit] result to a [Critical Hit] result.",
         "slots": [
           "Torpedo"
@@ -27,11 +27,11 @@
   {
     "name": "Ion Torpedoes",
     "limited": 0,
+    "xws": "iontorpedoes",
     "sides": [
       {
         "title": "Ion Torpedoes",
         "type": "Torpedo",
-        "xws": "iontorpedoes",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
         "slots": [
           "Torpedo"
@@ -52,11 +52,11 @@
   {
     "name": "Proton Torpedoes",
     "limited": 0,
+    "xws": "protontorpedoes",
     "sides": [
       {
         "title": "Proton Torpedoes",
         "type": "Torpedo",
-        "xws": "protontorpedoes",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. Change 1 [Hit] result to a [Critical Hit] result.",
         "slots": [
           "Torpedo"

--- a/data/upgrades/turret.json
+++ b/data/upgrades/turret.json
@@ -2,11 +2,11 @@
   {
     "name": "Dorsal Turret",
     "limited": 0,
+    "xws": "dorsalturret",
     "sides": [
       {
         "title": "Dorsal Turret",
         "type": "Turret",
-        "xws": "dorsalturret",
         "ability": "Attack",
         "slots": [
           "Turret"
@@ -29,11 +29,11 @@
   {
     "name": "Ion Cannon Turret",
     "limited": 0,
+    "xws": "ioncannonturret",
     "sides": [
       {
         "title": "Ion Cannon Turret",
         "type": "Turret",
-        "xws": "ioncannonturret",
         "ability": "Attack: If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
         "slots": [
           "Turret"


### PR DESCRIPTION
This was always meant to be a top-level property, but was placed inside `sides` field in error

Related: https://github.com/guidokessels/xwing-data2/pull/20