### PR TITLE
Updated Norra Wexley (ARC-170) to match the current errata

### DIFF
--- a/data/pilots/rebel-alliance/arc-170-starfighter.json
+++ b/data/pilots/rebel-alliance/arc-170-starfighter.json
@@ -81,7 +81,7 @@
       "limited": 1,
       "cost": 55,
       "xws": "norrawexley",
-      "ability": "While you defend, if there is an enemy ship at range 0-1, you may add 1 [Evade] result to your dice results.",
+      "ability": "While you defend, if there is an enemy ship at range 0-1, add 1 [Evade] result to your dice results.",
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
       "slots": [
         "Talent",


### PR DESCRIPTION
The text change is described in the Rules Reference, v1.0.2, page 22:

> •Norra Wexley (ARC-170)
> Should read: “...range 0–1, add 1 [Evade] result to your dice results.”
> (Removed “you may”) 