### PR TITLE
Fixed XWS names to resistance ships

### DIFF
--- a/data/pilots/resistance/mg-100-starfortress-sf-17.json
+++ b/data/pilots/resistance/mg-100-starfortress-sf-17.json
@@ -1,6 +1,6 @@
 {
   "name": "MG-100 StarFortress SF-17",
-  "name": "mg100starfortresssf17",
+  "xws": "mg100starfortresssf17",
   "size": "Large",
   "dial": [
     "0OR",

--- a/data/pilots/resistance/rz-2-a-wing.json
+++ b/data/pilots/resistance/rz-2-a-wing.json
@@ -1,6 +1,6 @@
 {
   "name": "RZ-2 A-wing",
-  "name": "rz2awing",
+  "xws": "rz2awing",
   "size": "Small",
   "dial": [
     "1TW",

--- a/data/pilots/resistance/scavenged-yt-1300.json
+++ b/data/pilots/resistance/scavenged-yt-1300.json
@@ -1,5 +1,6 @@
 {
   "name": "Scavenged YT-1300",
+  "xws": "scavengedyt1300",
   "size": "Large",
   "dial": [
     "1BW",

--- a/data/pilots/resistance/t-70-x-wing.json
+++ b/data/pilots/resistance/t-70-x-wing.json
@@ -1,6 +1,6 @@
 {
   "name": "T-70 X-wing",
-  "name": "t70xwing",
+  "xws": "t70xwing",
   "size": "Small",
   "dial": [
     "1BB",


### PR DESCRIPTION
The following ships incorrectly had two 'name' fields when one of them was the 'xws' name
- mg-100-starfortress-sf-17
- rz-2-a-wing
- t-70-x-wing

The scavenged-yt-1300 had no xws name so it's now 'scavengedyt1300'.