### PR TITLE
Some minor typos for Galactic Empire ships and moved an alt card to different parent

### DIFF
--- a/data/pilots/galactic-empire/tie-advanced-x1.json
+++ b/data/pilots/galactic-empire/tie-advanced-x1.json
@@ -98,7 +98,7 @@
       "limited": 0,
       "cost": 43,
       "xws": "stormsquadronace",
-      "text": "The TIE Advanced x1 was produced in limited quantities, but Sienar engineers incorporated many of its best qualities into their next TIE model, the TIE Interceptor.",
+      "text": "The TIE Advanced x1 was produced in limited quantities, but Sienar engineers incorporated many of its best qualities into their next TIE model: the TIE Interceptor.",
       "image": "https://i.imgur.com/ZPCZxyz.png",
       "shipAbility": {
         "name": "Advanced Targeting Computer",

--- a/data/pilots/galactic-empire/tie-ln-fighter.json
+++ b/data/pilots/galactic-empire/tie-ln-fighter.json
@@ -78,13 +78,7 @@
       "cost": 26,
       "xws": "nightbeast",
       "ability": "After you fully execute a blue maneuver, you may perform a [Focus] action.",
-      "image": "https://i.imgur.com/FbwsflC.png",
-      "alt": [
-        {
-          "image": "https://images-cdn.fantasyflightgames.com/filer_public/12/55/12552f53-decc-49ff-8fe2-e4285d4ff31e/op066-obsidian-squadron-pilot.png",
-          "source": "X-Wing Second Edition Launch Party"
-        }
-      ]
+      "image": "https://i.imgur.com/FbwsflC.png"
     },
     {
       "name": "\"Scourge\" Skutu",
@@ -175,7 +169,13 @@
       "cost": 24,
       "xws": "obsidiansquadronpilot",
       "text": "The TIE fighter's Twin Ion Engine system was designed for speed, making the TIE/ln one of the most maneuverable starships ever mass-produced.",
-      "image": "https://i.imgur.com/DDeq1x3.jpg"
+      "image": "https://i.imgur.com/DDeq1x3.jpg",
+      "alt": [
+        {
+          "image": "https://images-cdn.fantasyflightgames.com/filer_public/12/55/12552f53-decc-49ff-8fe2-e4285d4ff31e/op066-obsidian-squadron-pilot.png",
+          "source": "X-Wing Second Edition Launch Party"
+        }
+      ]
     },
     {
       "name": "Seyn Marana",

--- a/data/pilots/galactic-empire/tie-reaper.json
+++ b/data/pilots/galactic-empire/tie-reaper.json
@@ -79,7 +79,7 @@
       "limited": 1,
       "cost": 47,
       "xws": "captainferoph",
-      "ability": "While you defend, if the attacker does not have any green tokens, you may change 1 of your blank or [Focus] results to an [Evade] result.",
+      "ability": "While you defend, if the attacker does not have any green tokens, you may change 1 of your [Focus]/blank results to an [Evade] result.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/9c/e9/9ce9dedf-8f3f-482e-bcbb-d105e5c78682/swx75_card2_captain-feroph.png",
       "shipAbility": {
         "name": "Adaptive Ailerons",
@@ -93,7 +93,7 @@
       "limited": 1,
       "cost": 49,
       "xws": "majorvermeil",
-      "ability": "While you perform an attack, if the defender does not have any green tokens, you may change 1 of your blank or [Focus] results to a [Hit] result.",
+      "ability": "While you perform an attack, if the defender does not have any green tokens, you may change 1 of your [Focus]/blank results to a [Hit] result.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/a7/29/a729992e-5e68-46e8-93d7-33f1220aed9d/swx75_card2_major-vermeil.png",
       "shipAbility": {
         "name": "Adaptive Ailerons",


### PR DESCRIPTION
In change `ef79bef` I reparented the alt version of `Obsidian Squadron Pilot` from `Night Beast` to the regular `Obsidian Squadron Pilot`.

In change `7f15556` I made some very minor typo fixes to exactly match the text on the actual cards.