### PR TITLE
Update tie-ln-fighter.json

### DIFF
--- a/data/pilots/rebel-alliance/tie-ln-fighter.json
+++ b/data/pilots/rebel-alliance/tie-ln-fighter.json
@@ -68,7 +68,10 @@
       "cost": 32,
       "xws": "captainrex",
       "ability": "After you perform an attack, assign the Suppressive Fire condition to the defender.",
-      "image": "https://i.imgur.com/SXjax2A.jpg"
+      "image": "https://i.imgur.com/SXjax2A.jpg",
+      "conditions": [
+        "suppressivefire"
+      ]
     },
     {
       "name": "Ezra Bridger",


### PR DESCRIPTION
addition an association between a pilot entry and its condition (unique xwd id tag) card
it's a list since 1.0 had a pilot which needed 2 potential condition cards at once (Thweek)
