### PR TITLE
Restrictions

### DIFF
--- a/data/upgrades/astromech.json
+++ b/data/upgrades/astromech.json
@@ -15,7 +15,14 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "\"Genius\"",
@@ -33,7 +40,14 @@
     ],
     "cost": {
       "value": 0
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "R2 Astromech",
@@ -77,7 +91,14 @@
     ],
     "cost": {
       "value": 8
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "R3 Astromech",
@@ -113,7 +134,14 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "sizes": [
+          "Small"
+        ]
+      }
+    ]
   },
   {
     "name": "R5 Astromech",
@@ -157,7 +185,14 @@
     ],
     "cost": {
       "value": 7
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "R5-P8",
@@ -179,7 +214,14 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "R5-TK",
@@ -197,6 +239,13 @@
     ],
     "cost": {
       "value": 1
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   }
 ]

--- a/data/upgrades/configuration.json
+++ b/data/upgrades/configuration.json
@@ -56,7 +56,7 @@
     },
     "restrictions": [
       {
-        "chassis": [
+        "ships": [
           "alphaclassstarwing"
         ]
       }
@@ -89,7 +89,7 @@
     },
     "restrictions": [
       {
-        "chassis": [
+        "ships": [
           "ut60duwing"
         ]
       }
@@ -136,7 +136,7 @@
     },
     "restrictions": [
       {
-        "chassis": [
+        "ships": [
           "t65xwing"
         ]
       }
@@ -168,7 +168,7 @@
     },
     "restrictions": [
       {
-        "chassis": [
+        "ships": [
           "alphaclassstarwing"
         ]
       }

--- a/data/upgrades/configuration.json
+++ b/data/upgrades/configuration.json
@@ -53,7 +53,14 @@
     ],
     "cost": {
       "value": 0
-    }
+    },
+    "restrictions": [
+      {
+        "chassis": [
+          "alphaclassstarwing"
+        ]
+      }
+    ]
   },
   {
     "name": "Pivot Wing",
@@ -79,7 +86,14 @@
     ],
     "cost": {
       "value": 0
-    }
+    },
+    "restrictions": [
+      {
+        "chassis": [
+          "ut60duwing"
+        ]
+      }
+    ]
   },
   {
     "name": "Servomotor S-foils",
@@ -119,7 +133,14 @@
     ],
     "cost": {
       "value": 0
-    }
+    },
+    "restrictions": [
+      {
+        "chassis": [
+          "t65xwing"
+        ]
+      }
+    ]
   },
   {
     "name": "Xg-1 Assault Configuration",
@@ -144,6 +165,13 @@
     ],
     "cost": {
       "value": 0
-    }
+    },
+    "restrictions": [
+      {
+        "chassis": [
+          "alphaclassstarwing"
+        ]
+      }
+    ]
   }
 ]

--- a/data/upgrades/crew.json
+++ b/data/upgrades/crew.json
@@ -33,7 +33,14 @@
     ],
     "cost": {
       "value": 1
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "0-0-0",
@@ -51,7 +58,15 @@
     ],
     "cost": {
       "value": 3
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ],
+        "characters": ["darthvader"]
+      }
+    ]
   },
   {
     "name": "4-LOM",
@@ -69,7 +84,14 @@
     ],
     "cost": {
       "value": 3
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Admiral Sloane",
@@ -87,7 +109,14 @@
     ],
     "cost": {
       "value": 10
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      }
+    ]
   },
   {
     "name": "Agent Kallus",
@@ -108,7 +137,14 @@
     ],
     "cost": {
       "value": 6
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      }
+    ]
   },
   {
     "name": "Baze Malbus",
@@ -126,7 +162,14 @@
     ],
     "cost": {
       "value": 8
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Boba Fett",
@@ -144,7 +187,14 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "C-3PO",
@@ -178,7 +228,14 @@
     ],
     "cost": {
       "value": 12
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Cad Bane",
@@ -196,7 +253,14 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Captain Phasma",
@@ -232,7 +296,14 @@
     ],
     "cost": {
       "value": 6
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Chewbacca",
@@ -254,7 +325,14 @@
     ],
     "cost": {
       "value": 5
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Chewbacca",
@@ -272,7 +350,14 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Ciena Ree",
@@ -290,7 +375,19 @@
     ],
     "cost": {
       "value": 10
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      },
+      {
+        "action": {
+          "type": "Coordinate"
+        }
+      }
+    ]
   },
   {
     "name": "Cikatro Vizago",
@@ -308,7 +405,14 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Darth Vader",
@@ -330,7 +434,14 @@
     ],
     "cost": {
       "value": 14
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      }
+    ]
   },
   {
     "name": "Death Troopers",
@@ -349,7 +460,14 @@
     ],
     "cost": {
       "value": 6
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      }
+    ]
   },
   {
     "name": "Director Krennic",
@@ -386,7 +504,14 @@
     ],
     "cost": {
       "value": 5
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      }
+    ]
   },
   {
     "name": "Emperor Palpatine",
@@ -409,7 +534,14 @@
     ],
     "cost": {
       "value": 13
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      }
+    ]
   },
   {
     "name": "Freelance Slicer",
@@ -471,7 +603,14 @@
     ],
     "cost": {
       "value": 16
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      }
+    ]
   },
   {
     "name": "Grand Moff Tarkin",
@@ -493,7 +632,19 @@
     ],
     "cost": {
       "value": 10
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      },
+      {
+        "action": {
+          "type": "Lock"
+        }
+      }
+    ]
   },
   {
     "name": "Hera Syndulla",
@@ -511,7 +662,14 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "IG-88D",
@@ -545,7 +703,14 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "ISB Slicer",
@@ -563,7 +728,14 @@
     ],
     "cost": {
       "value": 3
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      }
+    ]
   },
   {
     "name": "Informant",
@@ -607,7 +779,14 @@
     ],
     "cost": {
       "value": 8
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Jyn Erso",
@@ -625,7 +804,14 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Kanan Jarrus",
@@ -647,7 +833,14 @@
     ],
     "cost": {
       "value": 14
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Ketsu Onyo",
@@ -665,7 +858,14 @@
     ],
     "cost": {
       "value": 5
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "L3-37",
@@ -695,7 +895,14 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Lando Calrissian",
@@ -713,7 +920,14 @@
     ],
     "cost": {
       "value": 0
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Lando Calrissian",
@@ -731,7 +945,14 @@
     ],
     "cost": {
       "value": 5
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Latts Razzi",
@@ -749,7 +970,14 @@
     ],
     "cost": {
       "value": 7
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Leia Organa",
@@ -771,7 +999,14 @@
     ],
     "cost": {
       "value": 8
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Magva Yarro",
@@ -789,7 +1024,14 @@
     ],
     "cost": {
       "value": 7
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Maul",
@@ -811,7 +1053,14 @@
     ],
     "cost": {
       "value": 13
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Minister Tua",
@@ -829,7 +1078,14 @@
     ],
     "cost": {
       "value": 7
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      }
+    ]
   },
   {
     "name": "Moff Jerjerrod",
@@ -851,7 +1107,19 @@
     ],
     "cost": {
       "value": 12
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      },
+      {
+        "action": {
+          "type": "Coordinate"
+        }
+      }
+    ]
   },
   {
     "name": "Nien Nunb",
@@ -869,7 +1137,14 @@
     ],
     "cost": {
       "value": 5
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Novice Technician",
@@ -923,7 +1198,14 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "R2-D2",
@@ -977,7 +1259,14 @@
     ],
     "cost": {
       "value": 3
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Saw Gerrera",
@@ -995,7 +1284,14 @@
     ],
     "cost": {
       "value": 8
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Seasoned Navigator",
@@ -1035,7 +1331,14 @@
     ],
     "cost": {
       "value": 12
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      }
+    ]
   },
   {
     "name": "Supreme Leader Snoke",
@@ -1088,7 +1391,15 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "action": {
+          "type": "Coordinate",
+          "difficulty": "Red"
+        }
+      }
+    ]
   },
   {
     "name": "Tobias Beckett",
@@ -1106,7 +1417,14 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Unkar Plutt",
@@ -1124,7 +1442,14 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Zuckuss",
@@ -1142,6 +1467,13 @@
     ],
     "cost": {
       "value": 3
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   }
 ]

--- a/data/upgrades/crew.json
+++ b/data/upgrades/crew.json
@@ -64,7 +64,7 @@
         "factions": [
           "Scum and Villainy"
         ],
-        "characters": ["darthvader"]
+        "names": ["Darth Vader"]
       }
     ]
   },
@@ -1058,7 +1058,8 @@
       {
         "factions": [
           "Scum and Villainy"
-        ]
+        ],
+        "names": ["Ezra Bridger"]
       }
     ]
   },

--- a/data/upgrades/force-power.json
+++ b/data/upgrades/force-power.json
@@ -69,6 +69,13 @@
     ],
     "cost": {
       "value": 12
-    }
+    },
+    "restrictions": [
+      {
+        "sizes": [
+          "Small"
+        ]
+      }
+    ]
   }
 ]

--- a/data/upgrades/gunner.json
+++ b/data/upgrades/gunner.json
@@ -39,7 +39,7 @@
         "factions": [
           "Scum and Villainy"
         ],
-        "characters": ["darthvader"]
+        "names": ["Darth Vader"]
       }
     ]
   },

--- a/data/upgrades/gunner.json
+++ b/data/upgrades/gunner.json
@@ -33,7 +33,15 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ],
+        "characters": ["darthvader"]
+      }
+    ]
   },
   {
     "name": "Bistan",
@@ -51,7 +59,14 @@
     ],
     "cost": {
       "value": 14
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Bossk",
@@ -69,7 +84,14 @@
     ],
     "cost": {
       "value": 10
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Dengar",
@@ -91,7 +113,14 @@
     ],
     "cost": {
       "value": 6
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Ezra Bridger",
@@ -113,7 +142,14 @@
     ],
     "cost": {
       "value": 18
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Fifth Brother",
@@ -135,7 +171,14 @@
     ],
     "cost": {
       "value": 12
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      }
+    ]
   },
   {
     "name": "Finn",
@@ -175,7 +218,14 @@
     ],
     "cost": {
       "value": 1
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Han Solo",
@@ -193,7 +243,14 @@
     ],
     "cost": {
       "value": 12
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Han Solo",
@@ -211,7 +268,14 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Hotshot Gunner",
@@ -251,7 +315,14 @@
     ],
     "cost": {
       "value": 30
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Skilled Bombardier",
@@ -305,7 +376,14 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "arcs": [
+          "Rear Arc"
+        ]
+      }
+    ]
   },
   {
     "name": "Veteran Turret Gunner",
@@ -323,6 +401,13 @@
     ],
     "cost": {
       "value": 8
-    }
+    },
+    "restrictions": [
+      {
+        "action": {
+          "type": "Rotate Arc"
+        }
+      }
+    ]
   }
 ]

--- a/data/upgrades/illicit.json
+++ b/data/upgrades/illicit.json
@@ -19,7 +19,15 @@
     ],
     "cost": {
       "value": 5
-    }
+    },
+    "restrictions": [
+      {
+        "sizes": [
+          "Small",
+          "Medium"
+        ]
+      }
+    ]
   },
   {
     "name": "Contraband Cybernetics",
@@ -117,6 +125,14 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "sizes": [
+          "Medium",
+          "Large"
+        ]
+      }
+    ]
   }
 ]

--- a/data/upgrades/modification.json
+++ b/data/upgrades/modification.json
@@ -19,7 +19,15 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "sizes": [
+          "Medium",
+          "Large"
+        ]
+      }
+    ]
   },
   {
     "name": "Advanced SLAM",
@@ -37,7 +45,15 @@
     ],
     "cost": {
       "value": 3
-    }
+    },
+    "restrictions": [
+      {
+        "action": {
+          "type": "SLAM",
+          "difficulty": "White"
+        }
+      }
+    ]
   },
   {
     "name": "Afterburners",
@@ -59,7 +75,14 @@
     ],
     "cost": {
       "value": 8
-    }
+    },
+    "restrictions": [
+      {
+        "sizes": [
+          "Small"
+        ]
+      }
+    ]
   },
   {
     "name": "Electronic Baffle",
@@ -116,7 +139,15 @@
         "Medium": 6,
         "Large": 9
       }
-    }
+    },
+    "restrictions": [
+      {
+        "action": {
+          "type": "Boost",
+          "difficulty": "Red"
+        }
+      }
+    ]
   },
   {
     "name": "Hull Upgrade",
@@ -256,6 +287,14 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "sizes": [
+          "Medium",
+          "Large"
+        ]
+      }
+    ]
   }
 ]

--- a/data/upgrades/talent.json
+++ b/data/upgrades/talent.json
@@ -15,7 +15,14 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "action": {
+          "type": "Focus"
+        }
+      }
+    ]
   },
   {
     "name": "Crack Shot",
@@ -55,7 +62,20 @@
     ],
     "cost": {
       "value": 3
-    }
+    },
+    "restrictions": [
+      {
+        "sizes": [
+          "Small"
+        ]
+      },
+      {
+        "action": {
+          "type": "Boost",
+          "difficulty": "White"
+        }
+      }
+    ]
   },
   {
     "name": "Debris Gambit",
@@ -89,7 +109,15 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "sizes": [
+          "Small",
+          "Medium"
+        ]
+      }
+    ]
   },
   {
     "name": "Elusive",
@@ -111,7 +139,15 @@
     ],
     "cost": {
       "value": 3
-    }
+    },
+    "restrictions": [
+      {
+        "sizes": [
+          "Small",
+          "Medium"
+        ]
+      }
+    ]
   },
   {
     "name": "Expert Handling",
@@ -150,7 +186,15 @@
         "Medium": 4,
         "Large": 6
       }
-    }
+    },
+    "restrictions": [
+      {
+        "action": {
+          "type": "Barrel Roll",
+          "difficulty": "Red"
+        }
+      }
+    ]
   },
   {
     "name": "Fanatical",
@@ -186,7 +230,14 @@
     ],
     "cost": {
       "value": 3
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      }
+    ]
   },
   {
     "name": "Heroic",
@@ -240,7 +291,15 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "sizes": [
+          "Small",
+          "Medium"
+        ]
+      }
+    ]
   },
   {
     "name": "Lone Wolf",
@@ -334,7 +393,14 @@
     ],
     "cost": {
       "value": 1
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      }
+    ]
   },
   {
     "name": "Saturation Salvo",
@@ -352,7 +418,14 @@
     ],
     "cost": {
       "value": 6
-    }
+    },
+    "restrictions": [
+      {
+        "action": {
+          "type": "Reload"
+        }
+      }
+    ]
   },
   {
     "name": "Selfless",
@@ -370,7 +443,14 @@
     ],
     "cost": {
       "value": 3
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      }
+    ]
   },
   {
     "name": "Squad Leader",

--- a/data/upgrades/title.json
+++ b/data/upgrades/title.json
@@ -36,7 +36,19 @@
     ],
     "cost": {
       "value": 6
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      },
+      {
+        "chassis": [
+          "firesprayclasspatrolcraft"
+        ]
+      }
+    ]
   },
   {
     "name": "Black One",
@@ -82,7 +94,19 @@
     ],
     "cost": {
       "value": 6
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      },
+      {
+        "chassis": [
+          "vt49decimator"
+        ]
+      }
+    ]
   },
   {
     "name": "Ghost",
@@ -100,7 +124,19 @@
     ],
     "cost": {
       "value": 0
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      },
+      {
+        "chassis": [
+          "vcx100lightfreighter"
+        ]
+      }
+    ]
   },
   {
     "name": "Havoc",
@@ -135,7 +171,19 @@
     ],
     "cost": {
       "value": 4
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      },
+      {
+        "chassis": [
+          "scurrgh6bomber"
+        ]
+      }
+    ]
   },
   {
     "name": "Hound's Tooth",
@@ -153,7 +201,19 @@
     ],
     "cost": {
       "value": 1
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      },
+      {
+        "chassis": [
+          "yv666lightfreighter"
+        ]
+      }
+    ]
   },
   {
     "name": "IG-2000",
@@ -171,7 +231,19 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      },
+      {
+        "chassis": [
+          "aggressorassaultfighter"
+        ]
+      }
+    ]
   },
   {
     "name": "Lando's Millennium Falcon",
@@ -189,7 +261,19 @@
     ],
     "cost": {
       "value": 6
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      },
+      {
+        "chassis": [
+          "customizedyt1300lightfreighter"
+        ]
+      }
+    ]
   },
   {
     "name": "Marauder",
@@ -214,7 +298,19 @@
     ],
     "cost": {
       "value": 3
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      },
+      {
+        "chassis": [
+          "firesprayclasspatrolcraft"
+        ]
+      }
+    ]
   },
   {
     "name": "Millennium Falcon",
@@ -248,7 +344,19 @@
     ],
     "cost": {
       "value": 6
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      },
+      {
+        "chassis": [
+          "modifiedyt1300lightfreighter"
+        ]
+      }
+    ]
   },
   {
     "name": "Mist Hunter",
@@ -287,7 +395,19 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      },
+      {
+        "chassis": [
+          "g1astarfighter"
+        ]
+      }
+    ]
   },
   {
     "name": "Moldy Crow",
@@ -305,7 +425,20 @@
     ],
     "cost": {
       "value": 12
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance",
+          "Scum and Villainy"
+        ]
+      },
+      {
+        "chassis": [
+          "hwk290lightfreighter"
+        ]
+      }
+    ]
   },
   {
     "name": "Outrider",
@@ -323,7 +456,19 @@
     ],
     "cost": {
       "value": 14
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      },
+      {
+        "chassis": [
+          "yt2400lightfreighter"
+        ]
+      }
+    ]
   },
   {
     "name": "Phantom",
@@ -341,7 +486,20 @@
     ],
     "cost": {
       "value": 2
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Rebel Alliance"
+        ]
+      },
+      {
+        "chassis": [
+          "attackshuttle",
+          "sheathipedeclassshuttle"
+        ]
+      }
+    ]
   },
   {
     "name": "Punishing One",
@@ -371,7 +529,19 @@
     ],
     "cost": {
       "value": 8
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      },
+      {
+        "chassis": [
+          "jumpmaster5000"
+        ]
+      }
+    ]
   },
   {
     "name": "ST-321",
@@ -389,7 +559,19 @@
     ],
     "cost": {
       "value": 6
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Galactic Empire"
+        ]
+      },
+      {
+        "chassis": [
+          "lambdaclasst4ashuttle"
+        ]
+      }
+    ]
   },
   {
     "name": "Shadow Caster",
@@ -407,7 +589,19 @@
     ],
     "cost": {
       "value": 6
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      },
+      {
+        "chassis": [
+          "lancerclasspursuitcraft"
+        ]
+      }
+    ]
   },
   {
     "name": "Slave I",
@@ -432,7 +626,19 @@
     ],
     "cost": {
       "value": 5
-    }
+    },
+    "restrictions": [
+      {
+        "factions": [
+          "Scum and Villainy"
+        ]
+      },
+      {
+        "chassis": [
+          "firesprayclasspatrolcraft"
+        ]
+      }
+    ]
   },
   {
     "name": "Virago",
@@ -466,6 +672,13 @@
     ],
     "cost": {
       "value": 10
-    }
+    },
+    "restrictions": [
+      {
+        "chassis": [
+          "starviperclassattackplatform"
+        ]
+      }
+    ]
   }
 ]

--- a/data/upgrades/title.json
+++ b/data/upgrades/title.json
@@ -44,7 +44,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "firesprayclasspatrolcraft"
         ]
       }
@@ -102,7 +102,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "vt49decimator"
         ]
       }
@@ -132,7 +132,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "vcx100lightfreighter"
         ]
       }
@@ -179,7 +179,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "scurrgh6bomber"
         ]
       }
@@ -209,7 +209,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "yv666lightfreighter"
         ]
       }
@@ -239,7 +239,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "aggressorassaultfighter"
         ]
       }
@@ -269,7 +269,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "customizedyt1300lightfreighter"
         ]
       }
@@ -306,7 +306,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "firesprayclasspatrolcraft"
         ]
       }
@@ -352,7 +352,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "modifiedyt1300lightfreighter"
         ]
       }
@@ -403,7 +403,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "g1astarfighter"
         ]
       }
@@ -434,7 +434,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "hwk290lightfreighter"
         ]
       }
@@ -464,7 +464,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "yt2400lightfreighter"
         ]
       }
@@ -494,7 +494,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "attackshuttle",
           "sheathipedeclassshuttle"
         ]
@@ -537,7 +537,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "jumpmaster5000"
         ]
       }
@@ -567,7 +567,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "lambdaclasst4ashuttle"
         ]
       }
@@ -597,7 +597,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "lancerclasspursuitcraft"
         ]
       }
@@ -634,7 +634,7 @@
         ]
       },
       {
-        "chassis": [
+        "ships": [
           "firesprayclasspatrolcraft"
         ]
       }
@@ -675,7 +675,7 @@
     },
     "restrictions": [
       {
-        "chassis": [
+        "ships": [
           "starviperclassattackplatform"
         ]
       }


### PR DESCRIPTION
This builds on top of the excellent work @andrelind did in https://github.com/guidokessels/xwing-data2/pull/24.

I changed the following from that PR:
- Resolved merge conflicts with latest `master`
- Renamed `chassis` restriction to `ships`
- Renamed `characters` restriction to `names` so we can re-use this if FFG decides to reference non-character cards
- Used full card names instead of XWS ids in `names` restriction. As FFG is using card names in their restriction I think we should follow that instead of writing a list of XWS ids