### PR TITLE
Convert the FFG id values to numbers from strings

### DIFF
--- a/data/actions/actions.json
+++ b/data/actions/actions.json
@@ -2,67 +2,67 @@
   {
     "name": "Boost",
     "xws": "boost",
-    "ffg": "1"
+    "ffg": 1
   },
   {
     "name": "Focus",
     "xws": "focus",
-    "ffg": "2"
+    "ffg": 2
   },
   {
     "name": "Evade",
     "xws": "evade",
-    "ffg": "3"
+    "ffg": 3
   },
   {
     "name": "Lock",
     "xws": "lock",
-    "ffg": "4"
+    "ffg": 4
   },
   {
     "name": "Barrel Roll",
     "xws": "barrelroll",
-    "ffg": "5"
+    "ffg": 5
   },
   {
     "name": "Reinforce",
     "xws": "reinforce",
-    "ffg": "6"
+    "ffg": 6
   },
   {
     "name": "Cloak",
     "xws": "cloak",
-    "ffg": "7"
+    "ffg": 7
   },
   {
     "name": "Coordinate",
     "xws": "coordinate",
-    "ffg": "8"
+    "ffg": 8
   },
   {
     "name": "Calculate",
     "xws": "calculate",
-    "ffg": "9"
+    "ffg": 9
   },
   {
     "name": "Jam",
     "xws": "jam",
-    "ffg": "10"
+    "ffg": 10
   },
   {
     "name": "Reload",
     "xws": "reload",
-    "ffg": "12"
+    "ffg": 12
   },
   {
     "name": "Slam",
     "xws": "slam",
-    "ffg": "13"
+    "ffg": 13
   },
   {
     "name": "Rotate Arc",
     "xws": "rotatearc",
-    "ffg": "14"
+    "ffg": 14
   }
 ]
 

--- a/data/factions/factions.json
+++ b/data/factions/factions.json
@@ -2,17 +2,17 @@
   {
     "name": "Rebel Alliance",
     "xws": "rebelalliance",
-    "ffg": "1"
+    "ffg": 1
   },
   {
     "name": "Galactic Empire",
     "xws": "galacticempire",
-    "ffg": "2"
+    "ffg": 2
   },
   {
     "name": "Scum and Villainy",
     "xws": "scumandvillainy",
-    "ffg": "3"
+    "ffg": 3
   },
   {
     "name": "Resistance",

--- a/data/pilots/galactic-empire/alpha-class-star-wing.json
+++ b/data/pilots/galactic-empire/alpha-class-star-wing.json
@@ -1,7 +1,7 @@
 {
   "name": "Alpha-class Star Wing",
   "xws": "alphaclassstarwing",
-  "ffg": "14",
+  "ffg": 14,
   "size": "Small",
   "dial": [
     "1BW",

--- a/data/pilots/galactic-empire/lambda-class-t-4a-shuttle.json
+++ b/data/pilots/galactic-empire/lambda-class-t-4a-shuttle.json
@@ -1,7 +1,7 @@
 {
   "name": "Lambda-class T-4a Shuttle",
   "xws": "lambdaclasst4ashuttle",
-  "ffg": "26",
+  "ffg": 26,
   "size": "Large",
   "dial": [
     "0OR",

--- a/data/pilots/galactic-empire/tie-advanced-v1.json
+++ b/data/pilots/galactic-empire/tie-advanced-v1.json
@@ -1,7 +1,7 @@
 {
   "name": "TIE Advanced v1",
   "xws": "tieadvancedv1",
-  "ffg": "25",
+  "ffg": 25,
   "size": "Small",
   "dial": [
     "1TB",

--- a/data/pilots/galactic-empire/tie-advanced-x1.json
+++ b/data/pilots/galactic-empire/tie-advanced-x1.json
@@ -1,7 +1,7 @@
 {
   "name": "TIE Advanced x1",
   "xws": "tieadvancedx1",
-  "ffg": "13",
+  "ffg": 13,
   "size": "Small",
   "dial": [
     "1BB",

--- a/data/pilots/galactic-empire/tie-ag-aggressor.json
+++ b/data/pilots/galactic-empire/tie-ag-aggressor.json
@@ -1,7 +1,7 @@
 {
   "name": "TIE/ag Aggressor",
   "xws": "tieagaggressor",
-  "ffg": "29",
+  "ffg": 29,
   "size": "Small",
   "dial": [
     "1BW",

--- a/data/pilots/galactic-empire/tie-ca-punisher.json
+++ b/data/pilots/galactic-empire/tie-ca-punisher.json
@@ -1,7 +1,7 @@
 {
   "name": "TIE/ca Punisher",
   "xws": "tiecapunisher",
-  "ffg": "20",
+  "ffg": 20,
   "size": "Medium",
   "dial": [
     "0OR",

--- a/data/pilots/galactic-empire/tie-d-defender.json
+++ b/data/pilots/galactic-empire/tie-d-defender.json
@@ -1,7 +1,7 @@
 {
   "name": "TIE/D Defender",
   "xws": "tieddefender",
-  "ffg": "18",
+  "ffg": 18,
   "size": "Small",
   "dial": [
     "1TR",

--- a/data/pilots/galactic-empire/tie-interceptor.json
+++ b/data/pilots/galactic-empire/tie-interceptor.json
@@ -1,7 +1,7 @@
 {
   "name": "TIE Interceptor",
   "xws": "tieininterceptor",
-  "ffg": "41",
+  "ffg": 41,
   "size": "Small",
   "dial": [
     "1TW",

--- a/data/pilots/galactic-empire/tie-ln-fighter.json
+++ b/data/pilots/galactic-empire/tie-ln-fighter.json
@@ -1,7 +1,7 @@
 {
   "name": "TIE/ln Fighter",
   "xws": "tielnfighter",
-  "ffg": "11",
+  "ffg": 11,
   "size": "Small",
   "dial": [
     "1TW",

--- a/data/pilots/galactic-empire/tie-ph-phantom.json
+++ b/data/pilots/galactic-empire/tie-ph-phantom.json
@@ -1,7 +1,7 @@
 {
   "name": "TIE/ph Phantom",
   "xws": "tiephphantom",
-  "ffg": "27",
+  "ffg": 27,
   "size": "Small",
   "dial": [
     "1TW",

--- a/data/pilots/galactic-empire/tie-reaper.json
+++ b/data/pilots/galactic-empire/tie-reaper.json
@@ -1,7 +1,7 @@
 {
   "name": "TIE Reaper",
   "xws": "tiereaper",
-  "ffg": "43",
+  "ffg": 43,
   "size": "Medium",
   "dial": [
     "0OR",

--- a/data/pilots/galactic-empire/tie-sa-bomber.json
+++ b/data/pilots/galactic-empire/tie-sa-bomber.json
@@ -1,7 +1,7 @@
 {
   "name": "TIE/sa Bomber",
   "xws": "tiesabomber",
-  "ffg": "19",
+  "ffg": 19,
   "size": "Small",
   "dial": [
     "1BW",

--- a/data/pilots/galactic-empire/tie-sk-striker.json
+++ b/data/pilots/galactic-empire/tie-sk-striker.json
@@ -1,7 +1,7 @@
 {
   "name": "TIE/sk Striker",
   "xws": "tieskstriker",
-  "ffg": "16",
+  "ffg": 16,
   "size": "Small",
   "dial": [
     "1TW",

--- a/data/pilots/galactic-empire/vt-49-decimator.json
+++ b/data/pilots/galactic-empire/vt-49-decimator.json
@@ -1,7 +1,7 @@
 {
   "name": "VT-49 Decimator",
   "xws": "vt49decimator",
-  "ffg": "28",
+  "ffg": 28,
   "size": "Large",
   "dial": [
     "1TR",

--- a/data/pilots/rebel-alliance/a-sf-01-b-wing.json
+++ b/data/pilots/rebel-alliance/a-sf-01-b-wing.json
@@ -1,7 +1,7 @@
 {
   "name": "A/SF-01 B-wing",
   "xws": "asf01bwing",
-  "ffg": "17",
+  "ffg": 17,
   "size": "Small",
   "dial": [
     "1ER",

--- a/data/pilots/rebel-alliance/arc-170-starfighter.json
+++ b/data/pilots/rebel-alliance/arc-170-starfighter.json
@@ -1,7 +1,7 @@
 {
   "name": "ARC-170 Starfighter",
   "xws": "arc170starfighter",
-  "ffg": "31",
+  "ffg": 31,
   "size": "Medium",
   "dial": [
     "1BB",

--- a/data/pilots/rebel-alliance/attack-shuttle.json
+++ b/data/pilots/rebel-alliance/attack-shuttle.json
@@ -1,7 +1,7 @@
 {
   "name": "Attack Shuttle",
   "xws": "attackshuttle",
-  "ffg": "32",
+  "ffg": 32,
   "size": "Small",
   "dial": [
     "1TR",

--- a/data/pilots/rebel-alliance/auzituck-gunship.json
+++ b/data/pilots/rebel-alliance/auzituck-gunship.json
@@ -1,7 +1,7 @@
 {
   "name": "Auzituck Gunship",
   "xws": "auzituckgunship",
-  "ffg": "6",
+  "ffg": 6,
   "size": "Small",
   "dial": [
     "0OR",

--- a/data/pilots/rebel-alliance/btl-a4-y-wing.json
+++ b/data/pilots/rebel-alliance/btl-a4-y-wing.json
@@ -1,7 +1,7 @@
 {
   "name": "BTL-A4 Y-wing",
   "xws": "btla4ywing",
-  "ffg": "12",
+  "ffg": 12,
   "size": "Small",
   "dial": [
     "1BB",

--- a/data/pilots/rebel-alliance/btl-s8-k-wing.json
+++ b/data/pilots/rebel-alliance/btl-s8-k-wing.json
@@ -1,7 +1,7 @@
 {
   "name": "BTL-S8 K-wing",
   "xws": "btls8kwing",
-  "ffg": "30",
+  "ffg": 30,
   "size": "Medium",
   "dial": [
     "1BB",

--- a/data/pilots/rebel-alliance/e-wing.json
+++ b/data/pilots/rebel-alliance/e-wing.json
@@ -1,7 +1,7 @@
 {
   "name": "E-wing",
   "xws": "ewing",
-  "ffg": "40",
+  "ffg": 40,
   "size": "Small",
   "dial": [
     "1TR",

--- a/data/pilots/rebel-alliance/hwk-290-light-freighter.json
+++ b/data/pilots/rebel-alliance/hwk-290-light-freighter.json
@@ -1,7 +1,7 @@
 {
   "name": "HWK-290 Light Freighter",
   "xws": "hwk290lightfreighter",
-  "ffg": "34",
+  "ffg": 34,
   "size": "Small",
   "dial": [
     "0OR",

--- a/data/pilots/rebel-alliance/modified-yt-1300-light-freighter.json
+++ b/data/pilots/rebel-alliance/modified-yt-1300-light-freighter.json
@@ -1,7 +1,7 @@
 {
   "name": "Modified YT-1300 Light Freighter",
   "xws": "modifiedyt1300lightfreighter",
-  "ffg": "1",
+  "ffg": 1,
   "size": "Large",
   "dial": [
     "1BW",

--- a/data/pilots/rebel-alliance/rz-1-a-wing.json
+++ b/data/pilots/rebel-alliance/rz-1-a-wing.json
@@ -1,7 +1,7 @@
 {
   "name": "RZ-1 A-wing",
   "xws": "rz1awing",
-  "ffg": "35",
+  "ffg": 35,
   "size": "Small",
   "dial": [
     "1TW",

--- a/data/pilots/rebel-alliance/sheathipede-class-shuttle.json
+++ b/data/pilots/rebel-alliance/sheathipede-class-shuttle.json
@@ -1,7 +1,7 @@
 {
   "name": "Sheathipede-class Shuttle",
   "xws": "sheathipedeclassshuttle",
-  "ffg": "8",
+  "ffg": 8,
   "size": "Small",
   "dial": [
     "1SR",

--- a/data/pilots/rebel-alliance/t-65-x-wing.json
+++ b/data/pilots/rebel-alliance/t-65-x-wing.json
@@ -1,7 +1,7 @@
 {
   "name": "T-65 X-wing",
   "xws": "t65xwing",
-  "ffg": "33",
+  "ffg": 33,
   "size": "Small",
   "dial": [
     "1BB",

--- a/data/pilots/rebel-alliance/tie-ln-fighter.json
+++ b/data/pilots/rebel-alliance/tie-ln-fighter.json
@@ -1,7 +1,7 @@
 {
   "name": "TIE/ln Fighter",
   "xws": "tielnfighter",
-  "ffg": "11",
+  "ffg": 11,
   "size": "Small",
   "dial": [
     "1TW",

--- a/data/pilots/rebel-alliance/ut-60d-u-wing.json
+++ b/data/pilots/rebel-alliance/ut-60d-u-wing.json
@@ -1,7 +1,7 @@
 {
   "name": "UT-60D U-wing",
   "xws": "ut60duwing",
-  "ffg": "15",
+  "ffg": 15,
   "size": "Medium",
   "dial": [
     "0OR",

--- a/data/pilots/rebel-alliance/vcx-100-light-freighter.json
+++ b/data/pilots/rebel-alliance/vcx-100-light-freighter.json
@@ -1,7 +1,7 @@
 {
   "name": "VCX-100 Light Freighter",
   "xws": "vcx100lightfreighter",
-  "ffg": "23",
+  "ffg": 23,
   "size": "Large",
   "dial": [
     "1TR",

--- a/data/pilots/rebel-alliance/yt-2400-light-freighter.json
+++ b/data/pilots/rebel-alliance/yt-2400-light-freighter.json
@@ -1,7 +1,7 @@
 {
   "name": "YT-2400 Light Freighter",
   "xws": "yt2400lightfreighter",
-  "ffg": "5",
+  "ffg": 5,
   "size": "Large",
   "dial": [
     "1TW",

--- a/data/pilots/rebel-alliance/z-95-af4-headhunter.json
+++ b/data/pilots/rebel-alliance/z-95-af4-headhunter.json
@@ -1,7 +1,7 @@
 {
   "name": "Z-95-AF4 Headhunter",
   "xws": "z95af4headhunter",
-  "ffg": "38",
+  "ffg": 38,
   "size": "Small",
   "dial": [
     "1BW",

--- a/data/pilots/scum-and-villainy/aggressor-assault-fighter.json
+++ b/data/pilots/scum-and-villainy/aggressor-assault-fighter.json
@@ -1,7 +1,7 @@
 {
   "name": "Aggressor Assault Fighter",
   "xws": "aggressorassaultfighter",
-  "ffg": "21",
+  "ffg": 21,
   "size": "Medium",
   "dial": [
     "1TW",

--- a/data/pilots/scum-and-villainy/btl-a4-y-wing.json
+++ b/data/pilots/scum-and-villainy/btl-a4-y-wing.json
@@ -1,7 +1,7 @@
 {
   "name": "BTL-A4 Y-wing",
   "xws": "btla4ywing",
-  "ffg": "12",
+  "ffg": 12,
   "size": "Small",
   "dial": [
     "1BB",

--- a/data/pilots/scum-and-villainy/customized-yt-1300-light-freighter.json
+++ b/data/pilots/scum-and-villainy/customized-yt-1300-light-freighter.json
@@ -1,7 +1,7 @@
 {
   "name": "Customized YT-1300 Light Freighter",
   "xws": "customizedyt1300lightfreighter",
-  "ffg": "47",
+  "ffg": 47,
   "size": "Large",
   "dial": [
     "1BB",

--- a/data/pilots/scum-and-villainy/escape-craft.json
+++ b/data/pilots/scum-and-villainy/escape-craft.json
@@ -1,7 +1,7 @@
 {
   "name": "Escape Craft",
   "xws": "escapecraft",
-  "ffg": "48",
+  "ffg": 48,
   "size": "Small",
   "dial": [
     "0OR",

--- a/data/pilots/scum-and-villainy/fang-fighter.json
+++ b/data/pilots/scum-and-villainy/fang-fighter.json
@@ -1,7 +1,7 @@
 {
   "name": "Fang Fighter",
   "xws": "fangfighter",
-  "ffg": "36",
+  "ffg": 36,
   "size": "Small",
   "dial": [
     "1TW",

--- a/data/pilots/scum-and-villainy/firespray-class-patrol-craft.json
+++ b/data/pilots/scum-and-villainy/firespray-class-patrol-craft.json
@@ -1,7 +1,7 @@
 {
   "name": "Firespray-class Patrol Craft",
   "xws": "firesprayclasspatrolcraft",
-  "ffg": "10",
+  "ffg": 10,
   "size": "Medium",
   "dial": [
     "1TW",

--- a/data/pilots/scum-and-villainy/g-1a-starfighter.json
+++ b/data/pilots/scum-and-villainy/g-1a-starfighter.json
@@ -1,7 +1,7 @@
 {
   "name": "G-1A Starfighter",
   "xws": "g1astarfighter",
-  "ffg": "22",
+  "ffg": 22,
   "size": "Medium",
   "dial": [
     "0OR",

--- a/data/pilots/scum-and-villainy/hwk-290-light-freighter.json
+++ b/data/pilots/scum-and-villainy/hwk-290-light-freighter.json
@@ -1,7 +1,7 @@
 {
   "name": "HWK-290 Light Freighter",
   "xws": "hwk290lightfreighter",
-  "ffg": "34",
+  "ffg": 34,
   "size": "Small",
   "dial": [
     "0OR",

--- a/data/pilots/scum-and-villainy/jumpmaster-5000.json
+++ b/data/pilots/scum-and-villainy/jumpmaster-5000.json
@@ -1,7 +1,7 @@
 {
   "name": "JumpMaster 5000",
   "xws": "jumpmaster5000",
-  "ffg": "45",
+  "ffg": 45,
   "size": "Large",
   "dial": [
     "1TW",

--- a/data/pilots/scum-and-villainy/kihraxz-fighter.json
+++ b/data/pilots/scum-and-villainy/kihraxz-fighter.json
@@ -1,7 +1,7 @@
 {
   "name": "Kihraxz Fighter",
   "xws": "kihraxzfighter",
-  "ffg": "7",
+  "ffg": 7,
   "size": "Small",
   "dial": [
     "1TW",

--- a/data/pilots/scum-and-villainy/lancer-class-pursuit-craft.json
+++ b/data/pilots/scum-and-villainy/lancer-class-pursuit-craft.json
@@ -1,7 +1,7 @@
 {
   "name": "Lancer-class Pursuit Craft",
   "xws": "lancerclasspursuitcraft",
-  "ffg": "42",
+  "ffg": 42,
   "size": "Large",
   "dial": [
     "1BW",

--- a/data/pilots/scum-and-villainy/m12-l-kimogila-fighter.json
+++ b/data/pilots/scum-and-villainy/m12-l-kimogila-fighter.json
@@ -1,7 +1,7 @@
 {
   "name": "M12-L Kimogila Fighter",
   "xws": "m12lkimogilafighter",
-  "ffg": "39",
+  "ffg": 39,
   "size": "Medium",
   "dial": [
     "1TR",

--- a/data/pilots/scum-and-villainy/m3-a-interceptor.json
+++ b/data/pilots/scum-and-villainy/m3-a-interceptor.json
@@ -1,7 +1,7 @@
 {
   "name": "M3-A Interceptor",
   "xws": "m3ainterceptor",
-  "ffg": "44",
+  "ffg": 44,
   "size": "Small",
   "dial": [
     "1TW",

--- a/data/pilots/scum-and-villainy/quadrijet-transfer-spacetug.json
+++ b/data/pilots/scum-and-villainy/quadrijet-transfer-spacetug.json
@@ -1,7 +1,7 @@
 {
   "name": "Quadrijet Transfer Spacetug",
   "xws": "quadrijettransferspacetug",
-  "ffg": "9",
+  "ffg": 9,
   "size": "Small",
   "dial": [
     "1AR",

--- a/data/pilots/scum-and-villainy/scurrg-h-6-bomber.json
+++ b/data/pilots/scum-and-villainy/scurrg-h-6-bomber.json
@@ -1,7 +1,7 @@
 {
   "name": "Scurrg H-6 Bomber",
   "xws": "scurrgh6bomber",
-  "ffg": "4",
+  "ffg": 4,
   "size": "Medium",
   "dial": [
     "1BB",

--- a/data/pilots/scum-and-villainy/starviper-class-attack-platform.json
+++ b/data/pilots/scum-and-villainy/starviper-class-attack-platform.json
@@ -1,7 +1,7 @@
 {
   "name": "StarViper-class Attack Platform",
   "xws": "starviperclassattackplatform",
-  "ffg": "3",
+  "ffg": 3,
   "size": "Small",
   "dial": [
     "1TW",

--- a/data/pilots/scum-and-villainy/yv-666-light-freighter.json
+++ b/data/pilots/scum-and-villainy/yv-666-light-freighter.json
@@ -1,7 +1,7 @@
 {
   "name": "YV-666 Light Freighter",
   "xws": "yv666lightfreighter",
-  "ffg": "24",
+  "ffg": 24,
   "size": "Large",
   "dial": [
     "0OR",

--- a/data/pilots/scum-and-villainy/z-95-af4-headhunter.json
+++ b/data/pilots/scum-and-villainy/z-95-af4-headhunter.json
@@ -1,7 +1,7 @@
 {
   "name": "Z-95-AF4 Headhunter",
   "xws": "z95af4headhunter",
-  "ffg": "38",
+  "ffg": 38,
   "size": "Small",
   "dial": [
     "1BW",

--- a/data/stats/stats.json
+++ b/data/stats/stats.json
@@ -2,65 +2,65 @@
   {
     "name": "Agility",
     "xws": "agility",
-    "ffg": "1"
+    "ffg": 1
   },
   {
     "name": "Hull",
     "xws": "hull",
-    "ffg": "2"
+    "ffg": 2
   },
   {
     "name": "Shields",
     "xws": "shields",
-    "ffg": "3"
+    "ffg": 3
   },
   {
     "name": "Force",
     "xws": "force",
-    "ffg": "4"
+    "ffg": 4
   },
   {
     "name": "Charge",
     "xws": "charge",
-    "ffg": "7"
+    "ffg": 7
   },
   {
     "name": "Double Turret Arc",
     "xws": "doubleturretarc",
     "ffg_name": "Dual Mobile Arc",
-    "ffg": "8"
+    "ffg": 8
   },
   {
     "name": "Full Front Arc",
     "xws": "fullfrontarc",
     "ffg_name": "Front 180 Arc",
-    "ffg": "9"
+    "ffg": 9
   },
   {
     "name": "Front Arc",
     "xws": "frontarc",
-    "ffg": "10"
+    "ffg": 10
   },
   {
     "name": "Bullseye Arc",
     "xws": "bullseyearc",
-    "ffg": "11"
+    "ffg": 11
   },
   {
     "name": "Single Turret Arc",
     "xws": "singleturretarc",
     "ffg_name": "Mobile Arc",
-    "ffg": "12"
+    "ffg": 12
   },
   {
     "name": "Rear Arc",
     "xws": "reararc",
-    "ffg": "14"
+    "ffg": 14
   },
   {
     "name": "Weapon Range No Bonus",
     "xws": "weaponrangenobonus",
-    "ffg": "20"
+    "ffg": 20
   }
 ]
 


### PR DESCRIPTION
As you mentioned in pull request #62 I left the FFG id values as strings not integers. Well by the power of sed that has been resolved :)

As per the usual, I deleted and regenerated the ffg-xws.json file and it was identical after the changes were made.