### PR TITLE
Added new force powers, changed force_side to list, added grant on maul

### DIFF
--- a/data/pilots/first-order/tie-vn-silencer.json
+++ b/data/pilots/first-order/tie-vn-silencer.json
@@ -82,6 +82,7 @@
       "limited": 1,
       "cost": 82,
       "ability": "After you defend, you may spend 1 [Force] to assign the I'll Show You the Dark Side condition to the attacker.",
+      "force": { "value": 2, "recovers": 1, "side": ["dark"] }
       "shipAbility": {
         "name": "Autothrusters",
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."

--- a/data/pilots/first-order/tie-vn-silencer.json
+++ b/data/pilots/first-order/tie-vn-silencer.json
@@ -82,7 +82,7 @@
       "limited": 1,
       "cost": 82,
       "ability": "After you defend, you may spend 1 [Force] to assign the I'll Show You the Dark Side condition to the attacker.",
-      "force": { "value": 2, "recovers": 1, "side": ["dark"] }
+      "force": { "value": 2, "recovers": 1, "side": ["dark"] },
       "shipAbility": {
         "name": "Autothrusters",
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."

--- a/data/pilots/galactic-empire/tie-advanced-v1.json
+++ b/data/pilots/galactic-empire/tie-advanced-v1.json
@@ -68,7 +68,7 @@
       "xws": "grandinquisitor",
       "ability": "While you defend at attack range 1, you may spend 1 [Force] to prevent the range 1 bonus. While you perform an attack against a defender at attack range 2-3, you may spend 1 [Force] to apply the range 1 bonus.",
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_99.png",
-      "force": { "value": 2, "recovers": 1, "side": "dark" },
+      "force": { "value": 2, "recovers": 1, "side": ["dark"] },
       "slots": ["Force Power", "Sensor", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_99.jpg",
       "ffg": 99
@@ -81,7 +81,7 @@
       "xws": "inquisitor",
       "text": "The fearsome Inquisitors are given a great deal of autonomy and access to the Empire's latest technology, like the prototype TIE Advanced v1.",
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
-      "force": { "value": 1, "recovers": 1, "side": "dark" },
+      "force": { "value": 1, "recovers": 1, "side": ["dark"] },
       "slots": ["Force Power", "Sensor", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
       "ffg": 102
@@ -95,7 +95,7 @@
       "xws": "seventhsister",
       "ability": "While you perform a primary attack, before the Neutralize Results step, you may spend 2 [Force] to cancel 1 [Evade] result.",
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_100.png",
-      "force": { "value": 2, "recovers": 1, "side": "dark" },
+      "force": { "value": 2, "recovers": 1, "side": ["dark"] },
       "slots": ["Force Power", "Sensor", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_100.jpg",
       "ffg": 100

--- a/data/pilots/galactic-empire/tie-advanced-x1.json
+++ b/data/pilots/galactic-empire/tie-advanced-x1.json
@@ -55,7 +55,7 @@
           "source": "European and North American Championship 2018"
         }
       ],
-      "force": { "value": 3, "recovers": 1, "side": "dark" },
+      "force": { "value": 3, "recovers": 1, "side": ["dark"] },
       "shipAbility": {
         "name": "Advanced Targeting Computer",
         "text": "While you perform a primary attack against a defender you have locked, roll 1 additional attack die and change 1 [Hit] result to a [Critical Hit] result."

--- a/data/pilots/rebel-alliance/attack-shuttle.json
+++ b/data/pilots/rebel-alliance/attack-shuttle.json
@@ -65,7 +65,7 @@
       "xws": "ezrabridger",
       "ability": "While you defend or perform an attack, if you are stressed, you may spend 1 [Force] to change up to 2 of your [Focus] results to [Evade] or [Hit] results.",
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
-      "force": { "value": 1, "recovers": 1, "side": "light" },
+      "force": { "value": 1, "recovers": 1, "side": ["light"] },
       "shipAbility": {
         "name": "Locked and Loaded",
         "text": "While you are docked, after your carrier ship performs a primary [Front Arc] or [Turret] attack, it may perform a bonus primary [Rear Arc] attack."

--- a/data/pilots/rebel-alliance/sheathipede-class-shuttle.json
+++ b/data/pilots/rebel-alliance/sheathipede-class-shuttle.json
@@ -81,7 +81,7 @@
       "xws": "ezrabridger-sheathipedeclassshuttle",
       "ability": "While you defend or perform an attack, if you are stressed, you may spend 1 [Force] to change up to 2 of your [Focus] results to [Evade]/[Hit] results.",
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
-      "force": { "value": 1, "recovers": 1, "side": "light" },
+      "force": { "value": 1, "recovers": 1, "side": ["light"] },
       "shipAbility": {
         "name": "Comms Shuttle",
         "text": "While you are docked, your carrier ship gains [Coordinate]. Before your carrier ship activates, it may perform a [Coordinate] action."

--- a/data/pilots/rebel-alliance/t-65-x-wing.json
+++ b/data/pilots/rebel-alliance/t-65-x-wing.json
@@ -189,7 +189,7 @@
       "xws": "lukeskywalker",
       "ability": "After you become the defender (before dice are rolled), you may recover 1 [Force].",
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
-      "force": { "value": 2, "recovers": 1, "side": "light" },
+      "force": { "value": 2, "recovers": 1, "side": ["light"] },
       "alt": [
         {
           "image": "https://images-cdn.fantasyflightgames.com/filer_public/5b/aa/5baa3742-b7b2-47d7-9bec-07f02fafaf1c/op066-luke-skywalker.png",

--- a/data/pilots/rebel-alliance/tie-ln-fighter.json
+++ b/data/pilots/rebel-alliance/tie-ln-fighter.json
@@ -69,7 +69,7 @@
       "xws": "ezrabridger-tielnfighter",
       "ability": "While you defend or perform an attack, if you are stressed, you may spend 1 [Force] to change up to 2 of your [Focus] results to [Evade] or [Hit] results.",
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
-      "force": { "value": 1, "recovers": 1, "side": "light" },
+      "force": { "value": 1, "recovers": 1, "side": ["light"] },
       "slots": ["Force Power", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
       "ffg": 46

--- a/data/pilots/rebel-alliance/vcx-100-light-freighter.json
+++ b/data/pilots/rebel-alliance/vcx-100-light-freighter.json
@@ -100,7 +100,7 @@
       "xws": "kananjarrus",
       "ability": "While a friendly ship in your firing arc defends, you may spend 1 [Force]. If you do, the attacker rolls 1 fewer attack die.",
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
-      "force": { "value": 2, "recovers": 1, "side": "light" },
+      "force": { "value": 2, "recovers": 1, "side": ["light"] },
       "shipAbility": {
         "name": "Tail Gun",
         "text": "While you have a docked ship, you have a primary [Rear Arc] weapon with an attack value equal to your docked ship's primary [Front Arc] value."

--- a/data/pilots/resistance/scavenged-yt-1300.json
+++ b/data/pilots/resistance/scavenged-yt-1300.json
@@ -115,7 +115,7 @@
       "xws": "rey",
       "ability": "While you defend or perform an attack, if the enemy ship is in your [Front Arc], you may spend 1 [Force] to change 1 of your blank results to an [Evade] or [Hit] result.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/f9/27/f9276fd7-52fd-4b05-8599-05039fa479e6/swz19_a2_reys-pilot.png",
-      "force": { "value": 2, "recovers": 1, "side": ["light"] }
+      "force": { "value": 2, "recovers": 1, "side": ["light"] },
       "cost": 80,
       "slots": [
         "Force Power",

--- a/data/pilots/resistance/scavenged-yt-1300.json
+++ b/data/pilots/resistance/scavenged-yt-1300.json
@@ -115,10 +115,7 @@
       "xws": "rey",
       "ability": "While you defend or perform an attack, if the enemy ship is in your [Front Arc], you may spend 1 [Force] to change 1 of your blank results to an [Evade] or [Hit] result.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/f9/27/f9276fd7-52fd-4b05-8599-05039fa479e6/swz19_a2_reys-pilot.png",
-      "force": {
-        "value": 2,
-        "recovers": 1
-      },
+      "force": { "value": 2, "recovers": 1, "side": ["light"] }
       "cost": 80,
       "slots": [
         "Force Power",

--- a/data/pilots/scum-and-villainy/lancer-class-pursuit-craft.json
+++ b/data/pilots/scum-and-villainy/lancer-class-pursuit-craft.json
@@ -45,7 +45,7 @@
       "xws": "asajjventress",
       "ability": "At the start of the Engagement Phase, you may choose 1 enemy ship in your [Single Turret Arc] at range 0-2 and spend 1 [Force] token. If you do, that ship gains 1 stress token unless it removes 1 green token.",
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_219.png",
-      "force": { "value": 2, "recovers": 1, "side": "dark" },
+      "force": { "value": 2, "recovers": 1, "side": ["dark"] },
       "slots": [
         "Force Power",
         "Crew",

--- a/data/pilots/separatist-alliance/sith-infiltrator.json
+++ b/data/pilots/separatist-alliance/sith-infiltrator.json
@@ -64,10 +64,7 @@
       "initiative": 5,
       "limited": 1,
       "xws": "darthmaul",
-      "force": {
-        "value": 3,
-        "recovers": 1
-      },
+      "force": { "value": 3, "recovers": 1, "side": ["dark"] },
       "ability": "After you perform an attack, you may spend 2 [Force] to perform a bonus primary attack against a different target. If your attack missed, you may perform that bonus primary attack against the same target instead.",
       "image": "https://images-cdn.fantasyflightgames.com/filer_public/35/d8/35d8295c-1018-4ed7-94a0-c0bff4e6fbbc/swz30_darth-maul.png"
     }

--- a/data/upgrades/crew.json
+++ b/data/upgrades/crew.json
@@ -777,6 +777,9 @@
         "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_136.png",
         "slots": ["Crew"],
         "force": { "value": 1, "recovers": 1 },
+        "grants": [
+          { "type": "force", "value": {"side": ["dark"]}, "amount": 1 }
+        ],
         "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_136.jpg",
         "ffg": 361
       }

--- a/data/upgrades/force-power.json
+++ b/data/upgrades/force-power.json
@@ -81,5 +81,32 @@
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/d0/a4/d0a49094-b246-4345-9f65-846b070e9fc6/swz34_brilliant-evasion.png"
       }
     ]
+  },
+  {
+    "name": "Hate",
+    "limited": 0,
+    "xws": "hate",
+    "sides": [
+      {
+        "title": "Hate",
+        "type": "Force Power",
+        "ability": "After you suffer 1 or more damage, recover that many [Force].",
+        "slots": ["Force Power"],
+        "restrictions": [{ "force_side": ["dark"] }]
+      }
+    ]
+  },
+  {
+    "name": "Predictive Shot",
+    "limited": 0,
+    "xws": "predictiveshot",
+    "sides": [
+      {
+        "title": "Predicitive Shot",
+        "type": "Force Power",
+        "ability": "After you declare an attack, if the defender is in your [Bullseye Arc], you may spend 1 [Force]. If you do, during the Roll Defense Dice step, the defender cannot roll more defense dice than the number of your [Hit]/[Crit] results.",
+        "slots": ["Force Power"]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Changing `force_side` to a list instead of a single value makes it easy to implement maul crew
Added new force powers
Added `grants` field on maul crew to add his "dark" force side value. This seems like the most sensible way. If we just add the `force_side` value into his `force` field then it's not clear that he's granting extra info.