### PR TITLE
Add ordnance attribute to special attacks

### DIFF
--- a/data/upgrades/cannon.json
+++ b/data/upgrades/cannon.json
@@ -15,7 +15,8 @@
           "arc": "Bullseye Arc",
           "value": 4,
           "minrange": 2,
-          "maxrange": 3
+          "maxrange": 3,
+          "ordnance": false
         }
       }
     ]
@@ -36,7 +37,8 @@
           "arc": "Front Arc",
           "value": 3,
           "minrange": 1,
-          "maxrange": 3
+          "maxrange": 3,
+          "ordnance": false
         }
       }
     ]
@@ -57,7 +59,8 @@
           "arc": "Front Arc",
           "value": 3,
           "minrange": 1,
-          "maxrange": 2
+          "maxrange": 2,
+          "ordnance": false
         }
       }
     ]
@@ -78,7 +81,8 @@
           "arc": "Front Arc",
           "value": 3,
           "minrange": 1,
-          "maxrange": 3
+          "maxrange": 3,
+          "ordnance": false
         }
       }
     ]

--- a/data/upgrades/missile.json
+++ b/data/upgrades/missile.json
@@ -19,7 +19,8 @@
           "arc": "Front Arc",
           "value": 3,
           "minrange": 2,
-          "maxrange": 3
+          "maxrange": 3,
+          "ordnance": true
         }
       }
     ]
@@ -44,7 +45,8 @@
           "arc": "Front Arc",
           "value": 3,
           "minrange": 1,
-          "maxrange": 2
+          "maxrange": 2,
+          "ordnance": true
         }
       }
     ]
@@ -69,7 +71,8 @@
           "arc": "Front Arc",
           "value": 3,
           "minrange": 2,
-          "maxrange": 3
+          "maxrange": 3,
+          "ordnance": true
         }
       }
     ]
@@ -94,7 +97,8 @@
           "arc": "Front Arc",
           "value": 4,
           "minrange": 2,
-          "maxrange": 3
+          "maxrange": 3,
+          "ordnance": true
         }
       }
     ]
@@ -119,7 +123,8 @@
           "arc": "Front Arc",
           "value": 3,
           "minrange": 2,
-          "maxrange": 3
+          "maxrange": 3,
+          "ordnance": true
         }
       }
     ]
@@ -144,7 +149,8 @@
           "arc": "Bullseye Arc",
           "value": 5,
           "minrange": 1,
-          "maxrange": 2
+          "maxrange": 2,
+          "ordnance": true
         }
       }
     ]

--- a/data/upgrades/torpedo.json
+++ b/data/upgrades/torpedo.json
@@ -19,7 +19,8 @@
           "arc": "Front Arc",
           "value": 5,
           "minrange": 1,
-          "maxrange": 1
+          "maxrange": 1,
+          "ordnance": true
         }
       }
     ]
@@ -44,7 +45,8 @@
           "arc": "Front Arc",
           "value": 4,
           "minrange": 2,
-          "maxrange": 3
+          "maxrange": 3,
+          "ordnance": true
         }
       }
     ]
@@ -69,7 +71,8 @@
           "arc": "Front Arc",
           "value": 4,
           "minrange": 2,
-          "maxrange": 3
+          "maxrange": 3,
+          "ordnance": true
         }
       }
     ]

--- a/data/upgrades/turret.json
+++ b/data/upgrades/turret.json
@@ -15,7 +15,8 @@
           "arc": "Single Turret Arc",
           "value": 2,
           "minrange": 1,
-          "maxrange": 2
+          "maxrange": 2,
+          "ordnance": false
         },
         "actions": [
           {
@@ -42,7 +43,8 @@
           "arc": "Single Turret Arc",
           "value": 3,
           "minrange": 1,
-          "maxrange": 2
+          "maxrange": 2,
+          "ordnance": false
         },
         "actions": [
           {


### PR DESCRIPTION
Indicates whether the card has the ordnance icon (which means the attack ignores range bonuses). Fixes #28.