### PR TITLE
Update tie interceptor's xws name

### DIFF
--- a/data/pilots/galactic-empire/tie-interceptor.json
+++ b/data/pilots/galactic-empire/tie-interceptor.json
@@ -1,6 +1,6 @@
 {
   "name": "TIE Interceptor",
-  "xws": "tieininterceptor",
+  "xws": "tieinterceptor",
   "ffg": 41,
   "size": "Small",
   "dial": [


### PR DESCRIPTION
I believe this ship's xws name is supposed to be "tieinterceptor" and had an extra "in" in the name.