### PR TITLE
Even more minor typos fixed

### DIFF
--- a/data/conditions/conditions.json
+++ b/data/conditions/conditions.json
@@ -11,7 +11,7 @@
   },
   {
     "name": "Optimized Prototype",
-    "ability": "While you perform a [Front Arc] primary attack against a ship locked by a friendly ship with the Director Krennic upgrade, you may spend 1 [Hit], [Critical Hit], or [Focus] result. If you do, choose one: the defender loses 1 shield, or the defender flips 1 of its facedown damage cards.",
+    "ability": "While you perform a [Front Arc] primary attack against a ship locked by a friendly ship with the Director Krennic upgrade, you may spend 1 [Hit]/[Critical Hit]/[Focus] result. If you do, choose one: the defender loses 1 shield, or the defender flips 1 of its facedown damage cards.",
     "xws": "optimizedprototype",
     "image": "https://images-cdn.fantasyflightgames.com/filer_public/0d/94/0d94dd35-08eb-493c-b4bd-c077be0e2292/swx75_card2_optimized-prototype.png"
   },

--- a/data/upgrades/gunner.json
+++ b/data/upgrades/gunner.json
@@ -78,7 +78,7 @@
       {
         "title": "Bossk",
         "type": "Gunner",
-        "ability": "After you perform a primary attack that misses, if you are not stressedm you must receive 1 stress token to perform a bonus primary attack against the same target.",
+        "ability": "After you perform a primary attack that misses, if you are not stressed, you must receive 1 stress token to perform a bonus primary attack against the same target.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/b0/67/b0671bc7-1508-4cd2-b54c-e9b797bad57c/swz08-bossk-gunner.png",
         "slots": [
           "Gunner"

--- a/data/upgrades/modification.json
+++ b/data/upgrades/modification.json
@@ -259,7 +259,7 @@
       {
         "title": "Stealth Device",
         "type": "Modification",
-        "ability": "While you defend, if your [Charge] is active, roll 1 additional defense die. After you suffer damage, lost 1 [Charge].",
+        "ability": "While you defend, if your [Charge] is active, roll 1 additional defense die. After you suffer damage, lose 1 [Charge].",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/8c/a1/8ca15a1e-3864-4245-8418-416030ac57ab/swz14_stealth-device.png",
         "slots": [
           "Modification"

--- a/data/upgrades/talent.json
+++ b/data/upgrades/talent.json
@@ -55,7 +55,7 @@
       {
         "title": "Daredevil",
         "type": "Talent",
-        "ability": "While you perform a while [Boost] action, you may treat it as red to use the [1[Turn Left]] or [1 [Turn Right]] template instead.",
+        "ability": "While you perform a white [Boost] action, you may treat it as red to use the [1 [Turn Left]] or [1 [Turn Right]] template instead.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/55/65/55659ceb-e6e7-475b-aabd-1791e9854f3b/swz17_daredevil.png",
         "slots": [
           "Talent"


### PR DESCRIPTION
`f76768d` - fixed minor typos on some Upgrade cards.
`d521ca7` - updated the text to exactly match the card (`1 [Hit]/[Critical Hit]/[Focus]` instead of `1 [Hit], [Critical Hit], or [Focus]`).