### PR TITLE
Updated upgrades from FFG squadbuilder

### DIFF
--- a/data/upgrades/astromech.json
+++ b/data/upgrades/astromech.json
@@ -9,21 +9,14 @@
         "type": "Astromech",
         "ability": "Action: Spend 1 non-recurring [Charge] from another equipped upgrade to recover 1 shield. Action: Spend 2 shields to recover 1 non-recurring [Charge] on an equipped upgrade.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/5d/1a/5d1a60e4-50f6-40fc-9711-4c4f4513eea9/swz06-chopper-astromech.png",
-        "slots": [
-          "Astromech"
-        ]
+        "slots": ["Astromech"]
       }
     ],
-    "cost": {
-      "value": 2
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 2 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
+    "ffg_id": "XW_U_99"
   },
   {
     "name": "\"Genius\"",
@@ -35,21 +28,14 @@
         "type": "Astromech",
         "ability": "After you fully execute a maneuver, if you have not dropped or launched a device this round, you may drop 1 bomb.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/8a/29/8a29bc40-8dc9-4f5d-86ce-316c0fbde972/swz08-genius.png",
-        "slots": [
-          "Astromech"
-        ]
+        "slots": ["Astromech"]
       }
     ],
-    "cost": {
-      "value": 0
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 0 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
+    "ffg_id": "XW_U_143"
   },
   {
     "name": "R2 Astromech",
@@ -60,18 +46,14 @@
         "title": "R2 Astromech",
         "type": "Astromech",
         "ability": "After you reveal your dial, you may spend 1 [Charge] and gain 1 disarm token to recover 1 shield.",
-        "slots": [
-          "Astromech"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        }
+        "slots": ["Astromech"],
+        "charges": { "value": 2, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 6
-    }
+    "cost": { "value": 6 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
+    "ffg_id": "XW_U_53"
   },
   {
     "name": "R2-D2",
@@ -83,25 +65,15 @@
         "type": "Astromech",
         "ability": "After you reveal your dial, you may spend 1 [Charge] and gain 1 disarm token to recover 1 shield.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/59/35/5935e6ec-474f-41d1-8236-9846ffa0d4b3/swz01-r2-d2-astromech.png",
-        "slots": [
-          "Astromech"
-        ],
-        "charges": {
-          "value": 3,
-          "recovers": 0
-        }
+        "slots": ["Astromech"],
+        "charges": { "value": 3, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 8
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 8 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_100.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_100.jpg",
+    "ffg_id": "XW_U_100"
   },
   {
     "name": "R3 Astromech",
@@ -113,14 +85,13 @@
         "type": "Astromech",
         "ability": "You can maintain up to 2 locks. Each lock must be on a different object. After you perform a [Lock] action, you may acquire a lock.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/d4/e8/d4e80f3e-cffc-4c4f-be2f-09af994f46c8/swz01_a5_r3-astromech.png",
-        "slots": [
-          "Astromech"
-        ]
+        "slots": ["Astromech"]
       }
     ],
-    "cost": {
-      "value": 3
-    }
+    "cost": { "value": 3 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_54.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_54.jpg",
+    "ffg_id": "XW_U_54"
   },
   {
     "name": "R4 Astromech",
@@ -132,21 +103,14 @@
         "type": "Astromech",
         "ability": "Decrease the difficulty of your speed 1-2 basic maneuvers ([Turn Left], [Bank Left], [Straight], [Bank Right], [Turn Right]).",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/cd/e5/cde5227e-ab1a-4031-a083-b17f48e3f84f/swz12_card_r4-astromech.png",
-        "slots": [
-          "Astromech"
-        ]
+        "slots": ["Astromech"]
       }
     ],
-    "cost": {
-      "value": 2
-    },
-    "restrictions": [
-      {
-        "sizes": [
-          "Small"
-        ]
-      }
-    ]
+    "cost": { "value": 2 },
+    "restrictions": [{ "sizes": ["Small"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_55.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_55.jpg",
+    "ffg_id": "XW_U_55"
   },
   {
     "name": "R5 Astromech",
@@ -157,18 +121,14 @@
         "title": "R5 Astromech",
         "type": "Astromech",
         "ability": "Action: Spend 1 [Charge] to repair 1 facedown damage card. Action: Repair 1 faceup Ship damage card.",
-        "slots": [
-          "Astromech"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        }
+        "slots": ["Astromech"],
+        "charges": { "value": 2, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 5
-    }
+    "cost": { "value": 5 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_56.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_56.jpg",
+    "ffg_id": "XW_U_56"
   },
   {
     "name": "R5-D8",
@@ -180,25 +140,15 @@
         "type": "Astromech",
         "ability": "Action: Spend 1 [Charge] to repair 1 facedown damage card. Action: Repair 1 faceup Ship damage card.",
         "images": "https://vignette.wikia.nocookie.net/xwing-miniatures-second-edition/images/6/6e/R5-D8.png",
-        "slots": [
-          "Astromech"
-        ],
-        "charges": {
-          "value": 3,
-          "recovers": 0
-        }
+        "slots": ["Astromech"],
+        "charges": { "value": 3, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 7
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 7 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_101.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_101.jpg",
+    "ffg_id": "XW_U_101"
   },
   {
     "name": "R5-P8",
@@ -210,25 +160,15 @@
         "type": "Astromech",
         "ability": "While you perform an attack against a defender in your [Front Arc], you may spend 1 [Charge] to reroll 1 attack die. If the rerolled result is a [Critical Hit], suffer 1 [Critical Hit] damage.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/db/b4/dbb4df75-43f6-4e1d-9860-b201db515f01/swz08-r5-p8.png",
-        "slots": [
-          "Astromech"
-        ],
-        "charges": {
-          "value": 3,
-          "recovers": 0
-        }
+        "slots": ["Astromech"],
+        "charges": { "value": 3, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 4
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+    "ffg_id": "XW_U_144"
   },
   {
     "name": "R5-TK",
@@ -240,20 +180,13 @@
         "type": "Astromech",
         "ability": "You can perform attacks against friendly ships.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/02/cf/02cf9d84-dbd1-46d4-ae8d-8ac6da7a717c/swz08-r5-tk.png",
-        "slots": [
-          "Astromech"
-        ]
+        "slots": ["Astromech"]
       }
     ],
-    "cost": {
-      "value": 1
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 1 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
+    "ffg_id": "XW_U_145"
   }
 ]

--- a/data/upgrades/astromech.json
+++ b/data/upgrades/astromech.json
@@ -9,13 +9,13 @@
         "type": "Astromech",
         "ability": "Action: Spend 1 non-recurring [Charge] from another equipped upgrade to recover 1 shield. Action: Spend 2 shields to recover 1 non-recurring [Charge] on an equipped upgrade.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/5d/1a/5d1a60e4-50f6-40fc-9711-4c4f4513eea9/swz06-chopper-astromech.png",
-        "slots": ["Astromech"]
+        "slots": ["Astromech"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg"
       }
     ],
     "cost": { "value": 2 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
     "ffg_id": "XW_U_99"
   },
   {
@@ -27,14 +27,13 @@
         "title": "\"Genius\"",
         "type": "Astromech",
         "ability": "After you fully execute a maneuver, if you have not dropped or launched a device this round, you may drop 1 bomb.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/8a/29/8a29bc40-8dc9-4f5d-86ce-316c0fbde972/swz08-genius.png",
-        "slots": ["Astromech"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
+        "slots": ["Astromech"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg"
       }
     ],
     "cost": { "value": 0 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
     "ffg_id": "XW_U_143"
   },
   {
@@ -47,12 +46,12 @@
         "type": "Astromech",
         "ability": "After you reveal your dial, you may spend 1 [Charge] and gain 1 disarm token to recover 1 shield.",
         "slots": ["Astromech"],
-        "charges": { "value": 2, "recovers": 0 }
+        "charges": { "value": 2, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg"
       }
     ],
     "cost": { "value": 6 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
     "ffg_id": "XW_U_53"
   },
   {
@@ -64,15 +63,14 @@
         "title": "R2-D2",
         "type": "Astromech",
         "ability": "After you reveal your dial, you may spend 1 [Charge] and gain 1 disarm token to recover 1 shield.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/59/35/5935e6ec-474f-41d1-8236-9846ffa0d4b3/swz01-r2-d2-astromech.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_100.png",
         "slots": ["Astromech"],
-        "charges": { "value": 3, "recovers": 0 }
+        "charges": { "value": 3, "recovers": 0 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_100.jpg"
       }
     ],
     "cost": { "value": 8 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_100.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_100.jpg",
     "ffg_id": "XW_U_100"
   },
   {
@@ -85,12 +83,12 @@
         "type": "Astromech",
         "ability": "You can maintain up to 2 locks. Each lock must be on a different object. After you perform a [Lock] action, you may acquire a lock.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/d4/e8/d4e80f3e-cffc-4c4f-be2f-09af994f46c8/swz01_a5_r3-astromech.png",
-        "slots": ["Astromech"]
+        "slots": ["Astromech"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_54.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_54.jpg"
       }
     ],
     "cost": { "value": 3 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_54.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_54.jpg",
     "ffg_id": "XW_U_54"
   },
   {
@@ -103,13 +101,13 @@
         "type": "Astromech",
         "ability": "Decrease the difficulty of your speed 1-2 basic maneuvers ([Turn Left], [Bank Left], [Straight], [Bank Right], [Turn Right]).",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/cd/e5/cde5227e-ab1a-4031-a083-b17f48e3f84f/swz12_card_r4-astromech.png",
-        "slots": ["Astromech"]
+        "slots": ["Astromech"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_55.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_55.jpg"
       }
     ],
     "cost": { "value": 2 },
     "restrictions": [{ "sizes": ["Small"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_55.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_55.jpg",
     "ffg_id": "XW_U_55"
   },
   {
@@ -122,12 +120,12 @@
         "type": "Astromech",
         "ability": "Action: Spend 1 [Charge] to repair 1 facedown damage card. Action: Repair 1 faceup Ship damage card.",
         "slots": ["Astromech"],
-        "charges": { "value": 2, "recovers": 0 }
+        "charges": { "value": 2, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_56.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_56.jpg"
       }
     ],
     "cost": { "value": 5 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_56.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_56.jpg",
     "ffg_id": "XW_U_56"
   },
   {
@@ -141,13 +139,13 @@
         "ability": "Action: Spend 1 [Charge] to repair 1 facedown damage card. Action: Repair 1 faceup Ship damage card.",
         "images": "https://vignette.wikia.nocookie.net/xwing-miniatures-second-edition/images/6/6e/R5-D8.png",
         "slots": ["Astromech"],
-        "charges": { "value": 3, "recovers": 0 }
+        "charges": { "value": 3, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_101.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_101.jpg"
       }
     ],
     "cost": { "value": 7 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_101.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_101.jpg",
     "ffg_id": "XW_U_101"
   },
   {
@@ -159,15 +157,14 @@
         "title": "R5-P8",
         "type": "Astromech",
         "ability": "While you perform an attack against a defender in your [Front Arc], you may spend 1 [Charge] to reroll 1 attack die. If the rerolled result is a [Critical Hit], suffer 1 [Critical Hit] damage.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/db/b4/dbb4df75-43f6-4e1d-9860-b201db515f01/swz08-r5-p8.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
         "slots": ["Astromech"],
-        "charges": { "value": 3, "recovers": 0 }
+        "charges": { "value": 3, "recovers": 0 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg"
       }
     ],
     "cost": { "value": 4 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
     "ffg_id": "XW_U_144"
   },
   {
@@ -179,14 +176,13 @@
         "title": "R5-TK",
         "type": "Astromech",
         "ability": "You can perform attacks against friendly ships.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/02/cf/02cf9d84-dbd1-46d4-ae8d-8ac6da7a717c/swz08-r5-tk.png",
-        "slots": ["Astromech"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
+        "slots": ["Astromech"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg"
       }
     ],
     "cost": { "value": 1 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
     "ffg_id": "XW_U_145"
   }
 ]

--- a/data/upgrades/cannon.json
+++ b/data/upgrades/cannon.json
@@ -16,12 +16,12 @@
           "minrange": 2,
           "maxrange": 3,
           "ordnance": false
-        }
+        },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_27.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_27.jpg"
       }
     ],
     "cost": { "value": 4 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_27.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_27.jpg",
     "ffg_id": "XW_U_27"
   },
   {
@@ -40,12 +40,12 @@
           "minrange": 1,
           "maxrange": 3,
           "ordnance": false
-        }
+        },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg"
       }
     ],
     "cost": { "value": 5 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
     "ffg_id": "XW_U_28"
   },
   {
@@ -64,12 +64,12 @@
           "minrange": 1,
           "maxrange": 2,
           "ordnance": false
-        }
+        },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_29.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_29.jpg"
       }
     ],
     "cost": { "value": 2 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_29.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_29.jpg",
     "ffg_id": "XW_U_29"
   },
   {
@@ -89,12 +89,11 @@
           "maxrange": 3,
           "ordnance": false
         },
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/ea/9c/ea9c60d3-b915-40cd-8d8d-7b0b96fa2fe3/swz08-tractor-beam.png"
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_30.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_30.jpg"
       }
     ],
     "cost": { "value": 3 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_30.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_30.jpg",
     "ffg_id": "XW_U_30"
   }
 ]

--- a/data/upgrades/cannon.json
+++ b/data/upgrades/cannon.json
@@ -9,9 +9,7 @@
         "type": "Cannon",
         "ability": "Attack: After the Modify Attack Dice step, change all [Critical Hit] results to [Hit] results.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/c0/10/c0102569-7d6d-4aeb-b5e1-82ea2947be03/swz16_heavy-laser-cannon.png",
-        "slots": [
-          "Cannon"
-        ],
+        "slots": ["Cannon"],
         "attack": {
           "arc": "Bullseye Arc",
           "value": 4,
@@ -21,9 +19,10 @@
         }
       }
     ],
-    "cost": {
-      "value": 4
-    }
+    "cost": { "value": 4 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_27.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_27.jpg",
+    "ffg_id": "XW_U_27"
   },
   {
     "name": "Ion Cannon",
@@ -34,9 +33,7 @@
         "title": "Ion Cannon",
         "type": "Cannon",
         "ability": "Attack: If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
-        "slots": [
-          "Cannon"
-        ],
+        "slots": ["Cannon"],
         "attack": {
           "arc": "Front Arc",
           "value": 3,
@@ -46,9 +43,10 @@
         }
       }
     ],
-    "cost": {
-      "value": 5
-    }
+    "cost": { "value": 5 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
+    "ffg_id": "XW_U_28"
   },
   {
     "name": "Jamming Beam",
@@ -59,9 +57,7 @@
         "title": "Jamming Beam",
         "type": "Cannon",
         "ability": "Attack: If this attack hits, all [Hit]/[Critical Hit] results inflict jam tokens instead of damage.",
-        "slots": [
-          "Cannon"
-        ],
+        "slots": ["Cannon"],
         "attack": {
           "arc": "Front Arc",
           "value": 3,
@@ -71,9 +67,10 @@
         }
       }
     ],
-    "cost": {
-      "value": 2
-    }
+    "cost": { "value": 2 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_29.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_29.jpg",
+    "ffg_id": "XW_U_29"
   },
   {
     "name": "Tractor Beam",
@@ -84,9 +81,7 @@
         "title": "Tractor Beam",
         "type": "Cannon",
         "ability": "Attack: If this attack hits, all [Hit]/[Critical Hit] results inflict tractor tokens instead of damage.",
-        "slots": [
-          "Cannon"
-        ],
+        "slots": ["Cannon"],
         "attack": {
           "arc": "Front Arc",
           "value": 3,
@@ -97,8 +92,9 @@
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/ea/9c/ea9c60d3-b915-40cd-8d8d-7b0b96fa2fe3/swz08-tractor-beam.png"
       }
     ],
-    "cost": {
-      "value": 3
-    }
+    "cost": { "value": 3 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_30.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_30.jpg",
+    "ffg_id": "XW_U_30"
   }
 ]

--- a/data/upgrades/configuration.json
+++ b/data/upgrades/configuration.json
@@ -8,22 +8,16 @@
         "title": "Integrated S-foils (Closed)",
         "type": "Configuration",
         "ability": "???",
-        "slots": [
-          "Configuration"
-        ]
+        "slots": ["Configuration"]
       },
       {
         "title": "Integrated S-foils (Open)",
         "type": "Configuration",
         "ability": "???",
-        "slots": [
-          "Configuration"
-        ]
+        "slots": ["Configuration"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Os-1 Arsenal Loadout",
@@ -34,33 +28,18 @@
         "title": "Os-1 Arsenal Loadout",
         "type": "Configuration",
         "ability": "While you have exactly 1 disarm token, you can still perform [Torpedo] and [Missile] attacks against targets you have locked. If you do, you cannot spend your lock during the attack. Add [Torpedo] and [Missile] slots.",
-        "slots": [
-          "Configuration"
-        ],
+        "slots": ["Configuration"],
         "grants": [
-          {
-            "type": "slot",
-            "value": "Torpedo",
-            "amount": 1
-          },
-          {
-            "type": "slot",
-            "value": "Missile",
-            "amount": 1
-          }
+          { "type": "slot", "value": "Torpedo", "amount": 1 },
+          { "type": "slot", "value": "Missile", "amount": 1 }
         ]
       }
     ],
-    "cost": {
-      "value": 0
-    },
-    "restrictions": [
-      {
-        "ships": [
-          "alphaclassstarwing"
-        ]
-      }
-    ]
+    "cost": { "value": 0 },
+    "restrictions": [{ "ships": ["alphaclassstarwing"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
+    "ffg_id": "XW_U_125"
   },
   {
     "name": "Pivot Wing",
@@ -72,30 +51,21 @@
         "type": "Configuration",
         "ability": "While you defend, roll 1 fewer defense die. After you execute a [0 [Stationary]] maneuver, you may rotate your ship 90˚ or 180˚. Before you activate, you may flip this card.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/40/f9/40f99994-5834-4865-9dce-48372baa164e/swz01_a3_pivot-closed.png",
-        "slots": [
-          "Configuration"
-        ]
+        "slots": ["Configuration"]
       },
       {
         "title": "Pivot Wing (Open)",
         "type": "Configuration",
         "ability": "Before you activate, you may flip this card.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/66/e9/66e9bcba-36fd-480e-be7c-17c7b93afa5e/swz01_a3_pivot-open.png",
-        "slots": [
-          "Configuration"
-        ]
+        "slots": ["Configuration"]
       }
     ],
-    "cost": {
-      "value": 0
-    },
-    "restrictions": [
-      {
-        "ships": [
-          "ut60duwing"
-        ]
-      }
-    ]
+    "cost": { "value": 0 },
+    "restrictions": [{ "ships": ["ut60duwing"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107b.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107b.jpg",
+    "ffg_id": "XW_U_107b"
   },
   {
     "name": "Servomotor S-foils",
@@ -107,40 +77,26 @@
         "type": "Configuration",
         "ability": "While you perform a primary attack, roll 1 fewer attack die. Before you activate, you may flip this card.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/40/ac/40ac4929-f664-4b0d-a983-8d78f6e1d65c/swz01_a3_servomotor-closed.png",
-        "slots": [
-          "Configuration"
-        ],
+        "slots": ["Configuration"],
         "actions": [
-          {
-            "type": "Boost",
-            "difficulty": "White"
-          },
+          { "type": "Boost", "difficulty": "White" },
           {
             "type": "Focus",
             "difficulty": "White",
-            "linked": {
-              "difficulty": "Red",
-              "type": "Boost"
-            }
+            "linked": { "difficulty": "Red", "type": "Boost" }
           }
         ],
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Boost",
-              "difficulty": "White"
-            }
+            "value": { "type": "Boost", "difficulty": "White" }
           },
           {
             "type": "action",
             "value": {
               "type": "Focus",
               "difficulty": "White",
-              "linked": {
-                "type": "Boost",
-                "difficulty": "Red"
-              }
+              "linked": { "type": "Boost", "difficulty": "Red" }
             }
           }
         ]
@@ -150,21 +106,14 @@
         "type": "Configuration",
         "ability": "Before you activate, you may flip this card.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/95/ab/95abfa8d-125b-42b9-ba92-7763240eca7f/swz01_a3_servomotor-open.png",
-        "slots": [
-          "Configuration"
-        ]
+        "slots": ["Configuration"]
       }
     ],
-    "cost": {
-      "value": 0
-    },
-    "restrictions": [
-      {
-        "ships": [
-          "t65xwing"
-        ]
-      }
-    ]
+    "cost": { "value": 0 },
+    "restrictions": [{ "ships": ["t65xwing"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+    "ffg_id": "XW_U_108"
   },
   {
     "name": "Xg-1 Assault Configuration",
@@ -175,27 +124,14 @@
         "title": "Xg-1 Assault Configuration",
         "type": "Configuration",
         "ability": "While you have exactly 1 disarm token, uou can still perform [Cannon] attacks. While you perform a [Cannon] attack while disarmed, roll a maximum of 3 attack dice. Add [Cannon] slot.",
-        "slots": [
-          "Configuration"
-        ],
-        "grants": [
-          {
-            "type": "slot",
-            "value": "Cannon",
-            "amount": 1
-          }
-        ]
+        "slots": ["Configuration"],
+        "grants": [{ "type": "slot", "value": "Cannon", "amount": 1 }]
       }
     ],
-    "cost": {
-      "value": 0
-    },
-    "restrictions": [
-      {
-        "ships": [
-          "alphaclassstarwing"
-        ]
-      }
-    ]
+    "cost": { "value": 0 },
+    "restrictions": [{ "ships": ["alphaclassstarwing"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_126.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_126.jpg",
+    "ffg_id": "XW_U_126"
   }
 ]

--- a/data/upgrades/configuration.json
+++ b/data/upgrades/configuration.json
@@ -32,13 +32,13 @@
         "grants": [
           { "type": "slot", "value": "Torpedo", "amount": 1 },
           { "type": "slot", "value": "Missile", "amount": 1 }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg"
       }
     ],
     "cost": { "value": 0 },
     "restrictions": [{ "ships": ["alphaclassstarwing"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
     "ffg_id": "XW_U_125"
   },
   {
@@ -51,20 +51,22 @@
         "type": "Configuration",
         "ability": "While you defend, roll 1 fewer defense die. After you execute a [0 [Stationary]] maneuver, you may rotate your ship 90˚ or 180˚. Before you activate, you may flip this card.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/40/f9/40f99994-5834-4865-9dce-48372baa164e/swz01_a3_pivot-closed.png",
-        "slots": ["Configuration"]
+        "slots": ["Configuration"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107b.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107b.jpg"
       },
       {
         "title": "Pivot Wing (Open)",
         "type": "Configuration",
         "ability": "Before you activate, you may flip this card.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/66/e9/66e9bcba-36fd-480e-be7c-17c7b93afa5e/swz01_a3_pivot-open.png",
-        "slots": ["Configuration"]
+        "slots": ["Configuration"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg"
       }
     ],
     "cost": { "value": 0 },
     "restrictions": [{ "ships": ["ut60duwing"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107b.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107b.jpg",
     "ffg_id": "XW_U_107b"
   },
   {
@@ -99,21 +101,23 @@
               "linked": { "type": "Boost", "difficulty": "Red" }
             }
           }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108b.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108b.jpg"
       },
       {
         "title": "Servomotor S-foils (Open)",
         "type": "Configuration",
         "ability": "Before you activate, you may flip this card.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/95/ab/95abfa8d-125b-42b9-ba92-7763240eca7f/swz01_a3_servomotor-open.png",
-        "slots": ["Configuration"]
+        "slots": ["Configuration"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg"
       }
     ],
     "cost": { "value": 0 },
     "restrictions": [{ "ships": ["t65xwing"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
-    "ffg_id": "XW_U_108"
+    "ffg_id": "XW_U_108b"
   },
   {
     "name": "Xg-1 Assault Configuration",
@@ -125,13 +129,13 @@
         "type": "Configuration",
         "ability": "While you have exactly 1 disarm token, uou can still perform [Cannon] attacks. While you perform a [Cannon] attack while disarmed, roll a maximum of 3 attack dice. Add [Cannon] slot.",
         "slots": ["Configuration"],
-        "grants": [{ "type": "slot", "value": "Cannon", "amount": 1 }]
+        "grants": [{ "type": "slot", "value": "Cannon", "amount": 1 }],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_126.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_126.jpg"
       }
     ],
     "cost": { "value": 0 },
     "restrictions": [{ "ships": ["alphaclassstarwing"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_126.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_126.jpg",
     "ffg_id": "XW_U_126"
   }
 ]

--- a/data/upgrades/crew.json
+++ b/data/upgrades/crew.json
@@ -9,14 +9,13 @@
         "type": "Crew",
         "ability": "During the Perform Action step, you may perform 1 action, even while stressed. After you perform an action while stressed, suffer 1 [Hit] damage unless you expose 1 of your damage cards.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/03/d1/03d1895f-2ffa-404c-aa5b-1d04bce446ab/swz06_a1_chopper.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 2
-    } 
+    "cost": { "value": 2 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
+    "ffg_id": "XW_U_99"
   },
   {
     "name": "\"Zeb\" Orrelios",
@@ -28,21 +27,14 @@
         "type": "Crew",
         "ability": "You can perform primary attacks at range 0. Enemy ships at range 0 can perform primary attacks against you.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/32/c2/32c2f094-1b7f-475d-986f-9b5c4db147cf/swz06-zeb-orrelios-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 1
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 1 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+    "ffg_id": "XW_U_94"
   },
   {
     "name": "0-0-0",
@@ -54,22 +46,16 @@
         "type": "Crew",
         "ability": "At the start of the Engagement Phase, you may choose 1 enemy ship at range 0-1. If you do, you gain 1 calculate token unless that ship chooses to gain 1 stress token.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/d9/dc/d9dccef4-7ddc-4fa5-afe4-8e91818a4fc8/swz08-0-0-0.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 3
-    },
+    "cost": { "value": 3 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ],
-        "names": ["Darth Vader"]
-      }
-    ]
+      { "factions": ["Scum and Villainy"], "names": ["Darth Vader"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
+    "ffg_id": "XW_U_127"
   },
   {
     "name": "4-LOM",
@@ -81,21 +67,14 @@
         "type": "Crew",
         "ability": "While you perform an attack, after rolling attack dice, you may name a type of green token. If you do, gain 2 ion tokens and, during this attack, the defender cannot spend tokens of the named type.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/53/b1/53b13c4e-0f68-4948-a3fe-a3dddd15a149/swz08-4-lom-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 3
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 3 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_128.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_128.jpg",
+    "ffg_id": "XW_U_128"
   },
   {
     "name": "Admiral Sloane",
@@ -107,21 +86,14 @@
         "type": "Crew",
         "ability": "After another friendly ship at range 0-3 defends, if it is destroyed, the attacker gains 2 stress tokens. While a friendly ship at range 0-3 performs an attack against a stressed ship, it may reroll 1 attack die.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/de/04/de04edd7-c26c-4e1d-bd34-a90a251f4b31/swz07-admiral-sloane.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 10
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      }
-    ]
+    "cost": { "value": 10 },
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
+    "ffg_id": "XW_U_109"
   },
   {
     "name": "Agent Kallus",
@@ -133,24 +105,15 @@
         "type": "Crew",
         "ability": "Setup: Assign the Hunted condition to 1 enemy ship. While you perform an attack against the ship with the Hunted condition, you may change 1 of your [Focus] results to a [Hit] result.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/2c/6e/2c6ef1f5-461f-41ed-881f-44513306565c/swz07-agent-kallus.png",
-        "conditions": [
-          "hunted"
-          ],
-        "slots": [
-          "Crew"
-        ]
+        "conditions": ["hunted"],
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 6
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      }
-    ]
+    "cost": { "value": 6 },
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_110.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_110.jpg",
+    "ffg_id": "XW_U_110"
   },
   {
     "name": "Baze Malbus",
@@ -162,21 +125,14 @@
         "type": "Crew",
         "ability": "While you perform a [Focus] action, you may treat it as red. If you do, gain 1 additional focus token for each enemy ship at range 0-1 to a maximum of 2.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/a9/aa/a9aa2092-b9fa-4bdb-afe4-184ed1a2c35e/swz06-baze-malbus-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 8
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 8 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
+    "ffg_id": "XW_U_79"
   },
   {
     "name": "Boba Fett",
@@ -188,21 +144,14 @@
         "type": "Crew",
         "ability": "Setup: Start in reserve. At the end of Setup, place yourself at range 0 of an obstacle and beyond range 3 of an enemy ship.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/6d/da/6dda5263-479c-49ae-973b-210a8b51aac8/swz08-boba-fett-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 4
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_129.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_129.jpg",
+    "ffg_id": "XW_U_129"
   },
   {
     "name": "C-3PO",
@@ -214,37 +163,22 @@
         "type": "Crew",
         "ability": "Before rolling defense dice, you may spend 1 calculate token to guess aloud a number 1 or higher. If you do, and you roll exactly that many [Evade] results, add 1 [Evade] result. Adter you perform the [Calculate] action, gain 1 calculate token.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/84/3b/843bd73a-cf48-464f-b3d6-352fb519cf7a/swz06-c-3po-crew.png",
-        "slots": [
-          "Crew"
-        ],
-        "actions": [
-          {
-            "type": "Calculate",
-            "difficulty": "White"
-          }
-        ],
+        "slots": ["Crew"],
+        "actions": [{ "type": "Calculate", "difficulty": "White" }],
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Calculate",
-              "difficulty": "White"
-            },
+            "value": { "type": "Calculate", "difficulty": "White" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "value": 12
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 12 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
+    "ffg_id": "XW_U_80"
   },
   {
     "name": "Cad Bane",
@@ -256,21 +190,14 @@
         "type": "Crew",
         "ability": "After you drop or launch a device, you may perform a red [Boost] action.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/ad/c8/adc8d61e-6a39-4639-8e29-fcbd3ea8cefd/swz08-cad-bane.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 4
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_130.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_130.jpg",
+    "ffg_id": "XW_U_130"
   },
   {
     "name": "Captain Phasma",
@@ -281,14 +208,10 @@
         "title": "Captain Phasma",
         "type": "Crew",
         "ability": "At the...",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Cassian Andor",
@@ -300,21 +223,14 @@
         "type": "Crew",
         "ability": "During the System Phase, you may choose 1 enemy ship at range 1-2 and guess aloud a bearing and speed, then look at that ship's dial. If the chosen ship's bearing and speed match your guess, you may set your dial to another maneuver.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/a6/6a/a66a361c-b29e-4346-aca2-32b0b31a72e5/swz06-cassian-andor-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 6
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 6 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_81.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_81.jpg",
+    "ffg_id": "XW_U_81"
   },
   {
     "name": "Chewbacca",
@@ -326,25 +242,15 @@
         "type": "Crew",
         "ability": "At the start of the Engagement Phase, you may spend 2 [Charge] to repair 1 faceup damage card.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/f5/2f/f52f142e-f347-41aa-a1ee-40b18aabda06/swz06-chewbacca-crew.png",
-        "slots": [
-          "Crew"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 1
-        }
+        "slots": ["Crew"],
+        "charges": { "value": 2, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 5
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
+    "ffg_id": "XW_U_157"
   },
   {
     "name": "Chewbacca",
@@ -356,21 +262,14 @@
         "type": "Crew",
         "ability": "At the start of the End Phase, you may spend 1 focus token to repair 1 of your faceup damage cards.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ff/d1/ffd12e55-4233-4b8c-90d7-0c69aad9d2da/swz04_chewbacca.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 4
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
+    "ffg_id": "XW_U_157"
   },
   {
     "name": "Ciena Ree",
@@ -381,27 +280,18 @@
         "title": "Ciena Ree",
         "type": "Crew",
         "ability": "After you perform a [Coordinate] action, if the ship you coordinated performed a [Barrel Roll] or [Boost] action, it may gain 1 stress token to rotate 90˚.",
-        "slots": [
-          "Crew"
-        ],
+        "slots": ["Crew"],
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/65/4e/654ec955-2bf2-4c3a-adbc-1af5c1df72cb/swz07-ciena-ree.png"
       }
     ],
-    "cost": {
-      "value": 10
-    },
+    "cost": { "value": 10 },
     "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      },
-      {
-        "action": {
-          "type": "Coordinate"
-        }
-      }
-    ]
+      { "factions": ["Galactic Empire"] },
+      { "action": { "type": "Coordinate" } }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_111.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_111.jpg",
+    "ffg_id": "XW_U_111"
   },
   {
     "name": "Cikatro Vizago",
@@ -413,21 +303,14 @@
         "type": "Crew",
         "ability": "During the End Phase, you may choose 2 [Illicit] upgrades equipped to friendly ships at range 0-1. If you do, you may exchange these upgrades. End of Game: Return all [Illicit] upgrades to their original ships.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/d1/73/d1730f1e-0488-4c64-af15-3aa1bb0c89a4/swz08-cikatro-vizago.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 2
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 2 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
+    "ffg_id": "XW_U_131"
   },
   {
     "name": "Darth Vader",
@@ -438,26 +321,16 @@
         "title": "Darth Vader",
         "type": "Crew",
         "ability": "At the start of the Engagement Phase, you may choose 1 ship in your firing arc at range 0-2 and spend 1 [Force]. If you do, that ship suffers 1 [Hit] damage unless it chooses to remove 1 green token.",
-        "slots": [
-          "Crew"
-        ],
-        "force": {
-          "value": 1,
-          "recovers": 1
-        },
+        "slots": ["Crew"],
+        "force": { "value": 1, "recovers": 1 },
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/4b/b1/4bb1283b-cb60-4f97-b7d8-20c4d5b13af9/swz07_a2_darth-vader.png"
       }
     ],
-    "cost": {
-      "value": 14
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      }
-    ]
+    "cost": { "value": 14 },
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_112.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_112.jpg",
+    "ffg_id": "XW_U_112"
   },
   {
     "name": "Death Troopers",
@@ -469,22 +342,14 @@
         "type": "Crew",
         "ability": "During the Activation Phase, enemy ships at range 0-1 cannot remove stress tokens.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ad/09/ad09c102-49fc-4de0-a60b-01b3f690a853/swx75_card2_death-troopers.png",
-        "slots": [
-          "Crew",
-          "Crew"
-        ]
+        "slots": ["Crew", "Crew"]
       }
     ],
-    "cost": {
-      "value": 6
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      }
-    ]
+    "cost": { "value": 6 },
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
+    "ffg_id": "XW_U_113"
   },
   {
     "name": "Director Krennic",
@@ -502,40 +367,23 @@
             "source": "Store Championship 2018"
           }
         ],
-        "conditions": [
-            "optimizedprototype"
-          ],
-        "slots": [
-          "Crew"
-        ],
-        "actions": [
-          {
-            "type": "Lock",
-            "difficulty": "White"
-          }
-        ],
+        "conditions": ["optimizedprototype"],
+        "slots": ["Crew"],
+        "actions": [{ "type": "Lock", "difficulty": "White" }],
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Lock",
-              "difficulty": "White"
-            },
+            "value": { "type": "Lock", "difficulty": "White" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "value": 5
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      }
-    ]
+    "cost": { "value": 5 },
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_114.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_114.jpg",
+    "ffg_id": "XW_U_114"
   },
   {
     "name": "Emperor Palpatine",
@@ -547,26 +395,15 @@
         "type": "Crew",
         "ability": "While another friendly ship defends or performs an attack, you may spend 1 [Force] to modify 1 of its dice as though that ship had spent 1 [Force].",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/01/bb/01bb0812-8672-452e-861c-ec5b726a5485/swz07-emperor-palpatine.png",
-        "slots": [
-          "Crew",
-          "Crew"
-        ],
-        "force": {
-          "value": 1,
-          "recovers": 1
-        }
+        "slots": ["Crew", "Crew"],
+        "force": { "value": 1, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 13
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      }
-    ]
+    "cost": { "value": 13 },
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_115.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_115.jpg",
+    "ffg_id": "XW_U_115"
   },
   {
     "name": "Freelance Slicer",
@@ -577,14 +414,13 @@
         "title": "Freelance Slicer",
         "type": "Crew",
         "ability": "While you defend, before attack dice are rolled, you may spend a lock you have on the attacker to roll 1 attack die. If you do, the attacker gains 1 [Jam] token. Then, on a [Hit] or [Critical Hit] result, gain 1 [Jam] token.",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 3
-    }
+    "cost": { "value": 3 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
+    "ffg_id": "XW_U_42"
   },
   {
     "name": "GNK \"Gonk\" Droid",
@@ -595,18 +431,14 @@
         "title": "GNK \"Gonk\" Droid",
         "type": "Crew",
         "ability": "Setup: Lose 1 [Charge]. Action: Recover 1 [Charge]. Action: Spend 1 [Charge] to recover 1 shield.",
-        "slots": [
-          "Crew"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 0
-        }
+        "slots": ["Crew"],
+        "charges": { "value": 1, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 10
-    }
+    "cost": { "value": 10 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
+    "ffg_id": "XW_U_43"
   },
   {
     "name": "Grand Inquisitor",
@@ -618,25 +450,15 @@
         "type": "Crew",
         "ability": "After an enemy ship at range 0-2 reveals its dial, you may spend 1 [Force] to perform 1 white action on your action bar, treating that action as red.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/10/f6/10f63a38-c045-4ec8-9ea0-d913ea7e1c90/swz07-grand-inquisitor-crew.png",
-        "slots": [
-          "Crew"
-        ],
-        "force": {
-          "value": 1,
-          "recovers": 1
-        }
+        "slots": ["Crew"],
+        "force": { "value": 1, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 16
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      }
-    ]
+    "cost": { "value": 16 },
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_116.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_116.jpg",
+    "ffg_id": "XW_U_116"
   },
   {
     "name": "Grand Moff Tarkin",
@@ -648,30 +470,18 @@
         "type": "Crew",
         "ability": "During the System Phase, you may spend 2 [Charge]. If you do, each friendly ship may acquire a lock on a ship that you have locked.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/ec/96/ec96ba92-fb6c-460e-bcc8-a30581d418f2/swz07-grand-moff-tarkin.png",
-        "slots": [
-          "Crew"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 1
-        }
+        "slots": ["Crew"],
+        "charges": { "value": 2, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 10
-    },
+    "cost": { "value": 10 },
     "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      },
-      {
-        "action": {
-          "type": "Lock"
-        }
-      }
-    ]
+      { "factions": ["Galactic Empire"] },
+      { "action": { "type": "Lock" } }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
+    "ffg_id": "XW_U_117"
   },
   {
     "name": "Hera Syndulla",
@@ -683,21 +493,14 @@
         "type": "Crew",
         "ability": "You can execute red maneuvers even while stressed. After you fully execute a red maneuver, if you ahve 3 or more stress tokens, remove 1 stress token and suffer 1 [Hit] damage.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/85/ca/85ca9f72-8d66-4d42-aad6-023f072acbf1/swz06_a1_hera.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 4
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_84.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_84.jpg",
+    "ffg_id": "XW_U_84"
   },
   {
     "name": "IG-88D",
@@ -709,37 +512,22 @@
         "type": "Crew",
         "ability": "You have the pilot ability of each other friendly ship with the IG-2000 upgrade. After you perform a [Calculate] action, gain 1 calculate token.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/83/e3/83e380a4-2b87-4bff-accd-b9f1ec9844e9/swz08-ig-88d-crew.png",
-        "slots": [
-          "Crew"
-        ],
-        "actions": [
-          {
-            "type": "Calculate",
-            "difficulty": "White"
-          }
-        ],
+        "slots": ["Crew"],
+        "actions": [{ "type": "Calculate", "difficulty": "White" }],
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Calculate",
-              "difficulty": "White"
-            },
+            "value": { "type": "Calculate", "difficulty": "White" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "value": 4
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_132.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_132.jpg",
+    "ffg_id": "XW_U_132"
   },
   {
     "name": "ISB Slicer",
@@ -751,21 +539,14 @@
         "type": "Crew",
         "ability": "During the End Phase, enemy ships at range 1-2 cannot remove jam tokens.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/8a/c4/8ac4d730-628e-47db-97f4-bb87aacdd29b/swx75_card2_isb-slicer.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 3
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      }
-    ]
+    "cost": { "value": 3 },
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+    "ffg_id": "XW_U_118"
   },
   {
     "name": "Informant",
@@ -776,17 +557,14 @@
         "title": "Informant",
         "type": "Crew",
         "ability": "Setup: After placing forces, choose 1 enemy ship and assign the Listening Device condition to it.",
-        "conditions": [
-          "listeningdevice"
-          ],
-        "slots": [
-          "Crew"
-        ]
+        "conditions": ["listeningdevice"],
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 5
-    }
+    "cost": { "value": 5 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
+    "ffg_id": "XW_U_44"
   },
   {
     "name": "Jabba the Hutt",
@@ -798,26 +576,15 @@
         "type": "Crew",
         "ability": "During the End Phase, you may choose 1 friendly ship at range 0-2 and spend 1 [Charge]. If you do, that ship recovers 1 [Charge] on 1 of its equipped [Illicit] upgrades.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/21/fc/21fc2caf-664e-4b98-a3cb-dad082bc042e/swz08-jabba-the-hutt.png",
-        "slots": [
-          "Crew",
-          "Crew"
-        ],
-        "charges": {
-          "value": 4,
-          "recovers": 0
-        }
+        "slots": ["Crew", "Crew"],
+        "charges": { "value": 4, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 8
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 8 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_133.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_133.jpg",
+    "ffg_id": "XW_U_133"
   },
   {
     "name": "Jyn Erso",
@@ -829,21 +596,14 @@
         "type": "Crew",
         "ability": "If a friendly ship at range 0-3 would gain a focus token, it may gain 1 evade token instead.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/e2/4c/e24c9c08-b56e-4c50-8681-fc0bde8f159f/swz06-jyn-erso-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 2
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 2 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
+    "ffg_id": "XW_U_85"
   },
   {
     "name": "Kanan Jarrus",
@@ -855,25 +615,15 @@
         "type": "Crew",
         "ability": "After a friendly ship at range 0-2 fully executes a white maneuver, you may spend 1 [Force] to remove 1 stress token from that ship.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/6e/57/6e57f217-5306-49c7-8f0d-b9da821ef9a1/swz06-kanan-jarrus-crew.png",
-        "slots": [
-          "Crew"
-        ],
-        "force": {
-          "value": 1,
-          "recovers": 1
-        }
+        "slots": ["Crew"],
+        "force": { "value": 1, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 14
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 14 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_86.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_86.jpg",
+    "ffg_id": "XW_U_86"
   },
   {
     "name": "Ketsu Onyo",
@@ -885,21 +635,14 @@
         "type": "Crew",
         "ability": "At the start of the End Phase, you may choose 1 enemy ship at range 0-2 in your firing arc. If you do, that ship does not remove its tractor tokens.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/5f/d2/5fd2daa0-5e24-4ce5-a7c1-2a7da25b903a/swz08-ketsu-onyo-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 5
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 5 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_134.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_134.jpg",
+    "ffg_id": "XW_U_134"
   },
   {
     "name": "L3-37",
@@ -911,30 +654,21 @@
         "type": "Crew",
         "ability": "Setup: Equip this side faceup. While you defend, you may flip this card. If you do, the attack must reroll all attack dice.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/8d/f0/8df09502-d83c-44d8-b9e8-452edd39ed23/swz04_l3-37_upgrade.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       },
       {
         "title": "L3-37's Programming",
         "type": "Configuration",
         "ability": "If you are not shielded, decrease the difficulty of your bank ([Bank Left] and [Bank Right]) maneuvers.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/52/c3/52c3a315-62cd-4dff-bdf0-e699f68b32b0/swz04_l3-37s-programming.png",
-        "slots": [
-          "Configuration"
-        ]
+        "slots": ["Configuration"]
       }
     ],
-    "cost": {
-      "value": 4
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
+    "ffg_id": "XW_U_158"
   },
   {
     "name": "Lando Calrissian",
@@ -946,21 +680,14 @@
         "type": "Crew",
         "ability": "After you roll dice, you may spend 1 green token to reroll up to 2 of your results.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/d3/89/d38942a6-ec76-445a-a21c-745c79bea713/swz04_lando-calrissian.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 8
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 8 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
+    "ffg_id": "XW_U_159"
   },
   {
     "name": "Lando Calrissian",
@@ -972,21 +699,14 @@
         "type": "Crew",
         "ability": "Action: Roll 2 defense dice. For each [Focus] result, gain 1 focus token. For each [Evade] result, gain 1 evade token. If both results are blank, the opposing player chooses focus or evade. You gain 1 token of that type.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/08/65/08655479-1a99-479e-acc3-db3787a1a3ac/swz06-lando-calrissian-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 5
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 8 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
+    "ffg_id": "XW_U_159"
   },
   {
     "name": "Latts Razzi",
@@ -998,21 +718,14 @@
         "type": "Crew",
         "ability": "While you defend, if the attacker is stressed, you may remove 1 stress from the attacker to change 1 of your blank/[Focus] results to an [Evade] result.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/18/a2/18a26c7f-5bc8-4ad3-8e92-8fdcab979062/swz08-latts-razzi.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 7
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 7 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
+    "ffg_id": "XW_U_135"
   },
   {
     "name": "Leia Organa",
@@ -1024,25 +737,15 @@
         "type": "Crew",
         "ability": "At the start of the Activation Phase, you may spend 3 [Charge]. During this phase, each friendly ship reduces the difficulty of its red maneuvers.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/12/9c/129c2e82-59f8-45f7-a34a-06b3c47a119e/swz06-leia-organa-crew.png",
-        "slots": [
-          "Crew"
-        ],
-        "charges": {
-          "value": 3,
-          "recovers": 1
-        }
+        "slots": ["Crew"],
+        "charges": { "value": 3, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 8
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 8 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_88.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_88.jpg",
+    "ffg_id": "XW_U_88"
   },
   {
     "name": "Magva Yarro",
@@ -1054,21 +757,14 @@
         "type": "Crew",
         "ability": "After you defend, if the attack hit, you may acquire a lock on the attacker.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/96/01/9601a4f8-09ee-47fe-8c7b-e728d8b13af6/swz02_a1_magva-yarro.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 7
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 7 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
+    "ffg_id": "XW_U_89"
   },
   {
     "name": "Maul",
@@ -1080,26 +776,17 @@
         "type": "Crew",
         "ability": "After you suffer damage, you may gain 1 stress token to recover 1 [Force]. You can equip \"Dark Side\" upgades.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/82/f0/82f03c84-c410-4c00-92cb-a235e267c3dd/swz08-maul.png",
-        "slots": [
-          "Crew"
-        ],
-        "force": {
-          "value": 1,
-          "recovers": 1
-        }
+        "slots": ["Crew"],
+        "force": { "value": 1, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 13
-    },
+    "cost": { "value": 13 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ],
-        "names": ["Ezra Bridger"]
-      }
-    ]
+      { "factions": ["Scum and Villainy"], "names": ["Ezra Bridger"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_136.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_136.jpg",
+    "ffg_id": "XW_U_136"
   },
   {
     "name": "Minister Tua",
@@ -1111,21 +798,14 @@
         "type": "Crew",
         "ability": "At the start of the Engagement Phase, if you are damaged, you may perform a red [Reinforce] action.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/e7/cc/e7ccd8b2-92c6-43ae-b4cc-64c34686d407/swz07-minister-tua.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 7
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      }
-    ]
+    "cost": { "value": 7 },
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_119.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_119.jpg",
+    "ffg_id": "XW_U_119"
   },
   {
     "name": "Moff Jerjerrod",
@@ -1137,30 +817,18 @@
         "type": "Crew",
         "ability": "During the System Phase, you may spend 2 [Charge]. If you do, choose the [1 [Bank Left]], [1 [Straight]], or [1 [Bank Right]] template. Each friendly ship may perform a red [Boost] action using that template.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/a2/8b/a28bfb61-b93c-4d8e-9887-7aab0ba3406f/swz07-moff-jerjerrod.png",
-        "slots": [
-          "Crew"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 1
-        }
+        "slots": ["Crew"],
+        "charges": { "value": 2, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 12
-    },
+    "cost": { "value": 12 },
     "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      },
-      {
-        "action": {
-          "type": "Coordinate"
-        }
-      }
-    ]
+      { "factions": ["Galactic Empire"] },
+      { "action": { "type": "Coordinate" } }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_120.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_120.jpg",
+    "ffg_id": "XW_U_120"
   },
   {
     "name": "Nien Nunb",
@@ -1172,21 +840,14 @@
         "type": "Crew",
         "ability": "Decrease the difficulty of your bank maneuvers [[Bank Left] and [Bank Right]].",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/e9/47/e94739bf-64eb-4217-94ad-053a8c9e1d81/swz06-nien-nunb-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 5
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 5 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_90.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_90.jpg",
+    "ffg_id": "XW_U_90"
   },
   {
     "name": "Novice Technician",
@@ -1197,14 +858,13 @@
         "title": "Novice Technician",
         "type": "Crew",
         "ability": "At the end of the round, you may roll 1 attack die to repair 1 faceup damage card. Then, on a [Hit] result, expose 1 damage card.",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 4
-    }
+    "cost": { "value": 4 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_45.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_45.jpg",
+    "ffg_id": "XW_U_45"
   },
   {
     "name": "Perceptive Copilot",
@@ -1215,14 +875,13 @@
         "title": "Perceptive Copilot",
         "type": "Crew",
         "ability": "After you perform a [Focus] action, gain 1 focus token.",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 10
-    }
+    "cost": { "value": 10 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
+    "ffg_id": "XW_U_46"
   },
   {
     "name": "Qi'ra",
@@ -1234,21 +893,14 @@
         "type": "Crew",
         "ability": "While you move and perform attacks, you ignore all obstacles that you are locking.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/d3/36/d336d416-3460-48ec-8fc2-5d8a20231e99/swz04_qira.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 2
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 2 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
+    "ffg_id": "XW_U_161"
   },
   {
     "name": "R2-D2",
@@ -1260,14 +912,13 @@
         "type": "Crew",
         "ability": "During the End Phase, if you are damaged and not shielded, you may roll 1 attack die to recover 1 shield. On a [Hit] result, expose 1 of your damage cards.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/26/9a/269a9f70-1fda-4da7-ba15-5101fc447629/swz06-r2-d2-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 8
-    }
+    "cost": { "value": 8 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_100.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_100.jpg",
+    "ffg_id": "XW_U_100"
   },
   {
     "name": "Rose Tico",
@@ -1278,14 +929,10 @@
         "title": "Rose Tico",
         "type": "Crew",
         "ability": "???",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Sabine Wren",
@@ -1297,21 +944,14 @@
         "type": "Crew",
         "ability": "Setup: Place 1 ion, 1 jam, 1 stress, and 1 tractor token on this card. After a ship suffers the effect of a friendly bomb, you may remove 1 ion, jam, stress, or tractor token from this card. If you do, that ship gains a matching token.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/51/f6/51f673d2-3982-4567-923b-82028c6dcacd/swz06-sabine-wren-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 3
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 3 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_92.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_92.jpg",
+    "ffg_id": "XW_U_92"
   },
   {
     "name": "Saw Gerrera",
@@ -1323,21 +963,14 @@
         "type": "Crew",
         "ability": "While you perform an attack, you may suffer 1 [Hit] damage to change all of your [Focus] results to [Critical Hit] results.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/29/69/2969903e-ab24-402b-aff1-7bdc3338fb86/swz02_a1_saw-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 8
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 8 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
+    "ffg_id": "XW_U_93"
   },
   {
     "name": "Seasoned Navigator",
@@ -1348,14 +981,13 @@
         "title": "Seasoned Navigator",
         "type": "Crew",
         "ability": "After you reveal your dial, you may set your dial to another non-red maneuver of the same speed. While you execute that maneuver, increase its difficulty.",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 5
-    }
+    "cost": { "value": 5 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_47.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_47.jpg",
+    "ffg_id": "XW_U_47"
   },
   {
     "name": "Seventh Sister",
@@ -1367,25 +999,15 @@
         "type": "Crew",
         "ability": "If an enemy ship at range 0-1 would gain a stress token, you may spend 1 [Force] to have it gain 1 jam or tractor token instead.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/36/7d/367d991a-75c9-4067-89bd-4666f162e3f2/swz07-seventh-sister.png",
-        "slots": [
-          "Crew"
-        ],
-        "force": {
-          "value": 1,
-          "recovers": 1
-        }
+        "slots": ["Crew"],
+        "force": { "value": 1, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 12
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      }
-    ]
+    "cost": { "value": 12 },
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
+    "ffg_id": "XW_U_121"
   },
   {
     "name": "Supreme Leader Snoke",
@@ -1396,15 +1018,10 @@
         "title": "Supreme Leader Snoke",
         "type": "Crew",
         "ability": "During the System... you may...",
-        "slots": [
-          "Crew",
-          "Crew"
-        ]
+        "slots": ["Crew", "Crew"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Tactical Officer",
@@ -1416,38 +1033,24 @@
         "type": "Crew",
         "text": "In the chaos of a starfighter battle, a single order can mean the difference between a victory and a massacre.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/30/e1/30e14296-7202-4a52-a671-e66400bef5ad/swx75_card2_tactical-officer.png",
-        "slots": [
-          "Crew"
-        ],
-        "actions": [
-          {
-            "type": "Coordinate",
-            "difficulty": "White"
-          }
-        ],
+        "slots": ["Crew"],
+        "actions": [{ "type": "Coordinate", "difficulty": "White" }],
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Coordinate",
-              "difficulty": "White"
-            },
+            "value": { "type": "Coordinate", "difficulty": "White" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "value": 2
-    },
+    "cost": { "value": 2 },
     "restrictions": [
-      {
-        "action": {
-          "type": "Coordinate",
-          "difficulty": "Red"
-        }
-      }
-    ]
+      { "action": { "type": "Coordinate", "difficulty": "Red" } }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_48.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_48.jpg",
+    "ffg_id": "XW_U_48"
   },
   {
     "name": "Tobias Beckett",
@@ -1459,21 +1062,14 @@
         "type": "Crew",
         "ability": "Setup: After placing forces, you may choose 1 obstacle in the play area. If you do, place it anywhere in the play area beyond range 2 of any board edge or ship and beyond range 1 of other obstacles.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/3b/4b/3b4b7b5a-93a9-4807-9112-a50357b3571d/swz04_a1_upgrade-card-tobias.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 2
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 2 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_160.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_160.jpg",
+    "ffg_id": "XW_U_160"
   },
   {
     "name": "Unkar Plutt",
@@ -1485,21 +1081,14 @@
         "type": "Crew",
         "ability": "After you partially excute a maneuver, you may suffer 1 [Hit] damage to perform 1 white action.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/b0/c5/b0c5236c-c231-4f85-9696-882c3a756cf2/swz08-unkar-plutt-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 2
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 2 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_137.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_137.jpg",
+    "ffg_id": "XW_U_137"
   },
   {
     "name": "Zuckuss",
@@ -1511,20 +1100,13 @@
         "type": "Crew",
         "ability": "While you perform an attack, if ou are not stressed, you may choose 1 defense die and gain 1 stress token. If you do, the defender must reroll that die.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/6b/7f/6b7f6000-b2ec-482e-aac8-d09d4585063a/swz08-zuckuss-crew.png",
-        "slots": [
-          "Crew"
-        ]
+        "slots": ["Crew"]
       }
     ],
-    "cost": {
-      "value": 3
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 3 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_138.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_138.jpg",
+    "ffg_id": "XW_U_138"
   }
 ]

--- a/data/upgrades/crew.json
+++ b/data/upgrades/crew.json
@@ -8,14 +8,13 @@
         "title": "\"Chopper\"",
         "type": "Crew",
         "ability": "During the Perform Action step, you may perform 1 action, even while stressed. After you perform an action while stressed, suffer 1 [Hit] damage unless you expose 1 of your damage cards.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/03/d1/03d1895f-2ffa-404c-aa5b-1d04bce446ab/swz06_a1_chopper.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg"
       }
     ],
     "cost": { "value": 2 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
-    "ffg_id": "XW_U_99"
+    "ffg_id": "XW_U_83"
   },
   {
     "name": "\"Zeb\" Orrelios",
@@ -27,13 +26,13 @@
         "type": "Crew",
         "ability": "You can perform primary attacks at range 0. Enemy ships at range 0 can perform primary attacks against you.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/32/c2/32c2f094-1b7f-475d-986f-9b5c4db147cf/swz06-zeb-orrelios-crew.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg"
       }
     ],
     "cost": { "value": 1 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
     "ffg_id": "XW_U_94"
   },
   {
@@ -45,16 +44,15 @@
         "title": "0-0-0",
         "type": "Crew",
         "ability": "At the start of the Engagement Phase, you may choose 1 enemy ship at range 0-1. If you do, you gain 1 calculate token unless that ship chooses to gain 1 stress token.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/d9/dc/d9dccef4-7ddc-4fa5-afe4-8e91818a4fc8/swz08-0-0-0.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg"
       }
     ],
     "cost": { "value": 3 },
     "restrictions": [
       { "factions": ["Scum and Villainy"], "names": ["Darth Vader"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
     "ffg_id": "XW_U_127"
   },
   {
@@ -66,14 +64,13 @@
         "title": "4-LOM",
         "type": "Crew",
         "ability": "While you perform an attack, after rolling attack dice, you may name a type of green token. If you do, gain 2 ion tokens and, during this attack, the defender cannot spend tokens of the named type.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/53/b1/53b13c4e-0f68-4948-a3fe-a3dddd15a149/swz08-4-lom-crew.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_128.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_128.jpg"
       }
     ],
     "cost": { "value": 3 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_128.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_128.jpg",
     "ffg_id": "XW_U_128"
   },
   {
@@ -85,14 +82,13 @@
         "title": "Admiral Sloane",
         "type": "Crew",
         "ability": "After another friendly ship at range 0-3 defends, if it is destroyed, the attacker gains 2 stress tokens. While a friendly ship at range 0-3 performs an attack against a stressed ship, it may reroll 1 attack die.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/de/04/de04edd7-c26c-4e1d-bd34-a90a251f4b31/swz07-admiral-sloane.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg"
       }
     ],
     "cost": { "value": 10 },
     "restrictions": [{ "factions": ["Galactic Empire"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
     "ffg_id": "XW_U_109"
   },
   {
@@ -104,15 +100,14 @@
         "title": "Agent Kallus",
         "type": "Crew",
         "ability": "Setup: Assign the Hunted condition to 1 enemy ship. While you perform an attack against the ship with the Hunted condition, you may change 1 of your [Focus] results to a [Hit] result.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/2c/6e/2c6ef1f5-461f-41ed-881f-44513306565c/swz07-agent-kallus.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_110.png",
         "conditions": ["hunted"],
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_110.jpg"
       }
     ],
     "cost": { "value": 6 },
     "restrictions": [{ "factions": ["Galactic Empire"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_110.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_110.jpg",
     "ffg_id": "XW_U_110"
   },
   {
@@ -125,13 +120,13 @@
         "type": "Crew",
         "ability": "While you perform a [Focus] action, you may treat it as red. If you do, gain 1 additional focus token for each enemy ship at range 0-1 to a maximum of 2.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/a9/aa/a9aa2092-b9fa-4bdb-afe4-184ed1a2c35e/swz06-baze-malbus-crew.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg"
       }
     ],
     "cost": { "value": 8 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
     "ffg_id": "XW_U_79"
   },
   {
@@ -143,14 +138,13 @@
         "title": "Boba Fett",
         "type": "Crew",
         "ability": "Setup: Start in reserve. At the end of Setup, place yourself at range 0 of an obstacle and beyond range 3 of an enemy ship.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/6d/da/6dda5263-479c-49ae-973b-210a8b51aac8/swz08-boba-fett-crew.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_129.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_129.jpg"
       }
     ],
     "cost": { "value": 4 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_129.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_129.jpg",
     "ffg_id": "XW_U_129"
   },
   {
@@ -171,13 +165,13 @@
             "value": { "type": "Calculate", "difficulty": "White" },
             "amount": 1
           }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg"
       }
     ],
     "cost": { "value": 12 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
     "ffg_id": "XW_U_80"
   },
   {
@@ -189,14 +183,13 @@
         "title": "Cad Bane",
         "type": "Crew",
         "ability": "After you drop or launch a device, you may perform a red [Boost] action.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/ad/c8/adc8d61e-6a39-4639-8e29-fcbd3ea8cefd/swz08-cad-bane.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_130.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_130.jpg"
       }
     ],
     "cost": { "value": 4 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_130.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_130.jpg",
     "ffg_id": "XW_U_130"
   },
   {
@@ -223,13 +216,13 @@
         "type": "Crew",
         "ability": "During the System Phase, you may choose 1 enemy ship at range 1-2 and guess aloud a bearing and speed, then look at that ship's dial. If the chosen ship's bearing and speed match your guess, you may set your dial to another maneuver.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/a6/6a/a66a361c-b29e-4346-aca2-32b0b31a72e5/swz06-cassian-andor-crew.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_81.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_81.jpg"
       }
     ],
     "cost": { "value": 6 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_81.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_81.jpg",
     "ffg_id": "XW_U_81"
   },
   {
@@ -243,14 +236,14 @@
         "ability": "At the start of the Engagement Phase, you may spend 2 [Charge] to repair 1 faceup damage card.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/f5/2f/f52f142e-f347-41aa-a1ee-40b18aabda06/swz06-chewbacca-crew.png",
         "slots": ["Crew"],
-        "charges": { "value": 2, "recovers": 1 }
+        "charges": { "value": 2, "recovers": 1 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_82.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_82.jpg"
       }
     ],
-    "cost": { "value": 4 },
+    "cost": { "value": 5 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
-    "ffg_id": "XW_U_157"
+    "ffg_id": "XW_U_82"
   },
   {
     "name": "Chewbacca",
@@ -262,13 +255,13 @@
         "type": "Crew",
         "ability": "At the start of the End Phase, you may spend 1 focus token to repair 1 of your faceup damage cards.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ff/d1/ffd12e55-4233-4b8c-90d7-0c69aad9d2da/swz04_chewbacca.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg"
       }
     ],
     "cost": { "value": 4 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
     "ffg_id": "XW_U_157"
   },
   {
@@ -281,7 +274,8 @@
         "type": "Crew",
         "ability": "After you perform a [Coordinate] action, if the ship you coordinated performed a [Barrel Roll] or [Boost] action, it may gain 1 stress token to rotate 90˚.",
         "slots": ["Crew"],
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/65/4e/654ec955-2bf2-4c3a-adbc-1af5c1df72cb/swz07-ciena-ree.png"
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_111.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_111.jpg"
       }
     ],
     "cost": { "value": 10 },
@@ -289,8 +283,6 @@
       { "factions": ["Galactic Empire"] },
       { "action": { "type": "Coordinate" } }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_111.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_111.jpg",
     "ffg_id": "XW_U_111"
   },
   {
@@ -302,14 +294,13 @@
         "title": "Cikatro Vizago",
         "type": "Crew",
         "ability": "During the End Phase, you may choose 2 [Illicit] upgrades equipped to friendly ships at range 0-1. If you do, you may exchange these upgrades. End of Game: Return all [Illicit] upgrades to their original ships.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/d1/73/d1730f1e-0488-4c64-af15-3aa1bb0c89a4/swz08-cikatro-vizago.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg"
       }
     ],
     "cost": { "value": 2 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
     "ffg_id": "XW_U_131"
   },
   {
@@ -323,13 +314,12 @@
         "ability": "At the start of the Engagement Phase, you may choose 1 ship in your firing arc at range 0-2 and spend 1 [Force]. If you do, that ship suffers 1 [Hit] damage unless it chooses to remove 1 green token.",
         "slots": ["Crew"],
         "force": { "value": 1, "recovers": 1 },
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/4b/b1/4bb1283b-cb60-4f97-b7d8-20c4d5b13af9/swz07_a2_darth-vader.png"
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_112.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_112.jpg"
       }
     ],
     "cost": { "value": 14 },
     "restrictions": [{ "factions": ["Galactic Empire"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_112.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_112.jpg",
     "ffg_id": "XW_U_112"
   },
   {
@@ -342,13 +332,13 @@
         "type": "Crew",
         "ability": "During the Activation Phase, enemy ships at range 0-1 cannot remove stress tokens.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ad/09/ad09c102-49fc-4de0-a60b-01b3f690a853/swx75_card2_death-troopers.png",
-        "slots": ["Crew", "Crew"]
+        "slots": ["Crew", "Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg"
       }
     ],
     "cost": { "value": 6 },
     "restrictions": [{ "factions": ["Galactic Empire"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
     "ffg_id": "XW_U_113"
   },
   {
@@ -360,7 +350,7 @@
         "title": "Director Krennic",
         "type": "Crew",
         "ability": "Setup: Before placing forces, assign the Optimized Prototype condition to another friendly ship.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/e9/45/e9451849-9178-4c8a-b8c3-09195f02b64d/swz07_a2_krennic.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_114.png",
         "alt": [
           {
             "image": "https://images-cdn.fantasyflightgames.com/filer_public/10/21/1021c262-702e-4857-9204-35756e051c2c/g18xs_krennic2nd.png",
@@ -376,13 +366,12 @@
             "value": { "type": "Lock", "difficulty": "White" },
             "amount": 1
           }
-        ]
+        ],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_114.jpg"
       }
     ],
     "cost": { "value": 5 },
     "restrictions": [{ "factions": ["Galactic Empire"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_114.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_114.jpg",
     "ffg_id": "XW_U_114"
   },
   {
@@ -394,15 +383,14 @@
         "title": "Emperor Palpatine",
         "type": "Crew",
         "ability": "While another friendly ship defends or performs an attack, you may spend 1 [Force] to modify 1 of its dice as though that ship had spent 1 [Force].",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/01/bb/01bb0812-8672-452e-861c-ec5b726a5485/swz07-emperor-palpatine.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_115.png",
         "slots": ["Crew", "Crew"],
-        "force": { "value": 1, "recovers": 1 }
+        "force": { "value": 1, "recovers": 1 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_115.jpg"
       }
     ],
     "cost": { "value": 13 },
     "restrictions": [{ "factions": ["Galactic Empire"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_115.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_115.jpg",
     "ffg_id": "XW_U_115"
   },
   {
@@ -414,12 +402,12 @@
         "title": "Freelance Slicer",
         "type": "Crew",
         "ability": "While you defend, before attack dice are rolled, you may spend a lock you have on the attacker to roll 1 attack die. If you do, the attacker gains 1 [Jam] token. Then, on a [Hit] or [Critical Hit] result, gain 1 [Jam] token.",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg"
       }
     ],
     "cost": { "value": 3 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
     "ffg_id": "XW_U_42"
   },
   {
@@ -432,12 +420,12 @@
         "type": "Crew",
         "ability": "Setup: Lose 1 [Charge]. Action: Recover 1 [Charge]. Action: Spend 1 [Charge] to recover 1 shield.",
         "slots": ["Crew"],
-        "charges": { "value": 1, "recovers": 0 }
+        "charges": { "value": 1, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg"
       }
     ],
     "cost": { "value": 10 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
     "ffg_id": "XW_U_43"
   },
   {
@@ -449,15 +437,14 @@
         "title": "Grand Inquisitor",
         "type": "Crew",
         "ability": "After an enemy ship at range 0-2 reveals its dial, you may spend 1 [Force] to perform 1 white action on your action bar, treating that action as red.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/10/f6/10f63a38-c045-4ec8-9ea0-d913ea7e1c90/swz07-grand-inquisitor-crew.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_116.png",
         "slots": ["Crew"],
-        "force": { "value": 1, "recovers": 1 }
+        "force": { "value": 1, "recovers": 1 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_116.jpg"
       }
     ],
     "cost": { "value": 16 },
     "restrictions": [{ "factions": ["Galactic Empire"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_116.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_116.jpg",
     "ffg_id": "XW_U_116"
   },
   {
@@ -469,9 +456,10 @@
         "title": "Grand Moff Tarkin",
         "type": "Crew",
         "ability": "During the System Phase, you may spend 2 [Charge]. If you do, each friendly ship may acquire a lock on a ship that you have locked.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/ec/96/ec96ba92-fb6c-460e-bcc8-a30581d418f2/swz07-grand-moff-tarkin.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
         "slots": ["Crew"],
-        "charges": { "value": 2, "recovers": 1 }
+        "charges": { "value": 2, "recovers": 1 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg"
       }
     ],
     "cost": { "value": 10 },
@@ -479,8 +467,6 @@
       { "factions": ["Galactic Empire"] },
       { "action": { "type": "Lock" } }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
     "ffg_id": "XW_U_117"
   },
   {
@@ -492,14 +478,13 @@
         "title": "Hera Syndulla",
         "type": "Crew",
         "ability": "You can execute red maneuvers even while stressed. After you fully execute a red maneuver, if you ahve 3 or more stress tokens, remove 1 stress token and suffer 1 [Hit] damage.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/85/ca/85ca9f72-8d66-4d42-aad6-023f072acbf1/swz06_a1_hera.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_84.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_84.jpg"
       }
     ],
     "cost": { "value": 4 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_84.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_84.jpg",
     "ffg_id": "XW_U_84"
   },
   {
@@ -511,7 +496,7 @@
         "title": "IG-88D",
         "type": "Crew",
         "ability": "You have the pilot ability of each other friendly ship with the IG-2000 upgrade. After you perform a [Calculate] action, gain 1 calculate token.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/83/e3/83e380a4-2b87-4bff-accd-b9f1ec9844e9/swz08-ig-88d-crew.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_132.png",
         "slots": ["Crew"],
         "actions": [{ "type": "Calculate", "difficulty": "White" }],
         "grants": [
@@ -520,13 +505,12 @@
             "value": { "type": "Calculate", "difficulty": "White" },
             "amount": 1
           }
-        ]
+        ],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_132.jpg"
       }
     ],
     "cost": { "value": 4 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_132.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_132.jpg",
     "ffg_id": "XW_U_132"
   },
   {
@@ -539,13 +523,13 @@
         "type": "Crew",
         "ability": "During the End Phase, enemy ships at range 1-2 cannot remove jam tokens.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/8a/c4/8ac4d730-628e-47db-97f4-bb87aacdd29b/swx75_card2_isb-slicer.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg"
       }
     ],
     "cost": { "value": 3 },
     "restrictions": [{ "factions": ["Galactic Empire"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
     "ffg_id": "XW_U_118"
   },
   {
@@ -558,12 +542,12 @@
         "type": "Crew",
         "ability": "Setup: After placing forces, choose 1 enemy ship and assign the Listening Device condition to it.",
         "conditions": ["listeningdevice"],
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg"
       }
     ],
     "cost": { "value": 5 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
     "ffg_id": "XW_U_44"
   },
   {
@@ -575,15 +559,14 @@
         "title": "Jabba the Hutt",
         "type": "Crew",
         "ability": "During the End Phase, you may choose 1 friendly ship at range 0-2 and spend 1 [Charge]. If you do, that ship recovers 1 [Charge] on 1 of its equipped [Illicit] upgrades.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/21/fc/21fc2caf-664e-4b98-a3cb-dad082bc042e/swz08-jabba-the-hutt.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_133.png",
         "slots": ["Crew", "Crew"],
-        "charges": { "value": 4, "recovers": 0 }
+        "charges": { "value": 4, "recovers": 0 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_133.jpg"
       }
     ],
     "cost": { "value": 8 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_133.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_133.jpg",
     "ffg_id": "XW_U_133"
   },
   {
@@ -596,13 +579,13 @@
         "type": "Crew",
         "ability": "If a friendly ship at range 0-3 would gain a focus token, it may gain 1 evade token instead.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/e2/4c/e24c9c08-b56e-4c50-8681-fc0bde8f159f/swz06-jyn-erso-crew.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg"
       }
     ],
     "cost": { "value": 2 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
     "ffg_id": "XW_U_85"
   },
   {
@@ -616,13 +599,13 @@
         "ability": "After a friendly ship at range 0-2 fully executes a white maneuver, you may spend 1 [Force] to remove 1 stress token from that ship.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/6e/57/6e57f217-5306-49c7-8f0d-b9da821ef9a1/swz06-kanan-jarrus-crew.png",
         "slots": ["Crew"],
-        "force": { "value": 1, "recovers": 1 }
+        "force": { "value": 1, "recovers": 1 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_86.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_86.jpg"
       }
     ],
     "cost": { "value": 14 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_86.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_86.jpg",
     "ffg_id": "XW_U_86"
   },
   {
@@ -634,14 +617,13 @@
         "title": "Ketsu Onyo",
         "type": "Crew",
         "ability": "At the start of the End Phase, you may choose 1 enemy ship at range 0-2 in your firing arc. If you do, that ship does not remove its tractor tokens.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/5f/d2/5fd2daa0-5e24-4ce5-a7c1-2a7da25b903a/swz08-ketsu-onyo-crew.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_134.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_134.jpg"
       }
     ],
     "cost": { "value": 5 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_134.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_134.jpg",
     "ffg_id": "XW_U_134"
   },
   {
@@ -654,7 +636,9 @@
         "type": "Crew",
         "ability": "Setup: Equip this side faceup. While you defend, you may flip this card. If you do, the attack must reroll all attack dice.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/8d/f0/8df09502-d83c-44d8-b9e8-452edd39ed23/swz04_l3-37_upgrade.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg"
       },
       {
         "title": "L3-37's Programming",
@@ -666,8 +650,6 @@
     ],
     "cost": { "value": 4 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
     "ffg_id": "XW_U_158"
   },
   {
@@ -680,13 +662,13 @@
         "type": "Crew",
         "ability": "After you roll dice, you may spend 1 green token to reroll up to 2 of your results.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/d3/89/d38942a6-ec76-445a-a21c-745c79bea713/swz04_lando-calrissian.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg"
       }
     ],
     "cost": { "value": 8 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
     "ffg_id": "XW_U_159"
   },
   {
@@ -699,14 +681,14 @@
         "type": "Crew",
         "ability": "Action: Roll 2 defense dice. For each [Focus] result, gain 1 focus token. For each [Evade] result, gain 1 evade token. If both results are blank, the opposing player chooses focus or evade. You gain 1 token of that type.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/08/65/08655479-1a99-479e-acc3-db3787a1a3ac/swz06-lando-calrissian-crew.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_87.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_87.jpg"
       }
     ],
-    "cost": { "value": 8 },
+    "cost": { "value": 5 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
-    "ffg_id": "XW_U_159"
+    "ffg_id": "XW_U_87"
   },
   {
     "name": "Latts Razzi",
@@ -717,14 +699,13 @@
         "title": "Latts Razzi",
         "type": "Crew",
         "ability": "While you defend, if the attacker is stressed, you may remove 1 stress from the attacker to change 1 of your blank/[Focus] results to an [Evade] result.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/18/a2/18a26c7f-5bc8-4ad3-8e92-8fdcab979062/swz08-latts-razzi.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg"
       }
     ],
     "cost": { "value": 7 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
     "ffg_id": "XW_U_135"
   },
   {
@@ -736,15 +717,14 @@
         "title": "Leia Organa",
         "type": "Crew",
         "ability": "At the start of the Activation Phase, you may spend 3 [Charge]. During this phase, each friendly ship reduces the difficulty of its red maneuvers.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/12/9c/129c2e82-59f8-45f7-a34a-06b3c47a119e/swz06-leia-organa-crew.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_88.png",
         "slots": ["Crew"],
-        "charges": { "value": 3, "recovers": 1 }
+        "charges": { "value": 3, "recovers": 1 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_88.jpg"
       }
     ],
     "cost": { "value": 8 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_88.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_88.jpg",
     "ffg_id": "XW_U_88"
   },
   {
@@ -757,13 +737,13 @@
         "type": "Crew",
         "ability": "After you defend, if the attack hit, you may acquire a lock on the attacker.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/96/01/9601a4f8-09ee-47fe-8c7b-e728d8b13af6/swz02_a1_magva-yarro.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg"
       }
     ],
     "cost": { "value": 7 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
     "ffg_id": "XW_U_89"
   },
   {
@@ -775,17 +755,16 @@
         "title": "Maul",
         "type": "Crew",
         "ability": "After you suffer damage, you may gain 1 stress token to recover 1 [Force]. You can equip \"Dark Side\" upgades.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/82/f0/82f03c84-c410-4c00-92cb-a235e267c3dd/swz08-maul.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_136.png",
         "slots": ["Crew"],
-        "force": { "value": 1, "recovers": 1 }
+        "force": { "value": 1, "recovers": 1 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_136.jpg"
       }
     ],
     "cost": { "value": 13 },
     "restrictions": [
       { "factions": ["Scum and Villainy"], "names": ["Ezra Bridger"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_136.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_136.jpg",
     "ffg_id": "XW_U_136"
   },
   {
@@ -797,14 +776,13 @@
         "title": "Minister Tua",
         "type": "Crew",
         "ability": "At the start of the Engagement Phase, if you are damaged, you may perform a red [Reinforce] action.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/e7/cc/e7ccd8b2-92c6-43ae-b4cc-64c34686d407/swz07-minister-tua.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_119.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_119.jpg"
       }
     ],
     "cost": { "value": 7 },
     "restrictions": [{ "factions": ["Galactic Empire"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_119.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_119.jpg",
     "ffg_id": "XW_U_119"
   },
   {
@@ -816,9 +794,10 @@
         "title": "Moff Jerjerrod",
         "type": "Crew",
         "ability": "During the System Phase, you may spend 2 [Charge]. If you do, choose the [1 [Bank Left]], [1 [Straight]], or [1 [Bank Right]] template. Each friendly ship may perform a red [Boost] action using that template.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/a2/8b/a28bfb61-b93c-4d8e-9887-7aab0ba3406f/swz07-moff-jerjerrod.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_120.png",
         "slots": ["Crew"],
-        "charges": { "value": 2, "recovers": 1 }
+        "charges": { "value": 2, "recovers": 1 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_120.jpg"
       }
     ],
     "cost": { "value": 12 },
@@ -826,8 +805,6 @@
       { "factions": ["Galactic Empire"] },
       { "action": { "type": "Coordinate" } }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_120.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_120.jpg",
     "ffg_id": "XW_U_120"
   },
   {
@@ -840,13 +817,13 @@
         "type": "Crew",
         "ability": "Decrease the difficulty of your bank maneuvers [[Bank Left] and [Bank Right]].",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/e9/47/e94739bf-64eb-4217-94ad-053a8c9e1d81/swz06-nien-nunb-crew.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_90.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_90.jpg"
       }
     ],
     "cost": { "value": 5 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_90.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_90.jpg",
     "ffg_id": "XW_U_90"
   },
   {
@@ -858,12 +835,12 @@
         "title": "Novice Technician",
         "type": "Crew",
         "ability": "At the end of the round, you may roll 1 attack die to repair 1 faceup damage card. Then, on a [Hit] result, expose 1 damage card.",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_45.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_45.jpg"
       }
     ],
     "cost": { "value": 4 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_45.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_45.jpg",
     "ffg_id": "XW_U_45"
   },
   {
@@ -875,12 +852,12 @@
         "title": "Perceptive Copilot",
         "type": "Crew",
         "ability": "After you perform a [Focus] action, gain 1 focus token.",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg"
       }
     ],
     "cost": { "value": 10 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
     "ffg_id": "XW_U_46"
   },
   {
@@ -893,13 +870,13 @@
         "type": "Crew",
         "ability": "While you move and perform attacks, you ignore all obstacles that you are locking.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/d3/36/d336d416-3460-48ec-8fc2-5d8a20231e99/swz04_qira.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg"
       }
     ],
     "cost": { "value": 2 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
     "ffg_id": "XW_U_161"
   },
   {
@@ -912,13 +889,13 @@
         "type": "Crew",
         "ability": "During the End Phase, if you are damaged and not shielded, you may roll 1 attack die to recover 1 shield. On a [Hit] result, expose 1 of your damage cards.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/26/9a/269a9f70-1fda-4da7-ba15-5101fc447629/swz06-r2-d2-crew.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg"
       }
     ],
     "cost": { "value": 8 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_100.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_100.jpg",
-    "ffg_id": "XW_U_100"
+    "ffg_id": "XW_U_91"
   },
   {
     "name": "Rose Tico",
@@ -944,13 +921,13 @@
         "type": "Crew",
         "ability": "Setup: Place 1 ion, 1 jam, 1 stress, and 1 tractor token on this card. After a ship suffers the effect of a friendly bomb, you may remove 1 ion, jam, stress, or tractor token from this card. If you do, that ship gains a matching token.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/51/f6/51f673d2-3982-4567-923b-82028c6dcacd/swz06-sabine-wren-crew.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_92.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_92.jpg"
       }
     ],
     "cost": { "value": 3 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_92.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_92.jpg",
     "ffg_id": "XW_U_92"
   },
   {
@@ -963,13 +940,13 @@
         "type": "Crew",
         "ability": "While you perform an attack, you may suffer 1 [Hit] damage to change all of your [Focus] results to [Critical Hit] results.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/29/69/2969903e-ab24-402b-aff1-7bdc3338fb86/swz02_a1_saw-crew.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg"
       }
     ],
     "cost": { "value": 8 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
     "ffg_id": "XW_U_93"
   },
   {
@@ -981,12 +958,12 @@
         "title": "Seasoned Navigator",
         "type": "Crew",
         "ability": "After you reveal your dial, you may set your dial to another non-red maneuver of the same speed. While you execute that maneuver, increase its difficulty.",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_47.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_47.jpg"
       }
     ],
     "cost": { "value": 5 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_47.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_47.jpg",
     "ffg_id": "XW_U_47"
   },
   {
@@ -998,15 +975,14 @@
         "title": "Seventh Sister",
         "type": "Crew",
         "ability": "If an enemy ship at range 0-1 would gain a stress token, you may spend 1 [Force] to have it gain 1 jam or tractor token instead.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/36/7d/367d991a-75c9-4067-89bd-4666f162e3f2/swz07-seventh-sister.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
         "slots": ["Crew"],
-        "force": { "value": 1, "recovers": 1 }
+        "force": { "value": 1, "recovers": 1 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg"
       }
     ],
     "cost": { "value": 12 },
     "restrictions": [{ "factions": ["Galactic Empire"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
     "ffg_id": "XW_U_121"
   },
   {
@@ -1041,15 +1017,15 @@
             "value": { "type": "Coordinate", "difficulty": "White" },
             "amount": 1
           }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_48.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_48.jpg"
       }
     ],
     "cost": { "value": 2 },
     "restrictions": [
       { "action": { "type": "Coordinate", "difficulty": "Red" } }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_48.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_48.jpg",
     "ffg_id": "XW_U_48"
   },
   {
@@ -1062,13 +1038,13 @@
         "type": "Crew",
         "ability": "Setup: After placing forces, you may choose 1 obstacle in the play area. If you do, place it anywhere in the play area beyond range 2 of any board edge or ship and beyond range 1 of other obstacles.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/3b/4b/3b4b7b5a-93a9-4807-9112-a50357b3571d/swz04_a1_upgrade-card-tobias.png",
-        "slots": ["Crew"]
+        "slots": ["Crew"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_160.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_160.jpg"
       }
     ],
     "cost": { "value": 2 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_160.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_160.jpg",
     "ffg_id": "XW_U_160"
   },
   {
@@ -1080,14 +1056,13 @@
         "title": "Unkar Plutt",
         "type": "Crew",
         "ability": "After you partially excute a maneuver, you may suffer 1 [Hit] damage to perform 1 white action.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/b0/c5/b0c5236c-c231-4f85-9696-882c3a756cf2/swz08-unkar-plutt-crew.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_137.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_137.jpg"
       }
     ],
     "cost": { "value": 2 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_137.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_137.jpg",
     "ffg_id": "XW_U_137"
   },
   {
@@ -1099,14 +1074,13 @@
         "title": "Zuckuss",
         "type": "Crew",
         "ability": "While you perform an attack, if ou are not stressed, you may choose 1 defense die and gain 1 stress token. If you do, the defender must reroll that die.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/6b/7f/6b7f6000-b2ec-482e-aac8-d09d4585063a/swz08-zuckuss-crew.png",
-        "slots": ["Crew"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_138.png",
+        "slots": ["Crew"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_138.jpg"
       }
     ],
     "cost": { "value": 3 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_138.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_138.jpg",
     "ffg_id": "XW_U_138"
   }
 ]

--- a/data/upgrades/device.json
+++ b/data/upgrades/device.json
@@ -8,19 +8,14 @@
         "title": "Bomblet Generator",
         "type": "Device",
         "ability": "Bomb During the System Phase, you may spend 1 [Charge] to drop a Bomblet with the [1 [Straight]] templete. At the start of the Activation Phase, you may spend 1 shield to recover 2 [Charge].",
-        "slots": [
-          "Device",
-          "Device"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        }
+        "slots": ["Device", "Device"],
+        "charges": { "value": 2, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 5
-    }
+    "cost": { "value": 5 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
+    "ffg_id": "XW_U_63"
   },
   {
     "name": "Conner Nets",
@@ -31,18 +26,14 @@
         "title": "Conner Nets",
         "type": "Device",
         "ability": "Mine During the System Phase, you may spend 1 [Charge] to drop a Conner Net using the [1 [Straight]] template. This card's [Charge] cannot be recovered.",
-        "slots": [
-          "Device"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 0
-        }
+        "slots": ["Device"],
+        "charges": { "value": 1, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 6
-    }
+    "cost": { "value": 6 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
+    "ffg_id": "XW_U_64"
   },
   {
     "name": "Proton Bombs",
@@ -54,18 +45,14 @@
         "type": "Device",
         "ability": "Bomb During the System Phase, you may spend 1 [Charge] to drop a Proton Bomb using the [1 [Straight]] template.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/9a/31/9a315db8-d666-43be-a1e1-eb5fbb73e8b6/swz07-proton-bombs.png",
-        "slots": [
-          "Device"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        }
+        "slots": ["Device"],
+        "charges": { "value": 2, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 5
-    }
+    "cost": { "value": 5 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
+    "ffg_id": "XW_U_65"
   },
   {
     "name": "Proximity Mines",
@@ -77,18 +64,14 @@
         "type": "Device",
         "ability": "Mine During the System Phase, you may spend 1 [Charge] to drop a Proximity Mine using the [1 [Straight]] template. This card's [Charge] cannot be recovered.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/3f/cb/3fcb3597-caf8-4835-a21d-328f3850816f/swz16_proximity-mines.png",
-        "slots": [
-          "Device"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        }
+        "slots": ["Device"],
+        "charges": { "value": 2, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 6
-    }
+    "cost": { "value": 6 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
+    "ffg_id": "XW_U_66"
   },
   {
     "name": "Seismic Charges",
@@ -100,17 +83,13 @@
         "type": "Device",
         "ability": "Bomb During the System Phase, you may spend 1 [Charge] to drop a Seismic Charge with the [1 [Straight]] template.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/4b/20/4b20111d-d6ce-44a5-9b4b-1a25476a3152/swz07-seismic-charges.png",
-        "slots": [
-          "Device"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        }
+        "slots": ["Device"],
+        "charges": { "value": 2, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 3
-    }
+    "cost": { "value": 3 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+    "ffg_id": "XW_U_67"
   }
 ]

--- a/data/upgrades/device.json
+++ b/data/upgrades/device.json
@@ -9,12 +9,12 @@
         "type": "Device",
         "ability": "Bomb During the System Phase, you may spend 1 [Charge] to drop a Bomblet with the [1 [Straight]] templete. At the start of the Activation Phase, you may spend 1 shield to recover 2 [Charge].",
         "slots": ["Device", "Device"],
-        "charges": { "value": 2, "recovers": 0 }
+        "charges": { "value": 2, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg"
       }
     ],
     "cost": { "value": 5 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
     "ffg_id": "XW_U_63"
   },
   {
@@ -27,12 +27,12 @@
         "type": "Device",
         "ability": "Mine During the System Phase, you may spend 1 [Charge] to drop a Conner Net using the [1 [Straight]] template. This card's [Charge] cannot be recovered.",
         "slots": ["Device"],
-        "charges": { "value": 1, "recovers": 0 }
+        "charges": { "value": 1, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg"
       }
     ],
     "cost": { "value": 6 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
     "ffg_id": "XW_U_64"
   },
   {
@@ -44,14 +44,13 @@
         "title": "Proton Bombs",
         "type": "Device",
         "ability": "Bomb During the System Phase, you may spend 1 [Charge] to drop a Proton Bomb using the [1 [Straight]] template.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/9a/31/9a315db8-d666-43be-a1e1-eb5fbb73e8b6/swz07-proton-bombs.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
         "slots": ["Device"],
-        "charges": { "value": 2, "recovers": 0 }
+        "charges": { "value": 2, "recovers": 0 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg"
       }
     ],
     "cost": { "value": 5 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
     "ffg_id": "XW_U_65"
   },
   {
@@ -65,12 +64,12 @@
         "ability": "Mine During the System Phase, you may spend 1 [Charge] to drop a Proximity Mine using the [1 [Straight]] template. This card's [Charge] cannot be recovered.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/3f/cb/3fcb3597-caf8-4835-a21d-328f3850816f/swz16_proximity-mines.png",
         "slots": ["Device"],
-        "charges": { "value": 2, "recovers": 0 }
+        "charges": { "value": 2, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg"
       }
     ],
     "cost": { "value": 6 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
     "ffg_id": "XW_U_66"
   },
   {
@@ -82,14 +81,13 @@
         "title": "Seismic Charges",
         "type": "Device",
         "ability": "Bomb During the System Phase, you may spend 1 [Charge] to drop a Seismic Charge with the [1 [Straight]] template.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/4b/20/4b20111d-d6ce-44a5-9b4b-1a25476a3152/swz07-seismic-charges.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
         "slots": ["Device"],
-        "charges": { "value": 2, "recovers": 0 }
+        "charges": { "value": 2, "recovers": 0 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg"
       }
     ],
     "cost": { "value": 3 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
     "ffg_id": "XW_U_67"
   }
 ]

--- a/data/upgrades/force-power.json
+++ b/data/upgrades/force-power.json
@@ -9,14 +9,13 @@
         "type": "Force Power",
         "ability": "At the start of the Engagement Phase, you may spend 1 [Force]. If you do, engage at initiative 7 instead of your standard initiative value this phase.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/dd/ab/ddab7958-9dbb-4868-8bcf-fc975b66969b/swz01_heightened-perception.png",
-        "slots": [
-          "Force Power"
-        ]
+        "slots": ["Force Power"]
       }
     ],
-    "cost": {
-      "value": 3
-    }
+    "cost": { "value": 3 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
+    "ffg_id": "XW_U_19"
   },
   {
     "name": "Instinctive Aim",
@@ -28,14 +27,13 @@
         "type": "Force Power",
         "ability": "While you perform a special attack, you may spend 1 [Force] to ignore the [Focus] or [Lock] requirement.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/5f/c3/5fc32861-848c-4e40-8313-ecfc7b99e64d/swz01_instinctive-aim.png",
-        "slots": [
-          "Force Power"
-        ]
+        "slots": ["Force Power"]
       }
     ],
-    "cost": {
-      "value": 2
-    }
+    "cost": { "value": 2 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_20.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_20.jpg",
+    "ffg_id": "XW_U_20"
   },
   {
     "name": "Sense",
@@ -47,14 +45,13 @@
         "type": "Force Power",
         "ability": "During the System Phase, you may choose 1 ship at range 0-1 and look at its dial. If you spend 1 [Force], you may choose a ship at range 0-3 instead.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/0f/4d/0f4d0ae3-65aa-40f8-aa00-51f2cec053ad/swz01_sense.png",
-        "slots": [
-          "Force Power"
-        ]
+        "slots": ["Force Power"]
       }
     ],
-    "cost": {
-      "value": 6
-    }
+    "cost": { "value": 6 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_21.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_21.jpg",
+    "ffg_id": "XW_U_21"
   },
   {
     "name": "Supernatural Reflexes",
@@ -65,21 +62,14 @@
         "title": "Supernatural Reflexes",
         "type": "Force Power",
         "ability": "Before you activate, you may spend 1 [Force] to perform a [Barrel Roll] or [Boost] action. Then, if you performed an action you do not have on your action bar, suffer 1 [Hit] damage.",
-        "slots": [
-          "Force Power"
-        ],
+        "slots": ["Force Power"],
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/17/1a/171aa533-6927-4c92-9a25-eea21390c1e9/swz01-supernatural-reflexes.png"
       }
     ],
-    "cost": {
-      "value": 12
-    },
-    "restrictions": [
-      {
-        "sizes": [
-          "Small"
-        ]
-      }
-    ]
+    "cost": { "value": 12 },
+    "restrictions": [{ "sizes": ["Small"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_22.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_22.jpg",
+    "ffg_id": "XW_U_22"
   }
 ]

--- a/data/upgrades/force-power.json
+++ b/data/upgrades/force-power.json
@@ -9,12 +9,12 @@
         "type": "Force Power",
         "ability": "At the start of the Engagement Phase, you may spend 1 [Force]. If you do, engage at initiative 7 instead of your standard initiative value this phase.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/dd/ab/ddab7958-9dbb-4868-8bcf-fc975b66969b/swz01_heightened-perception.png",
-        "slots": ["Force Power"]
+        "slots": ["Force Power"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg"
       }
     ],
     "cost": { "value": 3 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
     "ffg_id": "XW_U_19"
   },
   {
@@ -27,12 +27,12 @@
         "type": "Force Power",
         "ability": "While you perform a special attack, you may spend 1 [Force] to ignore the [Focus] or [Lock] requirement.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/5f/c3/5fc32861-848c-4e40-8313-ecfc7b99e64d/swz01_instinctive-aim.png",
-        "slots": ["Force Power"]
+        "slots": ["Force Power"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_20.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_20.jpg"
       }
     ],
     "cost": { "value": 2 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_20.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_20.jpg",
     "ffg_id": "XW_U_20"
   },
   {
@@ -45,12 +45,12 @@
         "type": "Force Power",
         "ability": "During the System Phase, you may choose 1 ship at range 0-1 and look at its dial. If you spend 1 [Force], you may choose a ship at range 0-3 instead.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/0f/4d/0f4d0ae3-65aa-40f8-aa00-51f2cec053ad/swz01_sense.png",
-        "slots": ["Force Power"]
+        "slots": ["Force Power"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_21.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_21.jpg"
       }
     ],
     "cost": { "value": 6 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_21.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_21.jpg",
     "ffg_id": "XW_U_21"
   },
   {
@@ -63,13 +63,12 @@
         "type": "Force Power",
         "ability": "Before you activate, you may spend 1 [Force] to perform a [Barrel Roll] or [Boost] action. Then, if you performed an action you do not have on your action bar, suffer 1 [Hit] damage.",
         "slots": ["Force Power"],
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/17/1a/171aa533-6927-4c92-9a25-eea21390c1e9/swz01-supernatural-reflexes.png"
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_22.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_22.jpg"
       }
     ],
     "cost": { "value": 12 },
     "restrictions": [{ "sizes": ["Small"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_22.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_22.jpg",
     "ffg_id": "XW_U_22"
   }
 ]

--- a/data/upgrades/gunner.json
+++ b/data/upgrades/gunner.json
@@ -8,14 +8,13 @@
         "title": "Agile Gunner",
         "type": "Gunner",
         "ability": "During the End Phase, you may rotate your [Single Turret Arc] indicator.",
-        "slots": [
-          "Gunner"
-        ]
+        "slots": ["Gunner"]
       }
     ],
-    "cost": {
-      "value": 10
-    }
+    "cost": { "value": 10 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_162.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_162.jpg",
+    "ffg_id": "XW_U_162"
   },
   {
     "name": "BT-1",
@@ -27,22 +26,16 @@
         "type": "Gunner",
         "ability": "While you perform an attack, you may change 1 [Hit] result to a [Critical Hit] result for each stress token the defender has.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/36/b2/36b24ad0-46b2-47af-9710-77802f1a0ec1/swz08-bt-1.png",
-        "slots": [
-          "Gunner"
-        ]
+        "slots": ["Gunner"]
       }
     ],
-    "cost": {
-      "value": 2
-    },
+    "cost": { "value": 2 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ],
-        "names": ["Darth Vader"]
-      }
-    ]
+      { "factions": ["Scum and Villainy"], "names": ["Darth Vader"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_140.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_140.jpg",
+    "ffg_id": "XW_U_140"
   },
   {
     "name": "Bistan",
@@ -54,21 +47,14 @@
         "type": "Gunner",
         "ability": "After you perform a primary attack, if you are focused, you may perform a bonus [Single Turret Arc] attack against a ship you have not already attacked this round.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/32/78/3278c4b7-3fd3-4ebd-9a7a-0b7795cf6962/swz06-bistan-gunner.png",
-        "slots": [
-          "Gunner"
-        ]
+        "slots": ["Gunner"]
       }
     ],
-    "cost": {
-      "value": 14
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 14 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
+    "ffg_id": "XW_U_95"
   },
   {
     "name": "Bossk",
@@ -80,21 +66,14 @@
         "type": "Gunner",
         "ability": "After you perform a primary attack that misses, if you are not stressed, you must receive 1 stress token to perform a bonus primary attack against the same target.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/b0/67/b0671bc7-1508-4cd2-b54c-e9b797bad57c/swz08-bossk-gunner.png",
-        "slots": [
-          "Gunner"
-        ]
+        "slots": ["Gunner"]
       }
     ],
-    "cost": {
-      "value": 10
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 10 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
+    "ffg_id": "XW_U_139"
   },
   {
     "name": "Dengar",
@@ -106,25 +85,15 @@
         "type": "Gunner",
         "ability": "After you defend, if the attacker is in your firing arc, you may spend 1 [Charge]. If you do, roll 1 attack die unless the attacker chooses to remove 1 green token. On a [Hit] or [Critical Hit] result, the attacker suffers 1 [Hit] damage.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/8f/c5/8fc50081-9592-4670-8838-1c03f5c5f801/swz08-dengar-gunner.png",
-        "slots": [
-          "Gunner"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 1
-        }
+        "slots": ["Gunner"],
+        "charges": { "value": 1, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 6
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 6 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_141.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_141.jpg",
+    "ffg_id": "XW_U_141"
   },
   {
     "name": "Ezra Bridger",
@@ -136,25 +105,15 @@
         "type": "Gunner",
         "ability": "After you perform a primary attack, you may spend 1 [Force] to perform a bonus [Single Turret Arc] attack from a [Single Turret Arc] you have not attacked from this round. If you do and you are stressed, you may reroll 1 attack die.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/e9/0d/e90da994-48cc-4357-9d7e-6eab9f0532b8/swz06_a1_ezra-bridger.png",
-        "slots": [
-          "Gunner"
-        ],
-        "force": {
-          "value": 1,
-          "recovers": 1
-        }
+        "slots": ["Gunner"],
+        "force": { "value": 1, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 18
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 18 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_96.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_96.jpg",
+    "ffg_id": "XW_U_96"
   },
   {
     "name": "Fifth Brother",
@@ -166,25 +125,15 @@
         "type": "Gunner",
         "ability": "While you perform an attack, you may spend 1 [Force] to change 1 of your [Focus] results to a [Critical Hit] result.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/1a/28/1a280e27-ef94-445d-ba1f-2ec8067a3206/swz07-fifth-brother.png",
-        "slots": [
-          "Gunner"
-        ],
-        "force": {
-          "value": 1,
-          "recovers": 1
-        }
+        "slots": ["Gunner"],
+        "force": { "value": 1, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 12
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      }
-    ]
+    "cost": { "value": 12 },
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_122.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_122.jpg",
+    "ffg_id": "XW_U_122"
   },
   {
     "name": "Finn",
@@ -195,14 +144,10 @@
         "title": "Finn",
         "type": "Gunner",
         "ability": "While you defend or perform a primary attack, if the enemy is in your [Front Arc], you may add 1 blank result to your roll... ..can be rerolled or otherwise...",
-        "slots": [
-          "Gunner"
-        ]
+        "slots": ["Gunner"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Greedo",
@@ -214,25 +159,15 @@
         "type": "Gunner",
         "ability": "While you perform an attack, you may spend 1 [Charge] to change 1 [Hit] result to a [Critical Hit] result. While you defend, if your [Charge] is active, the attacker may change 1 [Hit] result to a [Critical Hit] result.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/73/02/730288e6-bebc-4a91-ae0b-7afbf426dd8b/swz08-greedo.png",
-        "slots": [
-          "Gunner"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 1
-        }
+        "slots": ["Gunner"],
+        "charges": { "value": 1, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 1
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 1 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_142.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_142.jpg",
+    "ffg_id": "XW_U_142"
   },
   {
     "name": "Han Solo",
@@ -244,21 +179,14 @@
         "type": "Gunner",
         "ability": "During the Engagement Phase, at initiative 7, you may perform a [Single Turret Arc] attack. You cannot attack from that [Single Turret Arc] again this round.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ed/f0/edf03758-4e07-49ba-a769-6b97aec950a3/swz06-han-solo-gunner.png",
-        "slots": [
-          "Gunner"
-        ]
+        "slots": ["Gunner"]
       }
     ],
-    "cost": {
-      "value": 12
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_163.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_163.jpg",
+    "ffg_id": "XW_U_163"
   },
   {
     "name": "Han Solo",
@@ -270,21 +198,14 @@
         "type": "Gunner",
         "ability": "Before you engage, you may perform a red [Focus] action.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ae/67/ae67c8a9-4dae-4da5-a1d5-5eadcb53f86a/swz04_a1_upgrade-card-han.png",
-        "slots": [
-          "Gunner"
-        ]
+        "slots": ["Gunner"]
       }
     ],
-    "cost": {
-      "value": 4
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_163.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_163.jpg",
+    "ffg_id": "XW_U_163"
   },
   {
     "name": "Hotshot Gunner",
@@ -295,14 +216,13 @@
         "title": "Hotshot Gunner",
         "type": "Gunner",
         "ability": "While you perform a [Single Turret Arc] attack, after the Modify Defense Dice step, the defender removes 1 focus or calculate token.",
-        "slots": [
-          "Gunner"
-        ]
+        "slots": ["Gunner"]
       }
     ],
-    "cost": {
-      "value": 7
-    }
+    "cost": { "value": 7 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
+    "ffg_id": "XW_U_49"
   },
   {
     "name": "Luke Skywalker",
@@ -314,25 +234,15 @@
         "type": "Gunner",
         "ability": "At the start of the Engagement Phase, you may spend 1 [Force] to rotate your [Single Turret Arc] indicator.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/29/d1/29d15d33-0300-4046-9eaa-5396466219bc/swz06-luke-skywalker-gunner.png",
-        "slots": [
-          "Gunner"
-        ],
-        "force": {
-          "value": 1,
-          "recovers": 1
-        }
+        "slots": ["Gunner"],
+        "force": { "value": 1, "recovers": 1 }
       }
     ],
-    "cost": {
-      "value": 30
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 30 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_98.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_98.jpg",
+    "ffg_id": "XW_U_98"
   },
   {
     "name": "Skilled Bombardier",
@@ -343,14 +253,13 @@
         "title": "Skilled Bombardier",
         "type": "Gunner",
         "ability": "If you would drop or launch a device, you may use a template of the same bearing with a speed 1 higher or lower.",
-        "slots": [
-          "Gunner"
-        ]
+        "slots": ["Gunner"]
       }
     ],
-    "cost": {
-      "value": 2
-    }
+    "cost": { "value": 2 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_50.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_50.jpg",
+    "ffg_id": "XW_U_50"
   },
   {
     "name": "Special Forces Gunner",
@@ -361,14 +270,10 @@
         "title": "Special Forces Gunner",
         "type": "Gunner",
         "ability": "...e you perform a primary [Front Arc] attack, ...your [Single Turret Arc] is in your [Front Arc], you may roll 1 additional attack die. ...er you perform a primary [Front Arc] attack, ...our [Single Turret Arc] is in your [Rear Arc], you may perform a bonus primary [Single Turret Arc] attack.",
-        "slots": [
-          "Gunner"
-        ]
+        "slots": ["Gunner"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Veteran Tail Gunner",
@@ -380,21 +285,14 @@
         "type": "Gunner",
         "ability": "After you perform a primary [Front Arc] attack, you may perform a bonus primary [Rear Arc] attack.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/5e/6d/5e6d5e43-8078-484b-86fc-1a267cd1cd86/swz16_veteran-tail-gunner.png",
-        "slots": [
-          "Gunner"
-        ]
+        "slots": ["Gunner"]
       }
     ],
-    "cost": {
-      "value": 4
-    },
-    "restrictions": [
-      {
-        "arcs": [
-          "Rear Arc"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "arcs": ["Rear Arc"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_51.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_51.jpg",
+    "ffg_id": "XW_U_51"
   },
   {
     "name": "Veteran Turret Gunner",
@@ -406,20 +304,13 @@
         "type": "Gunner",
         "ability": "After you perform a primary attack, you may perform a bonus [Single Turret Arc] attack using a [Single Turret Arc] you did not already attack from this round.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ee/11/ee11e853-cb91-4de2-9848-3274478dbfee/swz13_veteran-turret-gunner.png",
-        "slots": [
-          "Gunner"
-        ]
+        "slots": ["Gunner"]
       }
     ],
-    "cost": {
-      "value": 8
-    },
-    "restrictions": [
-      {
-        "action": {
-          "type": "Rotate Arc"
-        }
-      }
-    ]
+    "cost": { "value": 8 },
+    "restrictions": [{ "action": { "type": "Rotate Arc" } }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_52.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_52.jpg",
+    "ffg_id": "XW_U_52"
   }
 ]

--- a/data/upgrades/gunner.json
+++ b/data/upgrades/gunner.json
@@ -8,12 +8,12 @@
         "title": "Agile Gunner",
         "type": "Gunner",
         "ability": "During the End Phase, you may rotate your [Single Turret Arc] indicator.",
-        "slots": ["Gunner"]
+        "slots": ["Gunner"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_162.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_162.jpg"
       }
     ],
     "cost": { "value": 10 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_162.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_162.jpg",
     "ffg_id": "XW_U_162"
   },
   {
@@ -25,16 +25,15 @@
         "title": "BT-1",
         "type": "Gunner",
         "ability": "While you perform an attack, you may change 1 [Hit] result to a [Critical Hit] result for each stress token the defender has.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/36/b2/36b24ad0-46b2-47af-9710-77802f1a0ec1/swz08-bt-1.png",
-        "slots": ["Gunner"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_140.png",
+        "slots": ["Gunner"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_140.jpg"
       }
     ],
     "cost": { "value": 2 },
     "restrictions": [
       { "factions": ["Scum and Villainy"], "names": ["Darth Vader"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_140.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_140.jpg",
     "ffg_id": "XW_U_140"
   },
   {
@@ -47,13 +46,13 @@
         "type": "Gunner",
         "ability": "After you perform a primary attack, if you are focused, you may perform a bonus [Single Turret Arc] attack against a ship you have not already attacked this round.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/32/78/3278c4b7-3fd3-4ebd-9a7a-0b7795cf6962/swz06-bistan-gunner.png",
-        "slots": ["Gunner"]
+        "slots": ["Gunner"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg"
       }
     ],
     "cost": { "value": 14 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
     "ffg_id": "XW_U_95"
   },
   {
@@ -65,14 +64,13 @@
         "title": "Bossk",
         "type": "Gunner",
         "ability": "After you perform a primary attack that misses, if you are not stressed, you must receive 1 stress token to perform a bonus primary attack against the same target.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/b0/67/b0671bc7-1508-4cd2-b54c-e9b797bad57c/swz08-bossk-gunner.png",
-        "slots": ["Gunner"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
+        "slots": ["Gunner"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg"
       }
     ],
     "cost": { "value": 10 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
     "ffg_id": "XW_U_139"
   },
   {
@@ -84,15 +82,14 @@
         "title": "Dengar",
         "type": "Gunner",
         "ability": "After you defend, if the attacker is in your firing arc, you may spend 1 [Charge]. If you do, roll 1 attack die unless the attacker chooses to remove 1 green token. On a [Hit] or [Critical Hit] result, the attacker suffers 1 [Hit] damage.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/8f/c5/8fc50081-9592-4670-8838-1c03f5c5f801/swz08-dengar-gunner.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_141.png",
         "slots": ["Gunner"],
-        "charges": { "value": 1, "recovers": 1 }
+        "charges": { "value": 1, "recovers": 1 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_141.jpg"
       }
     ],
     "cost": { "value": 6 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_141.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_141.jpg",
     "ffg_id": "XW_U_141"
   },
   {
@@ -104,15 +101,14 @@
         "title": "Ezra Bridger",
         "type": "Gunner",
         "ability": "After you perform a primary attack, you may spend 1 [Force] to perform a bonus [Single Turret Arc] attack from a [Single Turret Arc] you have not attacked from this round. If you do and you are stressed, you may reroll 1 attack die.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/e9/0d/e90da994-48cc-4357-9d7e-6eab9f0532b8/swz06_a1_ezra-bridger.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_96.png",
         "slots": ["Gunner"],
-        "force": { "value": 1, "recovers": 1 }
+        "force": { "value": 1, "recovers": 1 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_96.jpg"
       }
     ],
     "cost": { "value": 18 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_96.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_96.jpg",
     "ffg_id": "XW_U_96"
   },
   {
@@ -124,15 +120,14 @@
         "title": "Fifth Brother",
         "type": "Gunner",
         "ability": "While you perform an attack, you may spend 1 [Force] to change 1 of your [Focus] results to a [Critical Hit] result.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/1a/28/1a280e27-ef94-445d-ba1f-2ec8067a3206/swz07-fifth-brother.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_122.png",
         "slots": ["Gunner"],
-        "force": { "value": 1, "recovers": 1 }
+        "force": { "value": 1, "recovers": 1 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_122.jpg"
       }
     ],
     "cost": { "value": 12 },
     "restrictions": [{ "factions": ["Galactic Empire"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_122.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_122.jpg",
     "ffg_id": "XW_U_122"
   },
   {
@@ -158,15 +153,14 @@
         "title": "Greedo",
         "type": "Gunner",
         "ability": "While you perform an attack, you may spend 1 [Charge] to change 1 [Hit] result to a [Critical Hit] result. While you defend, if your [Charge] is active, the attacker may change 1 [Hit] result to a [Critical Hit] result.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/73/02/730288e6-bebc-4a91-ae0b-7afbf426dd8b/swz08-greedo.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_142.png",
         "slots": ["Gunner"],
-        "charges": { "value": 1, "recovers": 1 }
+        "charges": { "value": 1, "recovers": 1 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_142.jpg"
       }
     ],
     "cost": { "value": 1 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_142.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_142.jpg",
     "ffg_id": "XW_U_142"
   },
   {
@@ -179,14 +173,14 @@
         "type": "Gunner",
         "ability": "During the Engagement Phase, at initiative 7, you may perform a [Single Turret Arc] attack. You cannot attack from that [Single Turret Arc] again this round.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ed/f0/edf03758-4e07-49ba-a769-6b97aec950a3/swz06-han-solo-gunner.png",
-        "slots": ["Gunner"]
+        "slots": ["Gunner"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_97.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_97.jpg"
       }
     ],
-    "cost": { "value": 4 },
+    "cost": { "value": 12 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_163.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_163.jpg",
-    "ffg_id": "XW_U_163"
+    "ffg_id": "XW_U_97"
   },
   {
     "name": "Han Solo",
@@ -198,13 +192,13 @@
         "type": "Gunner",
         "ability": "Before you engage, you may perform a red [Focus] action.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ae/67/ae67c8a9-4dae-4da5-a1d5-5eadcb53f86a/swz04_a1_upgrade-card-han.png",
-        "slots": ["Gunner"]
+        "slots": ["Gunner"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_163.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_163.jpg"
       }
     ],
     "cost": { "value": 4 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_163.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_163.jpg",
     "ffg_id": "XW_U_163"
   },
   {
@@ -216,12 +210,12 @@
         "title": "Hotshot Gunner",
         "type": "Gunner",
         "ability": "While you perform a [Single Turret Arc] attack, after the Modify Defense Dice step, the defender removes 1 focus or calculate token.",
-        "slots": ["Gunner"]
+        "slots": ["Gunner"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg"
       }
     ],
     "cost": { "value": 7 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
     "ffg_id": "XW_U_49"
   },
   {
@@ -235,13 +229,13 @@
         "ability": "At the start of the Engagement Phase, you may spend 1 [Force] to rotate your [Single Turret Arc] indicator.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/29/d1/29d15d33-0300-4046-9eaa-5396466219bc/swz06-luke-skywalker-gunner.png",
         "slots": ["Gunner"],
-        "force": { "value": 1, "recovers": 1 }
+        "force": { "value": 1, "recovers": 1 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_98.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_98.jpg"
       }
     ],
     "cost": { "value": 30 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_98.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_98.jpg",
     "ffg_id": "XW_U_98"
   },
   {
@@ -253,12 +247,12 @@
         "title": "Skilled Bombardier",
         "type": "Gunner",
         "ability": "If you would drop or launch a device, you may use a template of the same bearing with a speed 1 higher or lower.",
-        "slots": ["Gunner"]
+        "slots": ["Gunner"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_50.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_50.jpg"
       }
     ],
     "cost": { "value": 2 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_50.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_50.jpg",
     "ffg_id": "XW_U_50"
   },
   {
@@ -285,13 +279,13 @@
         "type": "Gunner",
         "ability": "After you perform a primary [Front Arc] attack, you may perform a bonus primary [Rear Arc] attack.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/5e/6d/5e6d5e43-8078-484b-86fc-1a267cd1cd86/swz16_veteran-tail-gunner.png",
-        "slots": ["Gunner"]
+        "slots": ["Gunner"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_51.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_51.jpg"
       }
     ],
     "cost": { "value": 4 },
     "restrictions": [{ "arcs": ["Rear Arc"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_51.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_51.jpg",
     "ffg_id": "XW_U_51"
   },
   {
@@ -304,13 +298,13 @@
         "type": "Gunner",
         "ability": "After you perform a primary attack, you may perform a bonus [Single Turret Arc] attack using a [Single Turret Arc] you did not already attack from this round.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ee/11/ee11e853-cb91-4de2-9848-3274478dbfee/swz13_veteran-turret-gunner.png",
-        "slots": ["Gunner"]
+        "slots": ["Gunner"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_52.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_52.jpg"
       }
     ],
     "cost": { "value": 8 },
     "restrictions": [{ "action": { "type": "Rotate Arc" } }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_52.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_52.jpg",
     "ffg_id": "XW_U_52"
   }
 ]

--- a/data/upgrades/illicit.json
+++ b/data/upgrades/illicit.json
@@ -8,15 +8,14 @@
         "title": "Cloaking Device",
         "type": "Illicit",
         "ability": "Action: Spend 1 [Charge] to perform a [Cloak] action. At the start of the Planning Phase, roll 1 attack die. On a [Focus] result, decloak or discard your cloak token.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/a0/c8/a0c8f9f4-49fa-43d0-b48d-1140394c084c/swz08-cloaking-device.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
         "slots": ["Illicit"],
-        "charges": { "value": 2, "recovers": 0 }
+        "charges": { "value": 2, "recovers": 0 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg"
       }
     ],
     "cost": { "value": 5 },
     "restrictions": [{ "sizes": ["Small", "Medium"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
     "ffg_id": "XW_U_57"
   },
   {
@@ -28,14 +27,13 @@
         "title": "Contraband Cybernetics",
         "type": "Illicit",
         "ability": "Before you activate, you may spend 1 [Charge]. If you do, until the end of the round, you can perform actions and execute red maneuvers, even while stressed.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/10/eb/10ebe5e0-a3cf-460e-87b4-de714fb53797/swz08-contraband-cybernetics.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
         "slots": ["Illicit"],
-        "charges": { "value": 1, "recovers": 0 }
+        "charges": { "value": 1, "recovers": 0 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg"
       }
     ],
     "cost": { "value": 5 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
     "ffg_id": "XW_U_58"
   },
   {
@@ -47,13 +45,12 @@
         "title": "Deadman's Switch",
         "type": "Illicit",
         "ability": "After you are destroyed, each other ship at range 0-1 suffers 1 [Hit] damage.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/1d/8b/1d8bd3de-7431-4957-a2b0-6afad2bf2447/swz08-deadmans-switch.png",
-        "slots": ["Illicit"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_59.png",
+        "slots": ["Illicit"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_59.jpg"
       }
     ],
     "cost": { "value": 2 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_59.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_59.jpg",
     "ffg_id": "XW_U_59"
   },
   {
@@ -65,13 +62,12 @@
         "title": "Feedback Array",
         "type": "Illicit",
         "ability": "Before you engage, you may gain 1 ion token and 1 disarm token. If you do, each ship at range 0 suffers 1 [Hit] damage.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/92/0a/920a27ad-ef0d-46b7-826a-297f77c1e0bd/swz08-feedback-array.png",
-        "slots": ["Illicit"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_60.png",
+        "slots": ["Illicit"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_60.jpg"
       }
     ],
     "cost": { "value": 4 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_60.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_60.jpg",
     "ffg_id": "XW_U_60"
   },
   {
@@ -83,13 +79,12 @@
         "title": "Inertial Dampeners",
         "type": "Illicit",
         "ability": "Before you would execute a maneuver, you may spend 1 shield. If you do, execute a white [0 [Stationary]] instead of the maneuver you revealed, then gain 1 stress token.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/cf/ac/cfac1539-0244-407f-9369-645ca6347a33/swz08-inertial-dampeners.png",
-        "slots": ["Illicit"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_61.png",
+        "slots": ["Illicit"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_61.jpg"
       }
     ],
     "cost": { "value": 1 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_61.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_61.jpg",
     "ffg_id": "XW_U_61"
   },
   {
@@ -101,15 +96,14 @@
         "title": "Rigged Cargo Chute",
         "type": "Illicit",
         "ability": "Action: Spend 1 [Charge]. Drop 1 loose cargo using the [1 [Straight]] template.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/64/47/6447a9f5-5c18-4543-81cb-79c032b87e04/swz08-rigged-cargo-chute.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_62.png",
         "slots": ["Illicit"],
-        "charges": { "value": 1, "recovers": 0 }
+        "charges": { "value": 1, "recovers": 0 },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_62.jpg"
       }
     ],
     "cost": { "value": 4 },
     "restrictions": [{ "sizes": ["Medium", "Large"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_62.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_62.jpg",
     "ffg_id": "XW_U_62"
   }
 ]

--- a/data/upgrades/illicit.json
+++ b/data/upgrades/illicit.json
@@ -9,26 +9,15 @@
         "type": "Illicit",
         "ability": "Action: Spend 1 [Charge] to perform a [Cloak] action. At the start of the Planning Phase, roll 1 attack die. On a [Focus] result, decloak or discard your cloak token.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/a0/c8/a0c8f9f4-49fa-43d0-b48d-1140394c084c/swz08-cloaking-device.png",
-        "slots": [
-          "Illicit"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        }
+        "slots": ["Illicit"],
+        "charges": { "value": 2, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 5
-    },
-    "restrictions": [
-      {
-        "sizes": [
-          "Small",
-          "Medium"
-        ]
-      }
-    ]
+    "cost": { "value": 5 },
+    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
+    "ffg_id": "XW_U_57"
   },
   {
     "name": "Contraband Cybernetics",
@@ -40,18 +29,14 @@
         "type": "Illicit",
         "ability": "Before you activate, you may spend 1 [Charge]. If you do, until the end of the round, you can perform actions and execute red maneuvers, even while stressed.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/10/eb/10ebe5e0-a3cf-460e-87b4-de714fb53797/swz08-contraband-cybernetics.png",
-        "slots": [
-          "Illicit"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 0
-        }
+        "slots": ["Illicit"],
+        "charges": { "value": 1, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 5
-    }
+    "cost": { "value": 5 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
+    "ffg_id": "XW_U_58"
   },
   {
     "name": "Deadman's Switch",
@@ -63,14 +48,13 @@
         "type": "Illicit",
         "ability": "After you are destroyed, each other ship at range 0-1 suffers 1 [Hit] damage.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/1d/8b/1d8bd3de-7431-4957-a2b0-6afad2bf2447/swz08-deadmans-switch.png",
-        "slots": [
-          "Illicit"
-        ]
+        "slots": ["Illicit"]
       }
     ],
-    "cost": {
-      "value": 2
-    }
+    "cost": { "value": 2 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_59.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_59.jpg",
+    "ffg_id": "XW_U_59"
   },
   {
     "name": "Feedback Array",
@@ -82,14 +66,13 @@
         "type": "Illicit",
         "ability": "Before you engage, you may gain 1 ion token and 1 disarm token. If you do, each ship at range 0 suffers 1 [Hit] damage.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/92/0a/920a27ad-ef0d-46b7-826a-297f77c1e0bd/swz08-feedback-array.png",
-        "slots": [
-          "Illicit"
-        ]
+        "slots": ["Illicit"]
       }
     ],
-    "cost": {
-      "value": 4
-    }
+    "cost": { "value": 4 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_60.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_60.jpg",
+    "ffg_id": "XW_U_60"
   },
   {
     "name": "Inertial Dampeners",
@@ -101,14 +84,13 @@
         "type": "Illicit",
         "ability": "Before you would execute a maneuver, you may spend 1 shield. If you do, execute a white [0 [Stationary]] instead of the maneuver you revealed, then gain 1 stress token.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/cf/ac/cfac1539-0244-407f-9369-645ca6347a33/swz08-inertial-dampeners.png",
-        "slots": [
-          "Illicit"
-        ]
+        "slots": ["Illicit"]
       }
     ],
-    "cost": {
-      "value": 1
-    }
+    "cost": { "value": 1 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_61.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_61.jpg",
+    "ffg_id": "XW_U_61"
   },
   {
     "name": "Rigged Cargo Chute",
@@ -120,25 +102,14 @@
         "type": "Illicit",
         "ability": "Action: Spend 1 [Charge]. Drop 1 loose cargo using the [1 [Straight]] template.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/64/47/6447a9f5-5c18-4543-81cb-79c032b87e04/swz08-rigged-cargo-chute.png",
-        "slots": [
-          "Illicit"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 0
-        }
+        "slots": ["Illicit"],
+        "charges": { "value": 1, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 4
-    },
-    "restrictions": [
-      {
-        "sizes": [
-          "Medium",
-          "Large"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "sizes": ["Medium", "Large"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_62.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_62.jpg",
+    "ffg_id": "XW_U_62"
   }
 ]

--- a/data/upgrades/missile.json
+++ b/data/upgrades/missile.json
@@ -8,14 +8,8 @@
         "title": "Barrage Rockets",
         "type": "Missile",
         "ability": "Attack ([Focus]): Spend 1 [Charge]. If the defender is in your [Bullseye Arc], you may spend 1 or more [Charge] to reroll that many attack dice.",
-        "slots": [
-          "Missile",
-          "Missile"
-        ],
-        "charges": {
-          "value": 5,
-          "recovers": 0
-        },
+        "slots": ["Missile", "Missile"],
+        "charges": { "value": 5, "recovers": 0 },
         "attack": {
           "arc": "Front Arc",
           "value": 3,
@@ -25,9 +19,10 @@
         }
       }
     ],
-    "cost": {
-      "value": 6
-    }
+    "cost": { "value": 6 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+    "ffg_id": "XW_U_36"
   },
   {
     "name": "Cluster Missiles",
@@ -39,13 +34,8 @@
         "type": "Missile",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. After this attack, you may perform this attack as a bonus attack against a different target at range 0-1 of the defender, ignoring the [Lock] requirement.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/f0/e3/f0e35feb-d783-4756-8753-a16f09a11aed/swz15_a1_cluster-missiles.png",
-        "slots": [
-          "Missile"
-        ],
-        "charges": {
-          "value": 4,
-          "recovers": 0
-        },
+        "slots": ["Missile"],
+        "charges": { "value": 4, "recovers": 0 },
         "attack": {
           "arc": "Front Arc",
           "value": 3,
@@ -55,9 +45,10 @@
         }
       }
     ],
-    "cost": {
-      "value": 5
-    }
+    "cost": { "value": 5 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
+    "ffg_id": "XW_U_37"
   },
   {
     "name": "Concussion Missiles",
@@ -69,13 +60,8 @@
         "type": "Missile",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. After this attack hits, each ship at range 0-1 of the defender exposes 1 of its damage cards.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/d2/df/d2dfb147-7b92-4d97-8d67-bda037fe356e/swz16_concussion-missiles.png",
-        "slots": [
-          "Missile"
-        ],
-        "charges": {
-          "value": 3,
-          "recovers": 0
-        },
+        "slots": ["Missile"],
+        "charges": { "value": 3, "recovers": 0 },
         "attack": {
           "arc": "Front Arc",
           "value": 3,
@@ -85,9 +71,10 @@
         }
       }
     ],
-    "cost": {
-      "value": 6
-    }
+    "cost": { "value": 6 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_38.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_38.jpg",
+    "ffg_id": "XW_U_38"
   },
   {
     "name": "Homing Missiles",
@@ -98,13 +85,8 @@
         "title": "Homing Missiles",
         "type": "Missile",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. After you declare the defender, the defender may choose to suffer 1 [Hit] damage. If it does, skip the Attack and Defense Dice steps and the attack is treated as hitting.",
-        "slots": [
-          "Missile"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        },
+        "slots": ["Missile"],
+        "charges": { "value": 2, "recovers": 0 },
         "attack": {
           "arc": "Front Arc",
           "value": 4,
@@ -114,9 +96,10 @@
         }
       }
     ],
-    "cost": {
-      "value": 3
-    }
+    "cost": { "value": 3 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_39.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_39.jpg",
+    "ffg_id": "XW_U_39"
   },
   {
     "name": "Ion Missiles",
@@ -127,13 +110,8 @@
         "title": "Ion Missiles",
         "type": "Missile",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
-        "slots": [
-          "Missile"
-        ],
-        "charges": {
-          "value": 3,
-          "recovers": 0
-        },
+        "slots": ["Missile"],
+        "charges": { "value": 3, "recovers": 0 },
         "attack": {
           "arc": "Front Arc",
           "value": 3,
@@ -143,9 +121,10 @@
         }
       }
     ],
-    "cost": {
-      "value": 4
-    }
+    "cost": { "value": 4 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_40.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_40.jpg",
+    "ffg_id": "XW_U_40"
   },
   {
     "name": "Proton Rockets",
@@ -157,13 +136,8 @@
         "type": "Missile",
         "ability": "Attack ([Focus]): Spend 1 [Charge].",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/32/c8/32c81aab-6817-44a1-918b-540a1641e59e/swz06_a1_proton-rockets.png",
-        "slots": [
-          "Missile"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 0
-        },
+        "slots": ["Missile"],
+        "charges": { "value": 1, "recovers": 0 },
         "attack": {
           "arc": "Bullseye Arc",
           "value": 5,
@@ -173,8 +147,9 @@
         }
       }
     ],
-    "cost": {
-      "value": 7
-    }
+    "cost": { "value": 7 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_41.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_41.jpg",
+    "ffg_id": "XW_U_41"
   }
 ]

--- a/data/upgrades/missile.json
+++ b/data/upgrades/missile.json
@@ -16,12 +16,12 @@
           "minrange": 2,
           "maxrange": 3,
           "ordnance": true
-        }
+        },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg"
       }
     ],
     "cost": { "value": 6 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
     "ffg_id": "XW_U_36"
   },
   {
@@ -42,12 +42,12 @@
           "minrange": 1,
           "maxrange": 2,
           "ordnance": true
-        }
+        },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg"
       }
     ],
     "cost": { "value": 5 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
     "ffg_id": "XW_U_37"
   },
   {
@@ -59,7 +59,7 @@
         "title": "Concussion Missiles",
         "type": "Missile",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. After this attack hits, each ship at range 0-1 of the defender exposes 1 of its damage cards.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/d2/df/d2dfb147-7b92-4d97-8d67-bda037fe356e/swz16_concussion-missiles.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_38.png",
         "slots": ["Missile"],
         "charges": { "value": 3, "recovers": 0 },
         "attack": {
@@ -68,12 +68,11 @@
           "minrange": 2,
           "maxrange": 3,
           "ordnance": true
-        }
+        },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_38.jpg"
       }
     ],
     "cost": { "value": 6 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_38.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_38.jpg",
     "ffg_id": "XW_U_38"
   },
   {
@@ -93,12 +92,12 @@
           "minrange": 2,
           "maxrange": 3,
           "ordnance": true
-        }
+        },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_39.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_39.jpg"
       }
     ],
     "cost": { "value": 3 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_39.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_39.jpg",
     "ffg_id": "XW_U_39"
   },
   {
@@ -118,12 +117,12 @@
           "minrange": 2,
           "maxrange": 3,
           "ordnance": true
-        }
+        },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_40.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_40.jpg"
       }
     ],
     "cost": { "value": 4 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_40.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_40.jpg",
     "ffg_id": "XW_U_40"
   },
   {
@@ -135,7 +134,7 @@
         "title": "Proton Rockets",
         "type": "Missile",
         "ability": "Attack ([Focus]): Spend 1 [Charge].",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/32/c8/32c81aab-6817-44a1-918b-540a1641e59e/swz06_a1_proton-rockets.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_41.png",
         "slots": ["Missile"],
         "charges": { "value": 1, "recovers": 0 },
         "attack": {
@@ -144,12 +143,11 @@
           "minrange": 1,
           "maxrange": 2,
           "ordnance": true
-        }
+        },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_41.jpg"
       }
     ],
     "cost": { "value": 7 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_41.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_41.jpg",
     "ffg_id": "XW_U_41"
   }
 ]

--- a/data/upgrades/modification.json
+++ b/data/upgrades/modification.json
@@ -9,13 +9,13 @@
         "type": "Modification",
         "ability": "Before you would suffer damage from an obstacle or from a friendly bomb detonating, you may spend 1 [Charge]. If you do, prevent 1 damage.",
         "slots": ["Modification"],
-        "charges": { "value": 2, "recovers": 0 }
+        "charges": { "value": 2, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg"
       }
     ],
     "cost": { "value": 4 },
     "restrictions": [{ "sizes": ["Medium", "Large"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
     "ffg_id": "XW_U_68"
   },
   {
@@ -27,13 +27,13 @@
         "title": "Advanced SLAM",
         "type": "Modification",
         "ability": "After you perform a [Slam] action, if you fully executed that maneuver, you may perform a white action on your action bar, treating that action as red.",
-        "slots": ["Modification"]
+        "slots": ["Modification"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg"
       }
     ],
     "cost": { "value": 3 },
     "restrictions": [{ "action": { "type": "SLAM", "difficulty": "White" } }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
     "ffg_id": "XW_U_69"
   },
   {
@@ -47,13 +47,13 @@
         "ability": "After you fully execute a speed 3-5 maneuver, you may spend 1 [Charge] to perform a [Boost] action, even while stressed.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/3c/3a/3c3a7d01-4552-4944-ad86-9902d141dd86/swz17_afterburners.png",
         "slots": ["Modification"],
-        "charges": { "value": 2, "recovers": 0 }
+        "charges": { "value": 2, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_70.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_70.jpg"
       }
     ],
     "cost": { "value": 8 },
     "restrictions": [{ "sizes": ["Small"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_70.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_70.jpg",
     "ffg_id": "XW_U_70"
   },
   {
@@ -65,12 +65,12 @@
         "title": "Electronic Baffle",
         "type": "Modification",
         "ability": "During the End Phase, you may suffer 1 [Hit] damage to remove 1 red token.",
-        "slots": ["Modification"]
+        "slots": ["Modification"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_71.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_71.jpg"
       }
     ],
     "cost": { "value": 2 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_71.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_71.jpg",
     "ffg_id": "XW_U_71"
   },
   {
@@ -90,13 +90,16 @@
             "value": { "type": "Boost", "difficulty": "White" },
             "amount": 1
           }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_72.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_72.jpg"
       }
     ],
-    "cost": { "value": null },
+    "cost": {
+      "variable": "size",
+      "values": { "Small": 3, "Medium": 6, "Large": 9 }
+    },
     "restrictions": [{ "action": { "type": "Boost", "difficulty": "Red" } }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_72.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_72.jpg",
     "ffg_id": "XW_U_72"
   },
   {
@@ -110,12 +113,15 @@
         "text": "For those who cannot afford an enhanced shield generator, bolting additional plates onto the hull of a ship can serve as an adequate substitute.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/84/f3/84f33996-8984-4fd7-806d-1014cbd91ab8/swz01_a7_hull-upgrade.png",
         "slots": ["Modification"],
-        "grants": [{ "type": "stat", "value": "hull", "amount": 1 }]
+        "grants": [{ "type": "stat", "value": "hull", "amount": 1 }],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg"
       }
     ],
-    "cost": { "value": null },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
+    "cost": {
+      "variable": "agility",
+      "values": { "0": 2, "1": 3, "2": 5, "3": 7 }
+    },
     "ffg_id": "XW_U_73"
   },
   {
@@ -127,12 +133,12 @@
         "title": "Munitions Failsafe",
         "type": "Modification",
         "ability": "While you perform a [Torpedo] or [Missile] attack, after rolling attack dice, you may cancel all dice results to recover 1 [Charge] you spent as a cost for the attack.",
-        "slots": ["Modification"]
+        "slots": ["Modification"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_74.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_74.jpg"
       }
     ],
     "cost": { "value": 2 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_74.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_74.jpg",
     "ffg_id": "XW_U_74"
   },
   {
@@ -151,12 +157,15 @@
           }
         ],
         "slots": ["Modification"],
-        "grants": [{ "type": "stat", "value": "shields", "amount": 1 }]
+        "grants": [{ "type": "stat", "value": "shields", "amount": 1 }],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_75.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_75.jpg"
       }
     ],
-    "cost": { "value": null },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_75.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_75.jpg",
+    "cost": {
+      "variable": "agility",
+      "values": { "0": 3, "1": 4, "2": 6, "3": 8 }
+    },
     "ffg_id": "XW_U_75"
   },
   {
@@ -168,12 +177,12 @@
         "title": "Static Discharge Vanes",
         "type": "Modification",
         "ability": "Before you would gain 1 ion or jam token, if you are not stressed, you may choose another ship at range 0-1 and gain 1 stress token. If you do, the chosen ship gains that ion or jam token instead.",
-        "slots": ["Modification"]
+        "slots": ["Modification"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_76.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_76.jpg"
       }
     ],
     "cost": { "value": 6 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_76.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_76.jpg",
     "ffg_id": "XW_U_76"
   },
   {
@@ -187,12 +196,15 @@
         "ability": "While you defend, if your [Charge] is active, roll 1 additional defense die. After you suffer damage, lose 1 [Charge].",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/8c/a1/8ca15a1e-3864-4245-8418-416030ac57ab/swz14_stealth-device.png",
         "slots": ["Modification"],
-        "charges": { "value": 1, "recovers": 0 }
+        "charges": { "value": 1, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_77.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_77.jpg"
       }
     ],
-    "cost": { "value": null },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_77.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_77.jpg",
+    "cost": {
+      "variable": "agility",
+      "values": { "0": 3, "1": 4, "2": 6, "3": 8 }
+    },
     "ffg_id": "XW_U_77"
   },
   {
@@ -204,13 +216,13 @@
         "title": "Tactical Scrambler",
         "type": "Modification",
         "ability": "While you obstruct an enemy ship's attack, the defender rolls 1 additional defense die.",
-        "slots": ["Modification"]
+        "slots": ["Modification"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_78.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_78.jpg"
       }
     ],
     "cost": { "value": 2 },
     "restrictions": [{ "sizes": ["Medium", "Large"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_78.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_78.jpg",
     "ffg_id": "XW_U_78"
   }
 ]

--- a/data/upgrades/modification.json
+++ b/data/upgrades/modification.json
@@ -8,26 +8,15 @@
         "title": "Ablative Plating",
         "type": "Modification",
         "ability": "Before you would suffer damage from an obstacle or from a friendly bomb detonating, you may spend 1 [Charge]. If you do, prevent 1 damage.",
-        "slots": [
-          "Modification"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        }
+        "slots": ["Modification"],
+        "charges": { "value": 2, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 4
-    },
-    "restrictions": [
-      {
-        "sizes": [
-          "Medium",
-          "Large"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "sizes": ["Medium", "Large"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
+    "ffg_id": "XW_U_68"
   },
   {
     "name": "Advanced SLAM",
@@ -38,22 +27,14 @@
         "title": "Advanced SLAM",
         "type": "Modification",
         "ability": "After you perform a [Slam] action, if you fully executed that maneuver, you may perform a white action on your action bar, treating that action as red.",
-        "slots": [
-          "Modification"
-        ]
+        "slots": ["Modification"]
       }
     ],
-    "cost": {
-      "value": 3
-    },
-    "restrictions": [
-      {
-        "action": {
-          "type": "SLAM",
-          "difficulty": "White"
-        }
-      }
-    ]
+    "cost": { "value": 3 },
+    "restrictions": [{ "action": { "type": "SLAM", "difficulty": "White" } }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
+    "ffg_id": "XW_U_69"
   },
   {
     "name": "Afterburners",
@@ -65,25 +46,15 @@
         "type": "Modification",
         "ability": "After you fully execute a speed 3-5 maneuver, you may spend 1 [Charge] to perform a [Boost] action, even while stressed.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/3c/3a/3c3a7d01-4552-4944-ad86-9902d141dd86/swz17_afterburners.png",
-        "slots": [
-          "Modification"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        }
+        "slots": ["Modification"],
+        "charges": { "value": 2, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 8
-    },
-    "restrictions": [
-      {
-        "sizes": [
-          "Small"
-        ]
-      }
-    ]
+    "cost": { "value": 8 },
+    "restrictions": [{ "sizes": ["Small"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_70.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_70.jpg",
+    "ffg_id": "XW_U_70"
   },
   {
     "name": "Electronic Baffle",
@@ -94,14 +65,13 @@
         "title": "Electronic Baffle",
         "type": "Modification",
         "ability": "During the End Phase, you may suffer 1 [Hit] damage to remove 1 red token.",
-        "slots": [
-          "Modification"
-        ]
+        "slots": ["Modification"]
       }
     ],
-    "cost": {
-      "value": 2
-    }
+    "cost": { "value": 2 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_71.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_71.jpg",
+    "ffg_id": "XW_U_71"
   },
   {
     "name": "Engine Upgrade",
@@ -112,43 +82,22 @@
         "title": "Engine Upgrade",
         "type": "Modification",
         "text": "Large military forces such as the Galactic Empire have standardized engines, but individual pilots and small organizations often replace the power couplings add thrusters, or use high-performance fuel to get extra push out of their engines.",
-        "slots": [
-          "Modification"
-        ],
-        "actions": [
-          {
-            "type": "Boost",
-            "difficulty": "White"
-          }
-        ],
+        "slots": ["Modification"],
+        "actions": [{ "type": "Boost", "difficulty": "White" }],
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Boost",
-              "difficulty": "White"
-            },
+            "value": { "type": "Boost", "difficulty": "White" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "variable": "size",
-      "values": {
-        "Small": 3,
-        "Medium": 6,
-        "Large": 9
-      }
-    },
-    "restrictions": [
-      {
-        "action": {
-          "type": "Boost",
-          "difficulty": "Red"
-        }
-      }
-    ]
+    "cost": { "value": null },
+    "restrictions": [{ "action": { "type": "Boost", "difficulty": "Red" } }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_72.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_72.jpg",
+    "ffg_id": "XW_U_72"
   },
   {
     "name": "Hull Upgrade",
@@ -161,24 +110,13 @@
         "text": "For those who cannot afford an enhanced shield generator, bolting additional plates onto the hull of a ship can serve as an adequate substitute.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/84/f3/84f33996-8984-4fd7-806d-1014cbd91ab8/swz01_a7_hull-upgrade.png",
         "slots": ["Modification"],
-        "grants": [
-          {
-            "type": "stat",
-            "value": "hull",
-            "amount": 1
-          }
-        ]
+        "grants": [{ "type": "stat", "value": "hull", "amount": 1 }]
       }
     ],
-    "cost": {
-      "variable": "agility",
-      "values": {
-        "0": 2,
-        "1": 3,
-        "2": 5,
-        "3": 7
-      }
-    }
+    "cost": { "value": null },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
+    "ffg_id": "XW_U_73"
   },
   {
     "name": "Munitions Failsafe",
@@ -189,14 +127,13 @@
         "title": "Munitions Failsafe",
         "type": "Modification",
         "ability": "While you perform a [Torpedo] or [Missile] attack, after rolling attack dice, you may cancel all dice results to recover 1 [Charge] you spent as a cost for the attack.",
-        "slots": [
-          "Modification"
-        ]
+        "slots": ["Modification"]
       }
     ],
-    "cost": {
-      "value": 2
-    }
+    "cost": { "value": 2 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_74.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_74.jpg",
+    "ffg_id": "XW_U_74"
   },
   {
     "name": "Shield Upgrade",
@@ -214,24 +151,13 @@
           }
         ],
         "slots": ["Modification"],
-        "grants": [
-          {
-            "type": "stat",
-            "value": "shields",
-            "amount": 1
-          }
-        ]
+        "grants": [{ "type": "stat", "value": "shields", "amount": 1 }]
       }
     ],
-    "cost": {
-      "variable": "agility",
-      "values": {
-        "0": 3,
-        "1": 4,
-        "2": 6,
-        "3": 8
-      }
-    }
+    "cost": { "value": null },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_75.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_75.jpg",
+    "ffg_id": "XW_U_75"
   },
   {
     "name": "Static Discharge Vanes",
@@ -242,14 +168,13 @@
         "title": "Static Discharge Vanes",
         "type": "Modification",
         "ability": "Before you would gain 1 ion or jam token, if you are not stressed, you may choose another ship at range 0-1 and gain 1 stress token. If you do, the chosen ship gains that ion or jam token instead.",
-        "slots": [
-          "Modification"
-        ]
+        "slots": ["Modification"]
       }
     ],
-    "cost": {
-      "value": 6
-    }
+    "cost": { "value": 6 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_76.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_76.jpg",
+    "ffg_id": "XW_U_76"
   },
   {
     "name": "Stealth Device",
@@ -261,24 +186,14 @@
         "type": "Modification",
         "ability": "While you defend, if your [Charge] is active, roll 1 additional defense die. After you suffer damage, lose 1 [Charge].",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/8c/a1/8ca15a1e-3864-4245-8418-416030ac57ab/swz14_stealth-device.png",
-        "slots": [
-          "Modification"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 0
-        }
+        "slots": ["Modification"],
+        "charges": { "value": 1, "recovers": 0 }
       }
     ],
-    "cost": {
-      "variable": "agility",
-      "values": {
-        "0": 3,
-        "1": 4,
-        "2": 6,
-        "3": 8
-      }
-    }
+    "cost": { "value": null },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_77.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_77.jpg",
+    "ffg_id": "XW_U_77"
   },
   {
     "name": "Tactical Scrambler",
@@ -289,21 +204,13 @@
         "title": "Tactical Scrambler",
         "type": "Modification",
         "ability": "While you obstruct an enemy ship's attack, the defender rolls 1 additional defense die.",
-        "slots": [
-          "Modification"
-        ]
+        "slots": ["Modification"]
       }
     ],
-    "cost": {
-      "value": 2
-    },
-    "restrictions": [
-      {
-        "sizes": [
-          "Medium",
-          "Large"
-        ]
-      }
-    ]
+    "cost": { "value": 2 },
+    "restrictions": [{ "sizes": ["Medium", "Large"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_78.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_78.jpg",
+    "ffg_id": "XW_U_78"
   }
 ]

--- a/data/upgrades/sensor.json
+++ b/data/upgrades/sensor.json
@@ -9,14 +9,13 @@
         "type": "Sensor",
         "ability": "After you reveal your dial, you may perform 1 action. If you do, you cannot perform another action during your activation.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/05/5e/055e3ce9-dfd8-4e37-9b04-fdba19dbd6dc/swz02_a1_advanced-sensors.png",
-        "slots": [
-          "Sensor"
-        ]
+        "slots": ["Sensor"]
       }
     ],
-    "cost": {
-      "value": 8
-    }
+    "cost": { "value": 8 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
+    "ffg_id": "XW_U_23"
   },
   {
     "name": "Collision Detector",
@@ -27,18 +26,14 @@
         "title": "Collision Detector",
         "type": "Sensor",
         "ability": "While you boost or barrel roll, you can move through and overlap obstacles. After you move through or overlap an obstacle, you may spend 1 [Charge] to ignore its effects until the end of the round.",
-        "slots": [
-          "Sensor"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        }
+        "slots": ["Sensor"],
+        "charges": { "value": 2, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 5
-    }
+    "cost": { "value": 5 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
+    "ffg_id": "XW_U_24"
   },
   {
     "name": "Fire-Control System",
@@ -49,15 +44,14 @@
         "title": "Fire-Control System",
         "type": "Sensor",
         "ability": "While you perform an attack, if you have a lock on the defender, you may reroll 1 attack die. If you do, you cannot spend your lock during this attack.",
-        "slots": [
-          "Sensor"
-        ],
+        "slots": ["Sensor"],
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/57/49/57493390-f170-452c-8428-3e7f87c32b89/swz15_a1_fire-control-system.png"
       }
     ],
-    "cost": {
-      "value": 3
-    }
+    "cost": { "value": 3 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_25.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_25.jpg",
+    "ffg_id": "XW_U_25"
   },
   {
     "name": "Trajectory Simulator",
@@ -68,13 +62,12 @@
         "title": "Trajectory Simulator",
         "type": "Sensor",
         "ability": "During the System Phase, if you would drop or launch a bomb, you may launch it using the [5 [Straight]] template instead.",
-        "slots": [
-          "Sensor"
-        ]
+        "slots": ["Sensor"]
       }
     ],
-    "cost": {
-      "value": 3
-    }
+    "cost": { "value": 3 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+    "ffg_id": "XW_U_26"
   }
 ]

--- a/data/upgrades/sensor.json
+++ b/data/upgrades/sensor.json
@@ -9,12 +9,12 @@
         "type": "Sensor",
         "ability": "After you reveal your dial, you may perform 1 action. If you do, you cannot perform another action during your activation.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/05/5e/055e3ce9-dfd8-4e37-9b04-fdba19dbd6dc/swz02_a1_advanced-sensors.png",
-        "slots": ["Sensor"]
+        "slots": ["Sensor"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg"
       }
     ],
     "cost": { "value": 8 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
     "ffg_id": "XW_U_23"
   },
   {
@@ -27,12 +27,12 @@
         "type": "Sensor",
         "ability": "While you boost or barrel roll, you can move through and overlap obstacles. After you move through or overlap an obstacle, you may spend 1 [Charge] to ignore its effects until the end of the round.",
         "slots": ["Sensor"],
-        "charges": { "value": 2, "recovers": 0 }
+        "charges": { "value": 2, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg"
       }
     ],
     "cost": { "value": 5 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
     "ffg_id": "XW_U_24"
   },
   {
@@ -45,12 +45,11 @@
         "type": "Sensor",
         "ability": "While you perform an attack, if you have a lock on the defender, you may reroll 1 attack die. If you do, you cannot spend your lock during this attack.",
         "slots": ["Sensor"],
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/57/49/57493390-f170-452c-8428-3e7f87c32b89/swz15_a1_fire-control-system.png"
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_25.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_25.jpg"
       }
     ],
     "cost": { "value": 3 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_25.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_25.jpg",
     "ffg_id": "XW_U_25"
   },
   {
@@ -62,12 +61,12 @@
         "title": "Trajectory Simulator",
         "type": "Sensor",
         "ability": "During the System Phase, if you would drop or launch a bomb, you may launch it using the [5 [Straight]] template instead.",
-        "slots": ["Sensor"]
+        "slots": ["Sensor"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg"
       }
     ],
     "cost": { "value": 3 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
     "ffg_id": "XW_U_26"
   }
 ]

--- a/data/upgrades/talent.json
+++ b/data/upgrades/talent.json
@@ -8,13 +8,13 @@
         "title": "Composure",
         "type": "Talent",
         "ability": "After you fail an action, if you have no green tokens, you may perform a [Focus] action.",
-        "slots": ["Talent"]
+        "slots": ["Talent"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg"
       }
     ],
     "cost": { "value": 2 },
     "restrictions": [{ "action": { "type": "Focus" } }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
     "ffg_id": "XW_U_156"
   },
   {
@@ -28,12 +28,12 @@
         "ability": "While you perform a primary attack, if the defender is in your [Bullseye Arc], before the Neutralize Results step, you may spend 1 [Charge] to cancel 1 [Evade] result.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/86/d9/86d9931b-ee81-4c50-af26-7115febef89d/swz01_a4_crackshot.png",
         "slots": ["Talent"],
-        "charges": { "value": 1, "recovers": 0 }
+        "charges": { "value": 1, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg"
       }
     ],
     "cost": { "value": 1 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
     "ffg_id": "XW_U_1"
   },
   {
@@ -46,7 +46,9 @@
         "type": "Talent",
         "ability": "While you perform a white [Boost] action, you may treat it as red to use the [1 [Turn Left]] or [1 [Turn Right]] template instead.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/55/65/55659ceb-e6e7-475b-aabd-1791e9854f3b/swz17_daredevil.png",
-        "slots": ["Talent"]
+        "slots": ["Talent"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg"
       }
     ],
     "cost": { "value": 3 },
@@ -54,8 +56,6 @@
       { "sizes": ["Small"] },
       { "action": { "type": "Boost", "difficulty": "White" } }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
     "ffg_id": "XW_U_2"
   },
   {
@@ -75,13 +75,13 @@
             "value": { "type": "Evade", "difficulty": "Red" },
             "amount": 1
           }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_3.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_3.jpg"
       }
     ],
     "cost": { "value": 2 },
     "restrictions": [{ "sizes": ["Small", "Medium"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_3.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_3.jpg",
     "ffg_id": "XW_U_3"
   },
   {
@@ -94,13 +94,13 @@
         "type": "Talent",
         "ability": "While you defend, you may spend 1 [Charge] to reroll 1 defense die. After you fully execute a red maneuver, recover 1 [Charge].",
         "slots": ["Talent"],
-        "charges": { "value": 1, "recovers": 0 }
+        "charges": { "value": 1, "recovers": 0 },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_4.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_4.jpg"
       }
     ],
     "cost": { "value": 3 },
     "restrictions": [{ "sizes": ["Small", "Medium"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_4.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_4.jpg",
     "ffg_id": "XW_U_4"
   },
   {
@@ -121,15 +121,18 @@
             "value": { "type": "Barrel Roll", "difficulty": "White" },
             "amount": 1
           }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_5.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_5.jpg"
       }
     ],
-    "cost": { "value": null },
+    "cost": {
+      "variable": "size",
+      "values": { "Small": 2, "Medium": 4, "Large": 6 }
+    },
     "restrictions": [
       { "action": { "type": "Barrel Roll", "difficulty": "Red" } }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_5.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_5.jpg",
     "ffg_id": "XW_U_5"
   },
   {
@@ -156,14 +159,13 @@
         "title": "Fearless",
         "type": "Talent",
         "ability": "While you perform a [Front Arc] primary attack, if the attack range is 1 and you are in the defender's [Front Arc], you may change 1 of your results to a [Hit] result.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/71/ac/71ac027a-ce78-409d-a05e-0d7795225a8c/swz08-fearless.png",
-        "slots": ["Talent"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_6.png",
+        "slots": ["Talent"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_6.jpg"
       }
     ],
     "cost": { "value": 3 },
     "restrictions": [{ "factions": ["Scum and Villainy"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_6.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_6.jpg",
     "ffg_id": "XW_U_6"
   },
   {
@@ -189,12 +191,12 @@
         "title": "Intimidation",
         "type": "Talent",
         "ability": "While an enemy ship at range 0 defends, it rolls 1 fewer defense die.",
-        "slots": ["Talent"]
+        "slots": ["Talent"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg"
       }
     ],
     "cost": { "value": 3 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
     "ffg_id": "XW_U_7"
   },
   {
@@ -207,19 +209,18 @@
         "type": "Talent",
         "ability": "While you perform an attack, if you are evading, you may change 1 of the defender's [Evade] results to a [Focus] result.",
         "slots": ["Talent"],
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/a3/57/a357f9aa-dc26-45d4-894f-b6ff33f05aab/swz14_juke.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_8.png",
         "alt": [
           {
             "image": "https://images-cdn.fantasyflightgames.com/filer_public/4c/e1/4ce1fe4d-b778-4dc9-8272-23aac7c3884d/g18xs_juke2nd.png",
             "source": "Store Championship 2018"
           }
-        ]
+        ],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_8.jpg"
       }
     ],
     "cost": { "value": 4 },
     "restrictions": [{ "sizes": ["Small", "Medium"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_8.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_8.jpg",
     "ffg_id": "XW_U_8"
   },
   {
@@ -233,12 +234,11 @@
         "ability": "While you defend or perform an attack, if there are no other friendly ships at range 0-2, you may spend 1 [Charge] to reroll 1 of your dice.",
         "slots": ["Talent"],
         "charges": { "value": 1, "recovers": 1 },
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/97/aa/97aadf7e-f0bf-460f-9030-2ffb005dc8ab/swz16_lone-wolf.png"
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg"
       }
     ],
     "cost": { "value": 4 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
     "ffg_id": "XW_U_9"
   },
   {
@@ -251,12 +251,12 @@
         "type": "Talent",
         "ability": "While you perform an attack, if the defender is in your [Bullseye Arc], you may change 1 [Hit] result to a [Critical Hit] result.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/1a/55/1a5549b4-e246-4409-8064-52b22f454c4d/swz01_a4_marksmanship.png",
-        "slots": ["Talent"]
+        "slots": ["Talent"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_10.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_10.jpg"
       }
     ],
     "cost": { "value": 1 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_10.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_10.jpg",
     "ffg_id": "XW_U_10"
   },
   {
@@ -269,12 +269,12 @@
         "type": "Talent",
         "ability": "While you perform a [Front Arc] arrack, if you are not in the defender's firing arc, the defender rolls 1 fewer defense die.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/1d/f4/1df42725-46a8-45ff-8fd2-d8b649f0510c/swz01_a7_outmaneuver.png",
-        "slots": ["Talent"]
+        "slots": ["Talent"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg"
       }
     ],
     "cost": { "value": 6 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
     "ffg_id": "XW_U_11"
   },
   {
@@ -287,12 +287,11 @@
         "type": "Talent",
         "ability": "While you perform a primary attack, if the defender is in your [Bullseye Arc], you may reroll 1 attack die.",
         "slots": ["Talent"],
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/f9/a4/f9a40266-f33e-4080-becd-44baa827c831/swz08_a1_predator.png"
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_12.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_12.jpg"
       }
     ],
     "cost": { "value": 2 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_12.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_12.jpg",
     "ffg_id": "XW_U_12"
   },
   {
@@ -304,14 +303,13 @@
         "title": "Ruthless",
         "type": "Talent",
         "ability": "While you perform an attack, you may choose another friendly ship at range 0-1 of the defender. If you do, that ship suffers 1 [Hit] damage and you may change 1 of your die results to a [Hit] result.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/42/01/42018820-f3e5-4f11-8a95-e5ebbf1d9fd9/swz07-ruthless.png",
-        "slots": ["Talent"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_13.png",
+        "slots": ["Talent"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_13.jpg"
       }
     ],
     "cost": { "value": 1 },
     "restrictions": [{ "factions": ["Galactic Empire"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_13.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_13.jpg",
     "ffg_id": "XW_U_13"
   },
   {
@@ -323,13 +321,13 @@
         "title": "Saturation Salvo",
         "type": "Talent",
         "ability": "While you perform a [Torpedo] or [Missile] attack, you may spend 1 charge from that upgrade. If you do, choose two defence dice. The defender must reroll those dice.",
-        "slots": ["Talent"]
+        "slots": ["Talent"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_14.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_14.jpg"
       }
     ],
     "cost": { "value": 6 },
     "restrictions": [{ "action": { "type": "Reload" } }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_14.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_14.jpg",
     "ffg_id": "XW_U_14"
   },
   {
@@ -341,14 +339,13 @@
         "title": "Selfless",
         "type": "Talent",
         "ability": "While another friendly ship at range 0-1 defends, before the Neutralize Results step, if you are in the attack arc, you may suffer 1 [Critical Hit] damage to cancel 1 [Critical Hit] result.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/dd/ff/ddff7918-ccd9-4dd6-b7f5-ecfe7d5b2e9e/swz06-selfless.png",
-        "slots": ["Talent"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_15.png",
+        "slots": ["Talent"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_15.jpg"
       }
     ],
     "cost": { "value": 3 },
     "restrictions": [{ "factions": ["Rebel Alliance"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_15.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_15.jpg",
     "ffg_id": "XW_U_15"
   },
   {
@@ -369,12 +366,12 @@
             "value": { "type": "Coordinate", "difficulty": "Red" },
             "amount": 1
           }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg"
       }
     ],
     "cost": { "value": 4 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
     "ffg_id": "XW_U_16"
   },
   {
@@ -386,12 +383,12 @@
         "title": "Swarm Tactics",
         "type": "Talent",
         "ability": "At the start of the Engagement Phase, you may choose 1 friendly ship at range 1. If you do, that ship treats its initiative as equal to yours until the end of the round.",
-        "slots": ["Talent"]
+        "slots": ["Talent"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_17.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_17.jpg"
       }
     ],
     "cost": { "value": 3 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_17.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_17.jpg",
     "ffg_id": "XW_U_17"
   },
   {
@@ -404,12 +401,12 @@
         "type": "Talent",
         "ability": "While you perform an attack that is obstructed by an obstacle, roll 1 additional attack die.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ba/22/ba226a64-5ba6-481c-a576-921a3a00f9e5/swz02_a1_trick-shot.png",
-        "slots": ["Talent"]
+        "slots": ["Talent"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg"
       }
     ],
     "cost": { "value": 1 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
     "ffg_id": "XW_U_18"
   }
 ]

--- a/data/upgrades/talent.json
+++ b/data/upgrades/talent.json
@@ -8,21 +8,14 @@
         "title": "Composure",
         "type": "Talent",
         "ability": "After you fail an action, if you have no green tokens, you may perform a [Focus] action.",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 2
-    },
-    "restrictions": [
-      {
-        "action": {
-          "type": "Focus"
-        }
-      }
-    ]
+    "cost": { "value": 2 },
+    "restrictions": [{ "action": { "type": "Focus" } }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+    "ffg_id": "XW_U_156"
   },
   {
     "name": "Crack Shot",
@@ -34,18 +27,14 @@
         "type": "Talent",
         "ability": "While you perform a primary attack, if the defender is in your [Bullseye Arc], before the Neutralize Results step, you may spend 1 [Charge] to cancel 1 [Evade] result.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/86/d9/86d9931b-ee81-4c50-af26-7115febef89d/swz01_a4_crackshot.png",
-        "slots": [
-          "Talent"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 0
-        }
+        "slots": ["Talent"],
+        "charges": { "value": 1, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 1
-    }
+    "cost": { "value": 1 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
+    "ffg_id": "XW_U_1"
   },
   {
     "name": "Daredevil",
@@ -57,27 +46,17 @@
         "type": "Talent",
         "ability": "While you perform a white [Boost] action, you may treat it as red to use the [1 [Turn Left]] or [1 [Turn Right]] template instead.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/55/65/55659ceb-e6e7-475b-aabd-1791e9854f3b/swz17_daredevil.png",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 3
-    },
+    "cost": { "value": 3 },
     "restrictions": [
-      {
-        "sizes": [
-          "Small"
-        ]
-      },
-      {
-        "action": {
-          "type": "Boost",
-          "difficulty": "White"
-        }
-      }
-    ]
+      { "sizes": ["Small"] },
+      { "action": { "type": "Boost", "difficulty": "White" } }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
+    "ffg_id": "XW_U_2"
   },
   {
     "name": "Debris Gambit",
@@ -88,38 +67,22 @@
         "title": "Debris Gambit",
         "type": "Talent",
         "ability": "While you perform a red [Evade] action, if there is an obstacle at range 0-1, treat the action as white instead.",
-        "slots": [
-          "Talent"
-        ],
-        "actions": [
-          {
-            "type": "Evade",
-            "difficulty": "Red"
-          }
-        ],
+        "slots": ["Talent"],
+        "actions": [{ "type": "Evade", "difficulty": "Red" }],
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Evade",
-              "difficulty": "Red"
-            },
+            "value": { "type": "Evade", "difficulty": "Red" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "value": 2
-    },
-    "restrictions": [
-      {
-        "sizes": [
-          "Small",
-          "Medium"
-        ]
-      }
-    ]
+    "cost": { "value": 2 },
+    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_3.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_3.jpg",
+    "ffg_id": "XW_U_3"
   },
   {
     "name": "Elusive",
@@ -130,26 +93,15 @@
         "title": "Elusive",
         "type": "Talent",
         "ability": "While you defend, you may spend 1 [Charge] to reroll 1 defense die. After you fully execute a red maneuver, recover 1 [Charge].",
-        "slots": [
-          "Talent"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 0
-        }
+        "slots": ["Talent"],
+        "charges": { "value": 1, "recovers": 0 }
       }
     ],
-    "cost": {
-      "value": 3
-    },
-    "restrictions": [
-      {
-        "sizes": [
-          "Small",
-          "Medium"
-        ]
-      }
-    ]
+    "cost": { "value": 3 },
+    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_4.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_4.jpg",
+    "ffg_id": "XW_U_4"
   },
   {
     "name": "Expert Handling",
@@ -161,43 +113,24 @@
         "type": "Talent",
         "text": "While heavy fighters can often be coaxed into a barrel roll, seasoned pilots know how to do it without putting undue stress on their craft or leaving themselves open to attack.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ca/54/ca54d4e0-7d84-4171-b685-c3b10772dd78/swz01_a5_expert-handling.png",
-        "slots": [
-          "Talent"
-        ],
-        "actions": [
-          {
-            "type": "Barrel Roll",
-            "difficulty": "White"
-          }
-        ],
+        "slots": ["Talent"],
+        "actions": [{ "type": "Barrel Roll", "difficulty": "White" }],
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Barrel Roll",
-              "difficulty": "White"
-            },
+            "value": { "type": "Barrel Roll", "difficulty": "White" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "variable": "size",
-      "values": {
-        "Small": 2,
-        "Medium": 4,
-        "Large": 6
-      }
-    },
+    "cost": { "value": null },
     "restrictions": [
-      {
-        "action": {
-          "type": "Barrel Roll",
-          "difficulty": "Red"
-        }
-      }
-    ]
+      { "action": { "type": "Barrel Roll", "difficulty": "Red" } }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_5.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_5.jpg",
+    "ffg_id": "XW_U_5"
   },
   {
     "name": "Fanatical",
@@ -209,14 +142,10 @@
         "type": "Talent",
         "ability": "While you perform a primary attack, if you are not shielded, you may change 1 [Focus] result to a [Hit] result.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/6d/44/6d440bea-11dd-4e4c-b7ef-167a4b6d23e2/swz18_a1_fanatical.png",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Fearless",
@@ -228,21 +157,14 @@
         "type": "Talent",
         "ability": "While you perform a [Front Arc] primary attack, if the attack range is 1 and you are in the defender's [Front Arc], you may change 1 of your results to a [Hit] result.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/71/ac/71ac027a-ce78-409d-a05e-0d7795225a8c/swz08-fearless.png",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 3
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      }
-    ]
+    "cost": { "value": 3 },
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_6.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_6.jpg",
+    "ffg_id": "XW_U_6"
   },
   {
     "name": "Heroic",
@@ -253,14 +175,10 @@
         "title": "Heroic",
         "type": "Talent",
         "ability": "While you defend or perform an attack, if you have only blank results and have 2 or more results, you may reroll any number of your dice.",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Intimidation",
@@ -271,14 +189,13 @@
         "title": "Intimidation",
         "type": "Talent",
         "ability": "While an enemy ship at range 0 defends, it rolls 1 fewer defense die.",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 3
-    }
+    "cost": { "value": 3 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
+    "ffg_id": "XW_U_7"
   },
   {
     "name": "Juke",
@@ -289,9 +206,7 @@
         "title": "Juke",
         "type": "Talent",
         "ability": "While you perform an attack, if you are evading, you may change 1 of the defender's [Evade] results to a [Focus] result.",
-        "slots": [
-          "Talent"
-        ],
+        "slots": ["Talent"],
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/a3/57/a357f9aa-dc26-45d4-894f-b6ff33f05aab/swz14_juke.png",
         "alt": [
           {
@@ -301,17 +216,11 @@
         ]
       }
     ],
-    "cost": {
-      "value": 4
-    },
-    "restrictions": [
-      {
-        "sizes": [
-          "Small",
-          "Medium"
-        ]
-      }
-    ]
+    "cost": { "value": 4 },
+    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_8.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_8.jpg",
+    "ffg_id": "XW_U_8"
   },
   {
     "name": "Lone Wolf",
@@ -322,19 +231,15 @@
         "title": "Lone Wolf",
         "type": "Talent",
         "ability": "While you defend or perform an attack, if there are no other friendly ships at range 0-2, you may spend 1 [Charge] to reroll 1 of your dice.",
-        "slots": [
-          "Talent"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 1
-        },
+        "slots": ["Talent"],
+        "charges": { "value": 1, "recovers": 1 },
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/97/aa/97aadf7e-f0bf-460f-9030-2ffb005dc8ab/swz16_lone-wolf.png"
       }
     ],
-    "cost": {
-      "value": 4
-    }
+    "cost": { "value": 4 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
+    "ffg_id": "XW_U_9"
   },
   {
     "name": "Marksmanship",
@@ -346,14 +251,13 @@
         "type": "Talent",
         "ability": "While you perform an attack, if the defender is in your [Bullseye Arc], you may change 1 [Hit] result to a [Critical Hit] result.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/1a/55/1a5549b4-e246-4409-8064-52b22f454c4d/swz01_a4_marksmanship.png",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 1
-    }
+    "cost": { "value": 1 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_10.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_10.jpg",
+    "ffg_id": "XW_U_10"
   },
   {
     "name": "Outmaneuver",
@@ -365,14 +269,13 @@
         "type": "Talent",
         "ability": "While you perform a [Front Arc] arrack, if you are not in the defender's firing arc, the defender rolls 1 fewer defense die.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/1d/f4/1df42725-46a8-45ff-8fd2-d8b649f0510c/swz01_a7_outmaneuver.png",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 6
-    }
+    "cost": { "value": 6 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
+    "ffg_id": "XW_U_11"
   },
   {
     "name": "Predator",
@@ -383,15 +286,14 @@
         "title": "Predator",
         "type": "Talent",
         "ability": "While you perform a primary attack, if the defender is in your [Bullseye Arc], you may reroll 1 attack die.",
-        "slots": [
-          "Talent"
-        ],
+        "slots": ["Talent"],
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/f9/a4/f9a40266-f33e-4080-becd-44baa827c831/swz08_a1_predator.png"
       }
     ],
-    "cost": {
-      "value": 2
-    }
+    "cost": { "value": 2 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_12.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_12.jpg",
+    "ffg_id": "XW_U_12"
   },
   {
     "name": "Ruthless",
@@ -403,21 +305,14 @@
         "type": "Talent",
         "ability": "While you perform an attack, you may choose another friendly ship at range 0-1 of the defender. If you do, that ship suffers 1 [Hit] damage and you may change 1 of your die results to a [Hit] result.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/42/01/42018820-f3e5-4f11-8a95-e5ebbf1d9fd9/swz07-ruthless.png",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 1
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      }
-    ]
+    "cost": { "value": 1 },
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_13.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_13.jpg",
+    "ffg_id": "XW_U_13"
   },
   {
     "name": "Saturation Salvo",
@@ -428,21 +323,14 @@
         "title": "Saturation Salvo",
         "type": "Talent",
         "ability": "While you perform a [Torpedo] or [Missile] attack, you may spend 1 charge from that upgrade. If you do, choose two defence dice. The defender must reroll those dice.",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 6
-    },
-    "restrictions": [
-      {
-        "action": {
-          "type": "Reload"
-        }
-      }
-    ]
+    "cost": { "value": 6 },
+    "restrictions": [{ "action": { "type": "Reload" } }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_14.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_14.jpg",
+    "ffg_id": "XW_U_14"
   },
   {
     "name": "Selfless",
@@ -454,21 +342,14 @@
         "type": "Talent",
         "ability": "While another friendly ship at range 0-1 defends, before the Neutralize Results step, if you are in the attack arc, you may suffer 1 [Critical Hit] damage to cancel 1 [Critical Hit] result.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/dd/ff/ddff7918-ccd9-4dd6-b7f5-ecfe7d5b2e9e/swz06-selfless.png",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 3
-    },
-    "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      }
-    ]
+    "cost": { "value": 3 },
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_15.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_15.jpg",
+    "ffg_id": "XW_U_15"
   },
   {
     "name": "Squad Leader",
@@ -480,30 +361,21 @@
         "type": "Talent",
         "ability": "While you coordinate, the ship you choose can perform an action only if that action is also on your action bar.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/c3/5b/c35b9f4e-0a97-491c-9476-ab6fdb512ded/swz15_a1_squad-leader.png",
-        "slots": [
-          "Talent"
-        ],
-        "actions": [
-          {
-            "type": "Coordinate",
-            "difficulty": "Red"
-          }
-        ],
+        "slots": ["Talent"],
+        "actions": [{ "type": "Coordinate", "difficulty": "Red" }],
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Coordinate",
-              "difficulty": "Red"
-            },
+            "value": { "type": "Coordinate", "difficulty": "Red" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "value": 4
-    }
+    "cost": { "value": 4 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
+    "ffg_id": "XW_U_16"
   },
   {
     "name": "Swarm Tactics",
@@ -514,14 +386,13 @@
         "title": "Swarm Tactics",
         "type": "Talent",
         "ability": "At the start of the Engagement Phase, you may choose 1 friendly ship at range 1. If you do, that ship treats its initiative as equal to yours until the end of the round.",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 3
-    }
+    "cost": { "value": 3 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_17.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_17.jpg",
+    "ffg_id": "XW_U_17"
   },
   {
     "name": "Trick Shot",
@@ -533,13 +404,12 @@
         "type": "Talent",
         "ability": "While you perform an attack that is obstructed by an obstacle, roll 1 additional attack die.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/ba/22/ba226a64-5ba6-481c-a576-921a3a00f9e5/swz02_a1_trick-shot.png",
-        "slots": [
-          "Talent"
-        ]
+        "slots": ["Talent"]
       }
     ],
-    "cost": {
-      "value": 1
-    }
+    "cost": { "value": 1 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
+    "ffg_id": "XW_U_18"
   }
 ]

--- a/data/upgrades/tech.json
+++ b/data/upgrades/tech.json
@@ -8,14 +8,10 @@
         "title": "Advanced Optics",
         "type": "Tech",
         "ability": "While you perform an attack, you may spend 1 focus token to change 1 of your blank results to a [Hit] result.",
-        "slots": [
-          "Tech"
-        ]
+        "slots": ["Tech"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Ferrosphere Paint",
@@ -26,14 +22,10 @@
         "title": "Ferrosphere Paint",
         "type": "Tech",
         "ability": "???",
-        "slots": [
-          "Tech"
-        ]
+        "slots": ["Tech"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Hyperspace Tracking Data",
@@ -44,14 +36,10 @@
         "title": "Hyperspace Tracking Data",
         "type": "Tech",
         "ability": "Setup: Before placing forces, you may... 0 and 6...",
-        "slots": [
-          "Tech"
-        ]
+        "slots": ["Tech"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Primed Thrusters",
@@ -63,14 +51,10 @@
         "type": "Tech",
         "ability": "While you have 2 or fewer stress tokens, you can perform [Barrel Roll] and [Boost] actions even while stressed.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/86/a1/86a1115b-eb55-491b-84e4-67e2b6124999/swz19_a1_primed-thrusters.png",
-        "slots": [
-          "Tech"
-        ]
+        "slots": ["Tech"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Targeting Synchronizer",
@@ -82,13 +66,9 @@
         "type": "Tech",
         "ability": "While a friendly ship at range 1-2 performs an attack against a target you have locked, that ship ignores the [Lock] attack requirement.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/3a/f7/3af7d426-c7f1-456e-b2e7-dfb3b735f9da/swz19_a1_targeting-synchronizer.png",
-        "slots": [
-          "Tech"
-        ]
+        "slots": ["Tech"]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   }
 ]

--- a/data/upgrades/title.json
+++ b/data/upgrades/title.json
@@ -18,7 +18,9 @@
             "value": { "type": "Reload", "difficulty": "White" },
             "amount": 1
           }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_146.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_146.jpg"
       }
     ],
     "cost": { "value": 6 },
@@ -26,8 +28,6 @@
       { "factions": ["Scum and Villainy"] },
       { "ships": ["firesprayclasspatrolcraft"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_146.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_146.jpg",
     "ffg_id": "XW_U_146"
   },
   {
@@ -55,8 +55,9 @@
         "title": "Dauntless",
         "type": "Title",
         "ability": "After you partially execute a maneuver, you may perform 1 white action, treating that action as red.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/8b/a7/8ba7e5da-f36f-4db8-8632-07270e1e5dd5/swz07-dauntless.png",
-        "slots": ["Title"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_123.png",
+        "slots": ["Title"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_123.jpg"
       }
     ],
     "cost": { "value": 6 },
@@ -64,8 +65,6 @@
       { "factions": ["Galactic Empire"] },
       { "ships": ["vt49decimator"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_123.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_123.jpg",
     "ffg_id": "XW_U_123"
   },
   {
@@ -77,8 +76,9 @@
         "title": "Ghost",
         "type": "Title",
         "ability": "You can dock 1 attack shuttle or Sheathipede-class shuttle. Your docked ships can deploy only from your rear guides.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/76/ab/76abeac7-3d64-4156-9fc8-4e4685ef3d9a/swz06_a1_ghost.png",
-        "slots": ["Title"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
+        "slots": ["Title"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg"
       }
     ],
     "cost": { "value": 0 },
@@ -86,8 +86,6 @@
       { "factions": ["Rebel Alliance"] },
       { "ships": ["vcx100lightfreighter"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
     "ffg_id": "XW_U_102"
   },
   {
@@ -104,7 +102,9 @@
           { "type": "slot", "value": "Sensor", "amount": 1 },
           { "type": "slot", "value": "Astromech", "amount": 1 },
           { "type": "slot", "value": "Crew", "amount": -1 }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_147.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_147.jpg"
       }
     ],
     "cost": { "value": 4 },
@@ -112,8 +112,6 @@
       { "factions": ["Scum and Villainy"] },
       { "ships": ["scurrgh6bomber"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_147.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_147.jpg",
     "ffg_id": "XW_U_147"
   },
   {
@@ -125,7 +123,9 @@
         "title": "Hound's Tooth",
         "type": "Title",
         "ability": "1 Z-95 AF4 headhunter can dock with you.",
-        "slots": ["Title"]
+        "slots": ["Title"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg"
       }
     ],
     "cost": { "value": 1 },
@@ -133,8 +133,6 @@
       { "factions": ["Scum and Villainy"] },
       { "ships": ["yv666lightfreighter"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
     "ffg_id": "XW_U_148"
   },
   {
@@ -146,7 +144,9 @@
         "title": "IG-2000",
         "type": "Title",
         "ability": "You have the pilot ability of each other friendly ship with the IG-2000 upgrade.",
-        "slots": ["Title"]
+        "slots": ["Title"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg"
       }
     ],
     "cost": { "value": 2 },
@@ -154,8 +154,6 @@
       { "factions": ["Scum and Villainy"] },
       { "ships": ["aggressorassaultfighter"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
     "ffg_id": "XW_U_149"
   },
   {
@@ -168,7 +166,9 @@
         "type": "Title",
         "ability": "1 Escape Craft may dock with you. While you have an Escape Craft docked, you may spend its shields as if they were on your ship card. While you perform a primary attack against a stressed ship, roll 1 additional attack die.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/8d/a8/8da88777-3792-4da4-839e-ea7bfbbd5545/swz04_landos-millennium-falcon.png",
-        "slots": ["Title"]
+        "slots": ["Title"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_164.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_164.jpg"
       }
     ],
     "cost": { "value": 6 },
@@ -176,8 +176,6 @@
       { "factions": ["Scum and Villainy"] },
       { "ships": ["customizedyt1300lightfreighter"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_164.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_164.jpg",
     "ffg_id": "XW_U_164"
   },
   {
@@ -191,7 +189,9 @@
         "ability": "While you perform a primary [Rear Arc] attack,, you may reroll 1 attack die. Add [Gunner] slot.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/65/27/652749d7-13b1-4e68-a4cc-b34074a654c5/swz16_marauder.png",
         "slots": ["Title"],
-        "grants": [{ "type": "slot", "value": "Gunner", "amount": 1 }]
+        "grants": [{ "type": "slot", "value": "Gunner", "amount": 1 }],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_150.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_150.jpg"
       }
     ],
     "cost": { "value": 3 },
@@ -199,8 +199,6 @@
       { "factions": ["Scum and Villainy"] },
       { "ships": ["firesprayclasspatrolcraft"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_150.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_150.jpg",
     "ffg_id": "XW_U_150"
   },
   {
@@ -212,7 +210,7 @@
         "title": "Millennium Falcon",
         "type": "Title",
         "ability": "While you defend, if you are evading, you may reroll 1 defense die.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/31/27/3127e956-1a6c-4a8f-bae6-b1ca1c54390d/swz06-millennium-falcon.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_103.png",
         "slots": ["Title"],
         "actions": [{ "type": "Evade", "difficulty": "White" }],
         "grants": [
@@ -221,7 +219,8 @@
             "value": { "type": "Evade", "difficulty": "White" },
             "amount": 1
           }
-        ]
+        ],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_103.jpg"
       }
     ],
     "cost": { "value": 6 },
@@ -229,8 +228,6 @@
       { "factions": ["Rebel Alliance"] },
       { "ships": ["modifiedyt1300lightfreighter"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_103.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_103.jpg",
     "ffg_id": "XW_U_103"
   },
   {
@@ -252,7 +249,9 @@
             "value": { "type": "Barrel Roll", "difficulty": "White" },
             "amount": 1
           }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_151.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_151.jpg"
       }
     ],
     "cost": { "value": 2 },
@@ -260,8 +259,6 @@
       { "factions": ["Scum and Villainy"] },
       { "ships": ["g1astarfighter"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_151.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_151.jpg",
     "ffg_id": "XW_U_151"
   },
   {
@@ -274,7 +271,9 @@
         "type": "Title",
         "ability": "Gain a [Front Arc] primary weapon with a value of \"3.\" During the End Phase, do not remove up to 2 focus tokens.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/d5/a3/d5a3b474-777f-49ac-941b-e48c5744e206/swz06-moldy-crow.png",
-        "slots": ["Title"]
+        "slots": ["Title"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_104.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_104.jpg"
       }
     ],
     "cost": { "value": 12 },
@@ -282,8 +281,6 @@
       { "factions": ["Rebel Alliance", "Scum and Villainy"] },
       { "ships": ["hwk290lightfreighter"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_104.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_104.jpg",
     "ffg_id": "XW_U_104"
   },
   {
@@ -295,8 +292,9 @@
         "title": "Outrider",
         "type": "Title",
         "ability": "While you perform an attack that is obstructed by an obstacle, the defender rolls 1 fewer defense die. After you fully execute a maneuver, if you moved through or overlapped an obstacle, you may remove 1 of your red or orange tokens.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/fe/ae/feae6d90-2011-45bf-ab0d-94a0e37d1b6e/swz06-outrider.png",
-        "slots": ["Title"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_105.png",
+        "slots": ["Title"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_105.jpg"
       }
     ],
     "cost": { "value": 14 },
@@ -304,8 +302,6 @@
       { "factions": ["Rebel Alliance"] },
       { "ships": ["yt2400lightfreighter"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_105.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_105.jpg",
     "ffg_id": "XW_U_105"
   },
   {
@@ -317,8 +313,9 @@
         "title": "Phantom",
         "type": "Title",
         "ability": "You can dock at range 0-1.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/64/49/6449c2fd-c5cb-4f41-98a5-d03bebbc7311/swz06_a1_phantom.png",
-        "slots": ["Title"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
+        "slots": ["Title"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg"
       }
     ],
     "cost": { "value": 2 },
@@ -326,8 +323,6 @@
       { "factions": ["Rebel Alliance"] },
       { "ships": ["attackshuttle", "sheathipedeclassshuttle"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
     "ffg_id": "XW_U_106"
   },
   {
@@ -343,7 +338,9 @@
         "grants": [
           { "type": "slot", "value": "Crew", "amount": -1 },
           { "type": "slot", "value": "Astromech", "amount": 1 }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg"
       }
     ],
     "cost": { "value": 8 },
@@ -351,8 +348,6 @@
       { "factions": ["Scum and Villainy"] },
       { "ships": ["jumpmaster5000"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
     "ffg_id": "XW_U_152"
   },
   {
@@ -364,8 +359,9 @@
         "title": "ST-321",
         "type": "Title",
         "ability": "After you perform a [Coordinate] action, you may choose an enemy ship at range 0-3 of the ship you coordinated. If you do, acquire a lock on that enemy ship, ignoring range restrictions.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/e5/96/e5961bc7-0fcb-4046-9e99-889564b22d00/swz07-st-321.png",
-        "slots": ["Title"]
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+        "slots": ["Title"],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg"
       }
     ],
     "cost": { "value": 6 },
@@ -373,8 +369,6 @@
       { "factions": ["Galactic Empire"] },
       { "ships": ["lambdaclasst4ashuttle"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
     "ffg_id": "XW_U_124"
   },
   {
@@ -386,7 +380,9 @@
         "title": "Shadow Caster",
         "type": "Title",
         "ability": "After you perform an attack that hits, if the defender is in your [Single Turret Arc] and your [Front Arc], the defender gains 1 tractor token.",
-        "slots": ["Title"]
+        "slots": ["Title"],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_153.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_153.jpg"
       }
     ],
     "cost": { "value": 6 },
@@ -394,8 +390,6 @@
       { "factions": ["Scum and Villainy"] },
       { "ships": ["lancerclasspursuitcraft"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_153.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_153.jpg",
     "ffg_id": "XW_U_153"
   },
   {
@@ -408,7 +402,9 @@
         "type": "Title",
         "ability": "After you reveal a turn, ([Turn Left] or [Turn Right]) or bank ([Bank Left] or [Bank Right]) maneuver, you may set your dial to the maneuver of the same speed and bearing in the other direction. Add [Torpedo] slot.",
         "slots": ["Title"],
-        "grants": [{ "type": "slot", "value": "Torpedo", "amount": 1 }]
+        "grants": [{ "type": "slot", "value": "Torpedo", "amount": 1 }],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_154.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_154.jpg"
       }
     ],
     "cost": { "value": 5 },
@@ -416,8 +412,6 @@
       { "factions": ["Scum and Villainy"] },
       { "ships": ["firesprayclasspatrolcraft"] }
     ],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_154.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_154.jpg",
     "ffg_id": "XW_U_154"
   },
   {
@@ -434,13 +428,13 @@
         "grants": [
           { "type": "slot", "value": "Modification", "amount": 1 },
           { "type": "stat", "value": "shields", "amount": 1 }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_155.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_155.jpg"
       }
     ],
     "cost": { "value": 10 },
     "restrictions": [{ "ships": ["starviperclassattackplatform"] }],
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_155.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_155.jpg",
     "ffg_id": "XW_U_155"
   }
 ]

--- a/data/upgrades/title.json
+++ b/data/upgrades/title.json
@@ -9,47 +9,26 @@
         "type": "Title",
         "ability": "Add [Device] slot.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/8f/83/8f83a635-5a04-4951-8195-6e4c447fed35/swz16_andrasta.png",
-        "slots": [
-          "Title"
-        ],
-        "actions": [
-          {
-            "type": "Reload",
-            "difficulty": "White"
-          }
-        ],
+        "slots": ["Title"],
+        "actions": [{ "type": "Reload", "difficulty": "White" }],
         "grants": [
-          {
-            "type": "slot",
-            "value": "Device",
-            "amount": 1
-          },
+          { "type": "slot", "value": "Device", "amount": 1 },
           {
             "type": "action",
-            "value": {
-              "type": "Reload",
-              "difficulty": "White"
-            },
+            "value": { "type": "Reload", "difficulty": "White" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "value": 6
-    },
+    "cost": { "value": 6 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      },
-      {
-        "ships": [
-          "firesprayclasspatrolcraft"
-        ]
-      }
-    ]
+      { "factions": ["Scum and Villainy"] },
+      { "ships": ["firesprayclasspatrolcraft"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_146.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_146.jpg",
+    "ffg_id": "XW_U_146"
   },
   {
     "name": "Black One",
@@ -60,24 +39,12 @@
         "title": "Black One",
         "type": "Title",
         "ability": "After you perform a [Slam] acion, lose 1 [Charge]. Then, you may gain 1 ion token to remove 1 disarm token. If your [Charge] is inactive, you cannot perform the [Slam] action.",
-        "slots": [
-          "Title"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 0
-        },
-        "actions": [
-          {
-            "type": "SLAM",
-            "difficulty": "White"
-          }
-        ]
+        "slots": ["Title"],
+        "charges": { "value": 1, "recovers": 0 },
+        "actions": [{ "type": "SLAM", "difficulty": "White" }]
       }
     ],
-    "cost": {
-      "value": 0
-    }
+    "cost": { "value": 0 }
   },
   {
     "name": "Dauntless",
@@ -89,26 +56,17 @@
         "type": "Title",
         "ability": "After you partially execute a maneuver, you may perform 1 white action, treating that action as red.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/8b/a7/8ba7e5da-f36f-4db8-8632-07270e1e5dd5/swz07-dauntless.png",
-        "slots": [
-          "Title"
-        ]
+        "slots": ["Title"]
       }
     ],
-    "cost": {
-      "value": 6
-    },
+    "cost": { "value": 6 },
     "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      },
-      {
-        "ships": [
-          "vt49decimator"
-        ]
-      }
-    ]
+      { "factions": ["Galactic Empire"] },
+      { "ships": ["vt49decimator"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_123.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_123.jpg",
+    "ffg_id": "XW_U_123"
   },
   {
     "name": "Ghost",
@@ -120,26 +78,17 @@
         "type": "Title",
         "ability": "You can dock 1 attack shuttle or Sheathipede-class shuttle. Your docked ships can deploy only from your rear guides.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/76/ab/76abeac7-3d64-4156-9fc8-4e4685ef3d9a/swz06_a1_ghost.png",
-        "slots": [
-          "Title"
-        ]
+        "slots": ["Title"]
       }
     ],
-    "cost": {
-      "value": 0
-    },
+    "cost": { "value": 0 },
     "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      },
-      {
-        "ships": [
-          "vcx100lightfreighter"
-        ]
-      }
-    ]
+      { "factions": ["Rebel Alliance"] },
+      { "ships": ["vcx100lightfreighter"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
+    "ffg_id": "XW_U_102"
   },
   {
     "name": "Havoc",
@@ -150,43 +99,22 @@
         "title": "Havoc",
         "type": "Title",
         "ability": "Remove [Crew] slot. Add [Sensor] and [Astromech] slots.",
-        "slots": [
-          "Title"
-        ],
+        "slots": ["Title"],
         "grants": [
-          {
-            "type": "slot",
-            "value": "Sensor",
-            "amount": 1
-          },
-          {
-            "type": "slot",
-            "value": "Astromech",
-            "amount": 1
-          },
-          {
-            "type": "slot",
-            "value": "Crew",
-            "amount": -1
-          }
+          { "type": "slot", "value": "Sensor", "amount": 1 },
+          { "type": "slot", "value": "Astromech", "amount": 1 },
+          { "type": "slot", "value": "Crew", "amount": -1 }
         ]
       }
     ],
-    "cost": {
-      "value": 4
-    },
+    "cost": { "value": 4 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      },
-      {
-        "ships": [
-          "scurrgh6bomber"
-        ]
-      }
-    ]
+      { "factions": ["Scum and Villainy"] },
+      { "ships": ["scurrgh6bomber"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_147.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_147.jpg",
+    "ffg_id": "XW_U_147"
   },
   {
     "name": "Hound's Tooth",
@@ -197,26 +125,17 @@
         "title": "Hound's Tooth",
         "type": "Title",
         "ability": "1 Z-95 AF4 headhunter can dock with you.",
-        "slots": [
-          "Title"
-        ]
+        "slots": ["Title"]
       }
     ],
-    "cost": {
-      "value": 1
-    },
+    "cost": { "value": 1 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      },
-      {
-        "ships": [
-          "yv666lightfreighter"
-        ]
-      }
-    ]
+      { "factions": ["Scum and Villainy"] },
+      { "ships": ["yv666lightfreighter"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
+    "ffg_id": "XW_U_148"
   },
   {
     "name": "IG-2000",
@@ -227,26 +146,17 @@
         "title": "IG-2000",
         "type": "Title",
         "ability": "You have the pilot ability of each other friendly ship with the IG-2000 upgrade.",
-        "slots": [
-          "Title"
-        ]
+        "slots": ["Title"]
       }
     ],
-    "cost": {
-      "value": 2
-    },
+    "cost": { "value": 2 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      },
-      {
-        "ships": [
-          "aggressorassaultfighter"
-        ]
-      }
-    ]
+      { "factions": ["Scum and Villainy"] },
+      { "ships": ["aggressorassaultfighter"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+    "ffg_id": "XW_U_149"
   },
   {
     "name": "Lando's Millennium Falcon",
@@ -258,26 +168,17 @@
         "type": "Title",
         "ability": "1 Escape Craft may dock with you. While you have an Escape Craft docked, you may spend its shields as if they were on your ship card. While you perform a primary attack against a stressed ship, roll 1 additional attack die.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/8d/a8/8da88777-3792-4da4-839e-ea7bfbbd5545/swz04_landos-millennium-falcon.png",
-        "slots": [
-          "Title"
-        ]
+        "slots": ["Title"]
       }
     ],
-    "cost": {
-      "value": 6
-    },
+    "cost": { "value": 6 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      },
-      {
-        "ships": [
-          "customizedyt1300lightfreighter"
-        ]
-      }
-    ]
+      { "factions": ["Scum and Villainy"] },
+      { "ships": ["customizedyt1300lightfreighter"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_164.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_164.jpg",
+    "ffg_id": "XW_U_164"
   },
   {
     "name": "Marauder",
@@ -289,33 +190,18 @@
         "type": "Title",
         "ability": "While you perform a primary [Rear Arc] attack,, you may reroll 1 attack die. Add [Gunner] slot.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/65/27/652749d7-13b1-4e68-a4cc-b34074a654c5/swz16_marauder.png",
-        "slots": [
-          "Title"
-        ],
-        "grants": [
-          {
-            "type": "slot",
-            "value": "Gunner",
-            "amount": 1
-          }
-        ]
+        "slots": ["Title"],
+        "grants": [{ "type": "slot", "value": "Gunner", "amount": 1 }]
       }
     ],
-    "cost": {
-      "value": 3
-    },
+    "cost": { "value": 3 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      },
-      {
-        "ships": [
-          "firesprayclasspatrolcraft"
-        ]
-      }
-    ]
+      { "factions": ["Scum and Villainy"] },
+      { "ships": ["firesprayclasspatrolcraft"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_150.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_150.jpg",
+    "ffg_id": "XW_U_150"
   },
   {
     "name": "Millennium Falcon",
@@ -327,42 +213,25 @@
         "type": "Title",
         "ability": "While you defend, if you are evading, you may reroll 1 defense die.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/31/27/3127e956-1a6c-4a8f-bae6-b1ca1c54390d/swz06-millennium-falcon.png",
-        "slots": [
-          "Title"
-        ],
-        "actions": [
-          {
-            "type": "Evade",
-            "difficulty": "White"
-          }
-        ],
+        "slots": ["Title"],
+        "actions": [{ "type": "Evade", "difficulty": "White" }],
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Evade",
-              "difficulty": "White"
-            },
+            "value": { "type": "Evade", "difficulty": "White" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "value": 6
-    },
+    "cost": { "value": 6 },
     "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      },
-      {
-        "ships": [
-          "modifiedyt1300lightfreighter"
-        ]
-      }
-    ]
+      { "factions": ["Rebel Alliance"] },
+      { "ships": ["modifiedyt1300lightfreighter"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_103.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_103.jpg",
+    "ffg_id": "XW_U_103"
   },
   {
     "name": "Mist Hunter",
@@ -374,47 +243,26 @@
         "type": "Title",
         "ability": "Add [Cannon] slot.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/c3/d1/c3d11605-d84d-4a82-8a0e-299c995d6a6c/swz08_a1_mist-hunter.png",
-        "slots": [
-          "Title"
-        ],
-        "actions": [
-          {
-            "type": "Barrel Roll",
-            "difficulty": "White"
-          }
-        ],
+        "slots": ["Title"],
+        "actions": [{ "type": "Barrel Roll", "difficulty": "White" }],
         "grants": [
-          {
-            "type": "slot",
-            "value": "Cannon",
-            "amount": 1
-          },
+          { "type": "slot", "value": "Cannon", "amount": 1 },
           {
             "type": "action",
-            "value": {
-              "type": "Barrel Roll",
-              "difficulty": "White"
-            },
+            "value": { "type": "Barrel Roll", "difficulty": "White" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "value": 2
-    },
+    "cost": { "value": 2 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      },
-      {
-        "ships": [
-          "g1astarfighter"
-        ]
-      }
-    ]
+      { "factions": ["Scum and Villainy"] },
+      { "ships": ["g1astarfighter"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_151.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_151.jpg",
+    "ffg_id": "XW_U_151"
   },
   {
     "name": "Moldy Crow",
@@ -426,27 +274,17 @@
         "type": "Title",
         "ability": "Gain a [Front Arc] primary weapon with a value of \"3.\" During the End Phase, do not remove up to 2 focus tokens.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/d5/a3/d5a3b474-777f-49ac-941b-e48c5744e206/swz06-moldy-crow.png",
-        "slots": [
-          "Title"
-        ]
+        "slots": ["Title"]
       }
     ],
-    "cost": {
-      "value": 12
-    },
+    "cost": { "value": 12 },
     "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance",
-          "Scum and Villainy"
-        ]
-      },
-      {
-        "ships": [
-          "hwk290lightfreighter"
-        ]
-      }
-    ]
+      { "factions": ["Rebel Alliance", "Scum and Villainy"] },
+      { "ships": ["hwk290lightfreighter"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_104.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_104.jpg",
+    "ffg_id": "XW_U_104"
   },
   {
     "name": "Outrider",
@@ -458,26 +296,17 @@
         "type": "Title",
         "ability": "While you perform an attack that is obstructed by an obstacle, the defender rolls 1 fewer defense die. After you fully execute a maneuver, if you moved through or overlapped an obstacle, you may remove 1 of your red or orange tokens.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/fe/ae/feae6d90-2011-45bf-ab0d-94a0e37d1b6e/swz06-outrider.png",
-        "slots": [
-          "Title"
-        ]
+        "slots": ["Title"]
       }
     ],
-    "cost": {
-      "value": 14
-    },
+    "cost": { "value": 14 },
     "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      },
-      {
-        "ships": [
-          "yt2400lightfreighter"
-        ]
-      }
-    ]
+      { "factions": ["Rebel Alliance"] },
+      { "ships": ["yt2400lightfreighter"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_105.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_105.jpg",
+    "ffg_id": "XW_U_105"
   },
   {
     "name": "Phantom",
@@ -489,27 +318,17 @@
         "type": "Title",
         "ability": "You can dock at range 0-1.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/64/49/6449c2fd-c5cb-4f41-98a5-d03bebbc7311/swz06_a1_phantom.png",
-        "slots": [
-          "Title"
-        ]
+        "slots": ["Title"]
       }
     ],
-    "cost": {
-      "value": 2
-    },
+    "cost": { "value": 2 },
     "restrictions": [
-      {
-        "factions": [
-          "Rebel Alliance"
-        ]
-      },
-      {
-        "ships": [
-          "attackshuttle",
-          "sheathipedeclassshuttle"
-        ]
-      }
-    ]
+      { "factions": ["Rebel Alliance"] },
+      { "ships": ["attackshuttle", "sheathipedeclassshuttle"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
+    "ffg_id": "XW_U_106"
   },
   {
     "name": "Punishing One",
@@ -520,38 +339,21 @@
         "title": "Punishing One",
         "type": "Title",
         "ability": "When you perform a primary attack, if the defender is in your [Front Arc], roll 1 additional attack die. Remove [Crew] slot. Add [Astromech] slot.",
-        "slots": [
-          "Title"
-        ],
+        "slots": ["Title"],
         "grants": [
-          {
-            "type": "slot",
-            "value": "Crew",
-            "amount": -1
-          },
-          {
-            "type": "slot",
-            "value": "Astromech",
-            "amount": 1
-          }
+          { "type": "slot", "value": "Crew", "amount": -1 },
+          { "type": "slot", "value": "Astromech", "amount": 1 }
         ]
       }
     ],
-    "cost": {
-      "value": 8
-    },
+    "cost": { "value": 8 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      },
-      {
-        "ships": [
-          "jumpmaster5000"
-        ]
-      }
-    ]
+      { "factions": ["Scum and Villainy"] },
+      { "ships": ["jumpmaster5000"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
+    "ffg_id": "XW_U_152"
   },
   {
     "name": "ST-321",
@@ -563,26 +365,17 @@
         "type": "Title",
         "ability": "After you perform a [Coordinate] action, you may choose an enemy ship at range 0-3 of the ship you coordinated. If you do, acquire a lock on that enemy ship, ignoring range restrictions.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/e5/96/e5961bc7-0fcb-4046-9e99-889564b22d00/swz07-st-321.png",
-        "slots": [
-          "Title"
-        ]
+        "slots": ["Title"]
       }
     ],
-    "cost": {
-      "value": 6
-    },
+    "cost": { "value": 6 },
     "restrictions": [
-      {
-        "factions": [
-          "Galactic Empire"
-        ]
-      },
-      {
-        "ships": [
-          "lambdaclasst4ashuttle"
-        ]
-      }
-    ]
+      { "factions": ["Galactic Empire"] },
+      { "ships": ["lambdaclasst4ashuttle"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+    "ffg_id": "XW_U_124"
   },
   {
     "name": "Shadow Caster",
@@ -593,26 +386,17 @@
         "title": "Shadow Caster",
         "type": "Title",
         "ability": "After you perform an attack that hits, if the defender is in your [Single Turret Arc] and your [Front Arc], the defender gains 1 tractor token.",
-        "slots": [
-          "Title"
-        ]
+        "slots": ["Title"]
       }
     ],
-    "cost": {
-      "value": 6
-    },
+    "cost": { "value": 6 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      },
-      {
-        "ships": [
-          "lancerclasspursuitcraft"
-        ]
-      }
-    ]
+      { "factions": ["Scum and Villainy"] },
+      { "ships": ["lancerclasspursuitcraft"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_153.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_153.jpg",
+    "ffg_id": "XW_U_153"
   },
   {
     "name": "Slave I",
@@ -623,33 +407,18 @@
         "title": "Slave I",
         "type": "Title",
         "ability": "After you reveal a turn, ([Turn Left] or [Turn Right]) or bank ([Bank Left] or [Bank Right]) maneuver, you may set your dial to the maneuver of the same speed and bearing in the other direction. Add [Torpedo] slot.",
-        "slots": [
-          "Title"
-        ],
-        "grants": [
-          {
-            "type": "slot",
-            "value": "Torpedo",
-            "amount": 1
-          }
-        ]
+        "slots": ["Title"],
+        "grants": [{ "type": "slot", "value": "Torpedo", "amount": 1 }]
       }
     ],
-    "cost": {
-      "value": 5
-    },
+    "cost": { "value": 5 },
     "restrictions": [
-      {
-        "factions": [
-          "Scum and Villainy"
-        ]
-      },
-      {
-        "ships": [
-          "firesprayclasspatrolcraft"
-        ]
-      }
-    ]
+      { "factions": ["Scum and Villainy"] },
+      { "ships": ["firesprayclasspatrolcraft"] }
+    ],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_154.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_154.jpg",
+    "ffg_id": "XW_U_154"
   },
   {
     "name": "Virago",
@@ -660,36 +429,18 @@
         "title": "Virago",
         "type": "Title",
         "ability": "During the End Phase, you may spend 1 [Charge] to perform a red [Boost] action. Add [Modification] slot.",
-        "slots": [
-          "Title"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        },
+        "slots": ["Title"],
+        "charges": { "value": 2, "recovers": 0 },
         "grants": [
-          {
-            "type": "slot",
-            "value": "Modification",
-            "amount": 1
-          },
-          {
-            "type": "stat",
-            "value": "shields",
-            "amount": 1
-          }
+          { "type": "slot", "value": "Modification", "amount": 1 },
+          { "type": "stat", "value": "shields", "amount": 1 }
         ]
       }
     ],
-    "cost": {
-      "value": 10
-    },
-    "restrictions": [
-      {
-        "ships": [
-          "starviperclassattackplatform"
-        ]
-      }
-    ]
+    "cost": { "value": 10 },
+    "restrictions": [{ "ships": ["starviperclassattackplatform"] }],
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_155.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_155.jpg",
+    "ffg_id": "XW_U_155"
   }
 ]

--- a/data/upgrades/torpedo.json
+++ b/data/upgrades/torpedo.json
@@ -16,12 +16,12 @@
           "minrange": 1,
           "maxrange": 1,
           "ordnance": true
-        }
+        },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg"
       }
     ],
     "cost": { "value": 6 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
     "ffg_id": "XW_U_33"
   },
   {
@@ -42,12 +42,12 @@
           "minrange": 2,
           "maxrange": 3,
           "ordnance": true
-        }
+        },
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_34.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_34.jpg"
       }
     ],
     "cost": { "value": 6 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_34.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_34.jpg",
     "ffg_id": "XW_U_34"
   },
   {
@@ -59,7 +59,7 @@
         "title": "Proton Torpedoes",
         "type": "Torpedo",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. Change 1 [Hit] result to a [Critical Hit] result.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/f5/33/f5339cd5-514d-473f-92c7-eceb4fdc3cb7/swz01_a3_proton-torpedoes.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_35.png",
         "slots": ["Torpedo"],
         "charges": { "value": 2, "recovers": 0 },
         "attack": {
@@ -68,12 +68,11 @@
           "minrange": 2,
           "maxrange": 3,
           "ordnance": true
-        }
+        },
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_35.jpg"
       }
     ],
     "cost": { "value": 9 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_35.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_35.jpg",
     "ffg_id": "XW_U_35"
   }
 ]

--- a/data/upgrades/torpedo.json
+++ b/data/upgrades/torpedo.json
@@ -8,13 +8,8 @@
         "title": "Adv. Proton Torpedoes",
         "type": "Torpedo",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. Change 1 [Hit] result to a [Critical Hit] result.",
-        "slots": [
-          "Torpedo"
-        ],
-        "charges": {
-          "value": 1,
-          "recovers": 0
-        },
+        "slots": ["Torpedo"],
+        "charges": { "value": 1, "recovers": 0 },
         "attack": {
           "arc": "Front Arc",
           "value": 5,
@@ -24,9 +19,10 @@
         }
       }
     ],
-    "cost": {
-      "value": 6
-    }
+    "cost": { "value": 6 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
+    "ffg_id": "XW_U_33"
   },
   {
     "name": "Ion Torpedoes",
@@ -38,13 +34,8 @@
         "type": "Torpedo",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/b2/b8/b2b8fff4-2a82-4eac-9aa9-269e9f6a995b/swz12_card_ion-torpedoes.png",
-        "slots": [
-          "Torpedo"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        },
+        "slots": ["Torpedo"],
+        "charges": { "value": 2, "recovers": 0 },
         "attack": {
           "arc": "Front Arc",
           "value": 4,
@@ -54,9 +45,10 @@
         }
       }
     ],
-    "cost": {
-      "value": 6
-    }
+    "cost": { "value": 6 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_34.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_34.jpg",
+    "ffg_id": "XW_U_34"
   },
   {
     "name": "Proton Torpedoes",
@@ -68,13 +60,8 @@
         "type": "Torpedo",
         "ability": "Attack ([Lock]): Spend 1 [Charge]. Change 1 [Hit] result to a [Critical Hit] result.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/f5/33/f5339cd5-514d-473f-92c7-eceb4fdc3cb7/swz01_a3_proton-torpedoes.png",
-        "slots": [
-          "Torpedo"
-        ],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        },
+        "slots": ["Torpedo"],
+        "charges": { "value": 2, "recovers": 0 },
         "attack": {
           "arc": "Front Arc",
           "value": 4,
@@ -84,8 +71,9 @@
         }
       }
     ],
-    "cost": {
-      "value": 9
-    }
+    "cost": { "value": 9 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_35.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_35.jpg",
+    "ffg_id": "XW_U_35"
   }
 ]

--- a/data/upgrades/turret.json
+++ b/data/upgrades/turret.json
@@ -8,9 +8,7 @@
         "title": "Dorsal Turret",
         "type": "Turret",
         "ability": "Attack",
-        "slots": [
-          "Turret"
-        ],
+        "slots": ["Turret"],
         "attack": {
           "arc": "Single Turret Arc",
           "value": 2,
@@ -18,27 +16,20 @@
           "maxrange": 2,
           "ordnance": false
         },
-        "actions": [
-          {
-            "type": "Rotate Arc",
-            "difficulty": "White"
-          }
-        ],
+        "actions": [{ "type": "Rotate Arc", "difficulty": "White" }],
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Rotate Arc",
-              "difficulty": "White"
-            },
+            "value": { "type": "Rotate Arc", "difficulty": "White" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "value": 4
-    }
+    "cost": { "value": 4 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
+    "ffg_id": "XW_U_31"
   },
   {
     "name": "Ion Cannon Turret",
@@ -50,9 +41,7 @@
         "type": "Turret",
         "ability": "Attack: If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/0d/ab/0dabd201-f871-474c-9660-70dfc161e335/swz07-ion-cannon-turret.png",
-        "slots": [
-          "Turret"
-        ],
+        "slots": ["Turret"],
         "attack": {
           "arc": "Single Turret Arc",
           "value": 3,
@@ -60,26 +49,19 @@
           "maxrange": 2,
           "ordnance": false
         },
-        "actions": [
-          {
-            "type": "Rotate Arc",
-            "difficulty": "White"
-          }
-        ],
+        "actions": [{ "type": "Rotate Arc", "difficulty": "White" }],
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Rotate Arc",
-              "difficulty": "White"
-            },
+            "value": { "type": "Rotate Arc", "difficulty": "White" },
             "amount": 1
           }
         ]
       }
     ],
-    "cost": {
-      "value": 6
-    }
+    "cost": { "value": 6 },
+    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
+    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
+    "ffg_id": "XW_U_32"
   }
 ]

--- a/data/upgrades/turret.json
+++ b/data/upgrades/turret.json
@@ -23,12 +23,12 @@
             "value": { "type": "Rotate Arc", "difficulty": "White" },
             "amount": 1
           }
-        ]
+        ],
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg"
       }
     ],
     "cost": { "value": 4 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
     "ffg_id": "XW_U_31"
   },
   {
@@ -40,7 +40,7 @@
         "title": "Ion Cannon Turret",
         "type": "Turret",
         "ability": "Attack: If this attack hits, spend 1 [Hit] or [Critical Hit] result to cause the defender to suffer 1 [Hit] damage. All remaining [Hit]/[Critical Hit] results inflict ion tokens instead of damage.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/0d/ab/0dabd201-f871-474c-9660-70dfc161e335/swz07-ion-cannon-turret.png",
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
         "slots": ["Turret"],
         "attack": {
           "arc": "Single Turret Arc",
@@ -56,12 +56,11 @@
             "value": { "type": "Rotate Arc", "difficulty": "White" },
             "amount": 1
           }
-        ]
+        ],
+        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg"
       }
     ],
     "cost": { "value": 6 },
-    "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
-    "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
     "ffg_id": "XW_U_32"
   }
 ]


### PR DESCRIPTION
Imports the following from FFG's squadbuilder for upgrade cards:

- Point costs (though it looks like no changes were require)
- Image urls
- Artwork urls (new!)
- Unique IDs ffg_id (new!)

Like with @guidokessels, I used Prettier to reformat after running my script, so there will be some formatting changes.  The image and artwork was added to the appropriate sides.

Some manual verification should be done to make sure I didn't make any errors mapping the FFG data to our data.

Things to verify:

- Image shows the correct upgrade
- Artwork shows the correct upgrade
- ffg_id is correct (can be checked here: https://squadbuilder.fantasyflightgames.com/api/cards/, though if it matches the ID in the image URLs, it will be correct)