### PR TITLE
Minor fixes for some Scum and Villainy ships

### DIFF
--- a/data/pilots/scum-and-villainy/fang-fighter.json
+++ b/data/pilots/scum-and-villainy/fang-fighter.json
@@ -51,15 +51,15 @@
         "difficulty": "Red",
         "type": "Focus"
       },
-      "type": "Boost"
+      "type": "Barrel Roll"
     },
-    {
+	{
       "difficulty": "White",
       "linked": {
         "difficulty": "Red",
         "type": "Focus"
       },
-      "type": "Barrel Roll"
+      "type": "Boost"
     }
   ],
   "pilots": [

--- a/data/pilots/scum-and-villainy/g-1a-starfighter.json
+++ b/data/pilots/scum-and-villainy/g-1a-starfighter.json
@@ -71,7 +71,7 @@
       "limited": 0,
       "cost": 43,
       "xws": "gandfindsman",
-      "text": "The legendary Findsmen of Gand worship enshrouding mists of their home planet, using signs, augurs, and mystical rituals to track their quarry.",
+      "text": "The legendary Findsmen of Gand worship the enshrouding mists of their home planet, using signs, augurs, and mystical rituals to track their quarry.",
       "image": "https://i.imgur.com/yYVXjCS.png",
       "shipActions": [
         {

--- a/data/pilots/scum-and-villainy/jumpmaster-5000.json
+++ b/data/pilots/scum-and-villainy/jumpmaster-5000.json
@@ -102,7 +102,7 @@
       "limited": 1,
       "cost": 60,
       "xws": "teltrevura",
-      "ability": "If you would be destroyed, you may spend 1 [Charge]. If you do, discard all of your damage cards, suffer 5 [Hit] damage, and place yourself in reserves instead. At the start of the next planning phase, place yourself within range 1 of your player edge.",
+      "ability": "If you would be destroyed, you may spend 1 [Charge]. If you do, discard all of your damage cards, suffer 5 [Hit] damage, and place yourself in reserves instead. At the start of the next Planning Phase, place yourself within range 1 of your player edge.",
       "image": "https://i.imgur.com/FeUMuVx.jpg",
       "charges": {
         "value": 1,

--- a/data/pilots/scum-and-villainy/quadrijet-transfer-spacetug.json
+++ b/data/pilots/scum-and-villainy/quadrijet-transfer-spacetug.json
@@ -63,7 +63,7 @@
       "image": "https://i.imgur.com/7a7O9wm.jpg",
       "shipAbility": {
         "name": "Spacetug Tractor Array",
-        "text": "Action: Choose a ship in your [Front Arc] at tange 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in you [Bullseye Arc] at range 1."
+        "text": "Action: Choose a ship in your [Front Arc] at range 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in you [Bullseye Arc] at range 1."
       }
     },
     {
@@ -76,7 +76,7 @@
       "image": "https://i.imgur.com/HT0F6Yv.png",
       "shipAbility": {
         "name": "Spacetug Tractor Array",
-        "text": "Action: Choose a ship in your [Front Arc] at tange 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in you [Bullseye Arc] at range 1."
+        "text": "Action: Choose a ship in your [Front Arc] at range 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in you [Bullseye Arc] at range 1."
       }
     },
     {
@@ -90,7 +90,7 @@
       "image": "https://i.imgur.com/vCOYuiJ.jpg",
       "shipAbility": {
         "name": "Spacetug Tractor Array",
-        "text": "Action: Choose a ship in your [Front Arc] at tange 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in you [Bullseye Arc] at range 1."
+        "text": "Action: Choose a ship in your [Front Arc] at range 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in you [Bullseye Arc] at range 1."
       }
     },
     {
@@ -104,7 +104,7 @@
       "image": "https://i.imgur.com/VCf87Ha.png",
       "shipAbility": {
         "name": "Spacetug Tractor Array",
-        "text": "Action: Choose a ship in your [Front Arc] at tange 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in you [Bullseye Arc] at range 1."
+        "text": "Action: Choose a ship in your [Front Arc] at range 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in you [Bullseye Arc] at range 1."
       }
     }
   ]

--- a/data/pilots/scum-and-villainy/yv-666-light-freighter.json
+++ b/data/pilots/scum-and-villainy/yv-666-light-freighter.json
@@ -80,7 +80,7 @@
       "limited": 1,
       "cost": 72,
       "xws": "moraloeval",
-      "ability": "If you would flee, you may spend 1 [Charge]. If you do, place yourself in reserves instead. At the start of the next Planning Phase, place youself within range 1 of the edge of the play area that you fled from.",
+      "ability": "If you would flee, you may spend 1 [Charge]. If you do, place yourself in reserves instead. At the start of the next Planning Phase, place yourself within range 1 of the edge of the play area that you fled from.",
       "image": "https://i.imgur.com/kn89diB.png",
       "charges": {
         "value": 2,


### PR DESCRIPTION
`fc797e2` changes the order of actions for the Fang Fighter so that it matches the card exactly (first Barrel Roll > Focus, then Boost > Focus, rather than the other way around).

`f700737` fixes some typos and other minor differences between the data and the actual card text.