### PR TITLE
TIE SF Fighter

### DIFF
--- a/data/pilots/first-order/tie-sf-fighter.json
+++ b/data/pilots/first-order/tie-sf-fighter.json
@@ -25,9 +25,33 @@
   ],
   "faction": "First Order",
   "stats": [
+    { "arc": "Front Arc", "type": "attack", "value": 2 },
+    { "arc": "Single Turret Arc", "type": "attack", "value": 2 },
     { "type": "agility", "value": 2 },
     { "type": "hull", "value": 3 },
     { "type": "shields", "value": 3 }
+  ],
+  "actions": [
+      {
+      "difficulty": "White",
+      "linked": { "difficulty": "White", "type": "Rotate Arc" },
+      "type": "Focus"
+      },
+	{
+      "difficulty": "White",
+      "linked": { "difficulty": "White", "type": "Rotate Arc" },
+      "type": "Evade"
+      },
+      {
+      "difficulty": "White",
+      "linked": { "difficulty": "White", "type": "Rotate Arc" },
+      "type": "Lock"
+      },
+	{
+      "difficulty": "White",
+      "linked": { "difficulty": "White", "type": "Rotate Arc" },
+      "type": "Barrel Roll"
+      }
   ],
   "pilots": [
     {
@@ -37,7 +61,50 @@
       "limited": 1,
       "cost": 45,
       "xws": "quickdraw",
-      "ability": "???"
+      "ability": "After you lose a shield, you may spend 1 [Charge]. If you do, you may perform a bonus primary attack.",
+	"shipAbility": {
+	   "name": "Heavy Weapon Turret",
+	   "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. You must treat the [Front Arc] requirement of your equipped [Missile] upgrades as [Single Turret Arc]."
+	},
+      "slots": ["Talent", "Sensor", "Tech", "Missile", "Gunner", "Modification"]
+    },
+    {
+      "name": "Backdraft",
+      "caption": "Fiery Fanatic",
+      "initiative": 4,
+      "limited": 1,
+      "cost": 41,
+      "xws": "backdraft",
+      "ability": "While you perform a [Single Turret Arc] primary attack, if the defender is in your [Rear Arc] roll 1 additional die.",
+	"shipAbility": {
+	   "name": "Heavy Weapon Turret",
+	   "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. You must treat the [Front Arc] requirement of your equipped [Missile] upgrades as [Single Turret Arc]."
+	},
+      "slots": ["Talent", "Sensor", "Tech", "Missile", "Gunner", "Modification"]
+    },
+    {
+      "name": "Omega Squadron Expert",
+      "initiative": 3,
+      "limited": 0,
+      "cost": 36,
+      "xws": "omegasquadronexpert",
+	"shipAbility": {
+	   "name": "Heavy Weapon Turret",
+	   "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. You must treat the [Front Arc] requirement of your equipped [Missile] upgrades as [Single Turret Arc]."
+	},
+      "slots": ["Talent", "Sensor", "Tech", "Missile", "Gunner", "Modification"]
+    },
+    {
+      "name": "Zeta Squadron Survivor",
+      "initiative": 2,
+      "limited": 0,
+      "cost": 34,
+      "xws": "omegasquadronexpert",
+	"shipAbility": {
+	   "name": "Heavy Weapon Turret",
+	   "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. You must treat the [Front Arc] requirement of your equipped [Missile] upgrades as [Single Turret Arc]."
+	},
+      "slots": ["Talent", "Sensor", "Tech", "Missile", "Gunner", "Modification"]
     }
   ]
 }


### PR DESCRIPTION
added missing pilots, fixed quickdraw with remainder info
do you need the flavor text for generics too? wasn't sure. I made sure that every keyword in brackets was properly typed out like similar instances elsewhere in xwd2
source of info used: http://xhud.sirjorj.com/xwing.cgi/pilots2