### PR TITLE
Fix: Remove incorrect Chopper crew artwork

### DIFF
--- a/data/upgrades/astromech.json
+++ b/data/upgrades/astromech.json
@@ -10,8 +10,7 @@
         "ability": "Action: Spend 1 non-recurring [Charge] from another equipped upgrade to recover 1 shield. Action: Spend 2 shields to recover 1 non-recurring [Charge] on an equipped upgrade.",
         "images": "https://images-cdn.fantasyflightgames.com/filer_public/5d/1a/5d1a60e4-50f6-40fc-9711-4c4f4513eea9/swz06-chopper-astromech.png",
         "slots": ["Astromech"],
-        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
-        "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg"
+        "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png"
       }
     ],
     "cost": { "value": 2 },


### PR DESCRIPTION
After the [FFG import](https://github.com/guidokessels/xwing-data2/pull/57) we have the incorrect artwork for the Chopper crew card. This seems to be a problem in FFG's app data.