### PR TITLE
Wave 2 artwork and images from squadbuilder cdn

### DIFF
--- a/data/pilots/first-order/tie-fo-fighter.json
+++ b/data/pilots/first-order/tie-fo-fighter.json
@@ -69,7 +69,8 @@
       "cost": 44,
       "xws": "midnight",
       "ability": "While you defend or perform an attack, if you have a lock on the enemy ship, that ship's dice cannot be modified.",
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/56/94/56940164-d919-4b04-8303-f39357555fad/swz18_a1_midnight.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/c7994885b38757f92bdf3a98c37b3c96.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/c6a43d25d22d4112dd7e968cab4eb3d5.jpg",
       "slots": ["Talent", "Tech", "Modification"],
       "ffg": 397
     },
@@ -81,6 +82,8 @@
       "cost": 41,
       "xws": "commandermalarus",
       "ability": "At the start of the Engagement Phase, you may spend 1 [Charge] and gain 1 stress token. If you do, until the end of the round, while you defend or perform an attack, you may change all of your [Focus] results to [Evade] or [Hit] results.",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/f7506ec739f5580d484ff0ee49b041f3.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/d9cfa6aacc29d55a47aaa0d9f75d362e.jpg",
       "slots": ["Talent", "Tech", "Modification"],
       "charges": { "value": 2, "recovers": 0 },
       "ffg": 452
@@ -93,6 +96,8 @@
       "cost": 35,
       "xws": "scorch",
       "ability": "While you perform a primary attack, if you are not stressed, you may gain 1 stress token to roll 1 additional attack die.",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/9dd11d408bb869cb947663fc29622833.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/dd225b2dab46b921e622dca6d799591f.jpg",
       "slots": ["Talent", "Tech", "Modification"],
       "ffg": 398
     },
@@ -104,6 +109,8 @@
       "cost": 35,
       "xws": "static",
       "ability": "While you perform a primary attack, you may spend your lock on the defender and a focus token to change all your results to [Crit] results.",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/2481fe5d98026e086a901d83dbe87018.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/30e0837d4877df289c220ea0ae174078.jpg",
       "slots": ["Talent", "Tech", "Modification"],
       "ffg": 399
     },
@@ -115,6 +122,8 @@
       "cost": 33,
       "xws": "longshot",
       "ability": "While you perform a primary attack at attack range 3, roll 1 additional attack die.",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/d0e698f59696c15b60d7eaa1e2d51eeb.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/31ad38b2fc0d39f37ad82e1c70f62135.jpg",
       "slots": ["Talent", "Tech", "Modification"],
       "ffg": 400
     },
@@ -124,6 +133,8 @@
       "limited": 0,
       "cost": 31,
       "xws": "omegasquadronace",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/97e72d0f5dc8c2dd21a355e3258f37dd.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/4e5010f7b60902288dac36bf646dcde9.jpg",
       "slots": ["Talent", "Tech", "Modification"],
       "ffg": 403
     },
@@ -135,7 +146,8 @@
       "cost": 32,
       "xws": "muse",
       "ability": "At that start of the Engagement Phase, you may choose a friendly ship at range 0-1. If you do, that ship removes 1 stress token.",
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/bc/6a/bc6a10be-53d1-493d-95b5-d556ae7379a0/swz18_a1_muse.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/7de4e91de0906eb548bfe3a08a1b6abe.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/d3f8b9baf0bbd8a7d2b785a616dacbcf.jpg",
       "slots": ["Talent", "Tech", "Modification"],
       "ffg": 401
     },
@@ -147,6 +159,8 @@
       "cost": 31,
       "xws": "tn3465",
       "ability": "While another friendly ship performs an attack, if you are at range 0-1 of the defender, you may suffer 1 [Crit] damage to change 1 of the attacker's results to a [Crit] result.",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/333cbf0da8849edb38c4e93944d8fe57.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/9fce0e75539a225e9ff1536e466c3c13.jpg",
       "slots": ["Tech", "Modification"],
       "ffg": 453
     },
@@ -156,6 +170,8 @@
       "limited": 0,
       "cost": 29,
       "xws": "zetasquadronpilot",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/be1062b6a7a8e4644223146342990a02.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/d20d6cc2a052afc783d535c802874d23.jpg",
       "slots": ["Tech", "Modification"],
       "ffg": 404
     },
@@ -165,6 +181,8 @@
       "limited": 0,
       "cost": 28,
       "xws": "epsilonsquadroncadet",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/e911cd18f04225bbd36c48114b56f3cc.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/610cb198e4cda75aab0207841c6e4a87.jpg",
       "slots": ["Tech", "Modification"],
       "ffg": 405
     },
@@ -175,6 +193,8 @@
       "limited": 1,
       "cost": 30,
       "xws": "lieutenantrivas",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/7188ec2eb699261dbd47a15df6164f4c.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/66f969d008fc995bd940bf1ab647109f.jpg",
       "ability": "After a ship at range 1-2 gains a red or orange token, if you do not have that ship locked, you may acquire a lock on that ship.",
       "slots": ["Tech", "Modification"],
       "ffg": 454
@@ -187,6 +207,8 @@
       "cost": 31,
       "xws": "null",
       "ability": "While you are not damaged, treat your initiative value as 7.",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/79a9d780d3540647af1e057113869294.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/eb788d9622d096c6d96c96cf20dc1939.jpg",
       "slots": ["Talent", "Tech", "Modification"],
       "ffg": 402
     }

--- a/data/pilots/first-order/tie-sf-fighter.json
+++ b/data/pilots/first-order/tie-sf-fighter.json
@@ -76,6 +76,8 @@
         "Modification"
       ],
       "charges": { "value": 1, "recovers": 1 },
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/d038dadd7a62bbe2de89d3866e1a3639.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/86f8ccc959081a43dc4d0dbeb921d0ba.jpg",
       "ffg": 406
     },
     {
@@ -98,6 +100,8 @@
         "Gunner",
         "Modification"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/317cc5350980277f1d389ed618030d85.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/6c3a06877712596601ba1cc4ec533626.jpg",
       "ffg": 407
     },
     {
@@ -118,6 +122,8 @@
         "Gunner",
         "Modification"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/784d00f653ff7cd58cb634c7a59e47c1.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/2caf1312bd6aba3630ef6edc1ff81f53.jpg",
       "ffg": 408
     },
     {
@@ -138,6 +144,8 @@
         "Gunner",
         "Modification"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/848db1993150bda19217e2c14b3c3df6.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/55f72ce4974962db5b2ab3fac316b896.jpg",
       "ffg": 409
     }
   ]

--- a/data/pilots/first-order/tie-vn-silencer.json
+++ b/data/pilots/first-order/tie-vn-silencer.json
@@ -74,6 +74,8 @@
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
       "slots": ["Talent", "Tech", "Torpedo", "Missile", "Modification"],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/c5659b210e13b4e11fdd5f1396f2847c.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/20308b5887fb20d6b8ecdb3ede0bede3.jpg",
       "ffg": 415
     },
     {
@@ -90,6 +92,8 @@
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
       "slots": ["Force", "Tech", "Torpedo", "Missile", "Modification"],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/71dbde337b9ff5aab897781d40d8f653.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/80b87be22656fc01742fca490193d440.jpg",
       "ffg": 414
     },
     {
@@ -104,6 +108,8 @@
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
       "slots": ["Talent", "Tech", "Torpedo", "Missile", "Modification"],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/568abbcd68bb174173da4e7ee92051e3.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/86349c032fc169cb2000d3db7c9fbef4.jpg",
       "ffg": 416
     },
     {
@@ -119,6 +125,8 @@
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
       "slots": ["Talent", "Tech", "Torpedo", "Missile", "Modification"],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/ab11858b2b9ac5c8bbfb2dc21023ba34.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/c4590088696ecc687f5c0f004d1d97ab.jpg",
       "ffg": 455
     },
     {
@@ -134,6 +142,8 @@
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
       "slots": ["Talent", "Tech", "Torpedo", "Missile", "Modification"],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/d90d3057ead18b5df5f6de55a199a4cd.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/3778411ec66e33951231314e909b981d.jpg",
       "ffg": 456
     },
     {
@@ -148,6 +158,8 @@
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
       "slots": ["Tech", "Torpedo", "Missile", "Modification"],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/8f7c4680fbc001169baf6538ab259e9b.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/18b2a1b00b2f8c6669b6b1d1b278dcf2.jpg",
       "ffg": 417
     }
   ]

--- a/data/pilots/first-order/upsilon-class-command-shuttle.json
+++ b/data/pilots/first-order/upsilon-class-command-shuttle.json
@@ -86,6 +86,8 @@
         "Crew",
         "Modification"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/e4acd80da2c39e25d4f999cb7c314fe5.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/4505cb1930309673fe5592dbc112d733.jpg",
       "ffg": 412
     },
     {
@@ -96,7 +98,6 @@
       "cost": 63,
       "xws": "majorstridan",
       "ability": "While you coordinate or resolve the effect of one of your upgrades, you may treat friendly ships at range 2-3 as being at range 0 or range1.",
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/1b/2c/1b2cbc1c-7e49-4f9d-b25a-b72d7319b90b/swz18_major-stridan_a2.png",
       "shipAbility": {
         "name": "Linked Battery",
         "text": "Whlie you perform a [Cannon] attack, roll 1 additional die."
@@ -111,6 +112,8 @@
         "Crew",
         "Modification"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/8420beca035dedf1596c7c99255fb2e7.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/862f9dcc1ce9809f9a394d8f0b05f268.jpg",
       "ffg": 410
     },
     {
@@ -140,6 +143,8 @@
         "Crew",
         "Modification"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/3a2232a5238d8bf5e7538fe1d6003dbc.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/24a40f6ec1875bfae9e7531b02252993.jpg",
       "ffg": 458
     },
     {
@@ -167,6 +172,8 @@
         "Crew",
         "Modification"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/41f6d936f14a058ed1c5e6ac12de37c2.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/1ea0266ea42691778e8ecff6a5b50e45.jpg",
       "ffg": 413
     },
     {
@@ -195,6 +202,8 @@
         "Crew",
         "Modification"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/20fbf3ed79c50d2082cdb44caac26064.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/151154b50732a6dd42b411fc312137b9.jpg",
       "ffg": 411
     },
     {
@@ -205,7 +214,6 @@
       "cost": 64,
       "xws": "captaincardinal",
       "ability": "While a friendly ship at range 1-2 with lower initiative than you defends or performs an attack, if you have at least 1 [Charge], that ship may reroll 1 [Focus] result. After an enemy ship are range 0-3 is destroyed, lose 1 [Charge].",
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/1b/2c/1b2cbc1c-7e49-4f9d-b25a-b72d7319b90b/swz18_major-stridan_a2.png",
       "shipAbility": {
         "name": "Linked Battery",
         "text": "Whlie you perform a [Cannon] attack, roll 1 additional die."
@@ -224,6 +232,8 @@
         "Crew",
         "Modification"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/be29a69f75726ad48f607eecca671e01.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/a88822cc408323e561efd9e2acb83f2a.jpg",
       "ffg": 457
     }
   ]

--- a/data/pilots/rebel-alliance/t-65-x-wing.json
+++ b/data/pilots/rebel-alliance/t-65-x-wing.json
@@ -56,6 +56,7 @@
       "xws": "bluesquadronescort",
       "text": "Designed by Incom Corporation, the T-65 X-wing quickly proved to be one of the most effective and versatile military vehicles in the galaxy and a boon to the Rebellion.",
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
       "alt": [
         {
           "image": "https://images-cdn.fantasyflightgames.com/filer_public/9c/1a/9c1ad7ef-dfb1-427c-b700-747d857f53fc/op066-blue-squadron-pilot.png",

--- a/data/pilots/resistance/mg-100-starfortress-sf-17.json
+++ b/data/pilots/resistance/mg-100-starfortress-sf-17.json
@@ -69,7 +69,8 @@
       "limited": 0,
       "xws": "cobaltsquadronbomber",
       "text": "Whether the ordnance silos of their StarFortresses are loaded with proton bombs or relief supplies, the heroic crews of Cobalt Squadron dedicate their lives to making a difference in the galaxy.",
-      "image": "http://www.infinitearenas.com/xw2browse/images/resistance/cobalt-squadron-bomber.jpg",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/6b6a3bb8049699e2d66fe09531e8bc00.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/514351d5c41a8341ea5da5673269d917.jpg",
       "cost": 63,
       "slots": [
         "Sensor",
@@ -90,7 +91,8 @@
       "limited": 1,
       "xws": "cat",
       "ability": "While you perform a primary attack, if the defender is at range 0-1 of at least 1 friendly device, roll 1 additional die.",
-      "image": "http://www.infinitearenas.com/xw2browse/images/resistance/cat.jpg",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/b386dc25736682ebc785b15551de903b.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/d927ccf08a9444340378449fe71e9f70.jpg",
       "cost": 64,
       "slots": [
         "Sensor",
@@ -111,7 +113,8 @@
       "limited": 1,
       "xws": "vennie",
       "ability": "While you defend, if the attacker is in a friendly ship's [Turret], you may add 1 [Focus] result to your roll.",
-      "image": "http://www.infinitearenas.com/xw2browse/images/resistance/vennie.jpg",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/0d494986a24e6c55efae066a43161b0d.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/511b878f719e9fa59a50cdf980d10ead.jpg",
       "cost": 67,
       "slots": [
         "Sensor",
@@ -132,7 +135,8 @@
       "limited": 1,
       "xws": "benteene",
       "ability": "After you perform an attack, if the defender is in your [Turret], assign the RATTLED condition to the defender.",
-      "image": "http://www.infinitearenas.com/xw2browse/images/resistance/ben-teene.jpg",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/c9189c7e510b4d734d4d78c4f595010f.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/74ca7444aec38cb0034b67b04f6aaa76.jpg",
       "cost": 68,
       "slots": [
         "Sensor",
@@ -153,7 +157,8 @@
       "limited": 1,
       "xws": "edonkappehl",
       "ability": "After you fully execute a blue or white maneuver, if you have not dropped or launched a device this round, you may drop 1 device.",
-      "image": "http://www.infinitearenas.com/xw2browse/images/resistance/edon-kappehl.jpg",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/f58fe0b57dc4a9c878627f0fea9cf1ef.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/bbac51ca4ba44f26d90a53b6c5db5e2c.jpg",
       "cost": 69,
       "slots": [
         "Sensor",
@@ -174,7 +179,8 @@
       "limited": 1,
       "xws": "finchdallow",
       "ability": "Before you would drop a bomb, you may place it in the play area touching you instead.",
-      "image": "http://www.infinitearenas.com/xw2browse/images/resistance/finch-dallow.jpg",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/43d9a0555f719a4cbe1ffe905fd38c46.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/dafd2937accc362f766ca0da3308ccbc.jpg",
       "cost": 70,
       "slots": [
         "Sensor",

--- a/data/pilots/resistance/rz-2-a-wing.json
+++ b/data/pilots/resistance/rz-2-a-wing.json
@@ -47,8 +47,9 @@
         "name": "Refined Gyrostabilizers",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/87/ef/87efde7e-148e-44e9-85ee-a1153de4b86b/swz22_lulo_lampar.png",
       "slots": ["Talent", "Talent", "Tech", "Missile"],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/e15d3e2a2fc082b95a64a83df0c96f7f.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/b97a025a7859f54bbc68374ff5d8116e.jpg",
       "ffg": 435
     },
     {
@@ -63,7 +64,8 @@
         "name": "Refined Gyrostabilizers",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/4c/5f/4c5ff4d0-0a0b-450c-b557-3baca4cabdb9/swz22_tallissan_lintra.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/72cb6c4e50b0ad24af0bb84ce0aa53f0.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/ee8c3c26ce6432d7581c5f61392597bc.jpg",
       "charges": { "value": 1, "recovers": 1 },
       "slots": ["Talent", "Talent", "Tech", "Missile"],
       "ffg": 436
@@ -80,7 +82,8 @@
         "name": "Refined Gyrostabilizers",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/8f/63/8f630eba-1203-41f7-b4d1-688c6b8e7b53/swz22_zari_bangel.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/d7f37dbb86bb706dd535e9a65b69149a.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/2fe44e1e5496645c16f4d2189a1746e3.jpg",
       "slots": ["Talent", "Talent", "Tech", "Missile"],
       "ffg": 438
     },
@@ -96,7 +99,8 @@
         "name": "Refined Gyrostabilizers",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/0e/a9/0ea93e07-5308-434d-b1ef-28b4cb8cc9d9/swz22_greer_sonnel.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/7fc7b194b02ad7af6adf4ef9b79108d1.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/84bf1ce21926d4500b54e122da01b162.jpg",
       "slots": ["Talent", "Talent", "Tech", "Missile"],
       "ffg": 437
     },
@@ -111,6 +115,8 @@
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
       "slots": ["Talent", "Talent", "Tech", "Missile"],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/3f7ad9efb4c5af8b4d1f5c07a3c7538b.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/8427bdfb1cf9497a9ab797e2c955ba41.jpg",
       "ffg": 439
     },
     {
@@ -124,6 +130,8 @@
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
       "slots": ["Tech", "Missile"],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/e033b2729305ac0b678d6031ada7b2b8.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/3df643a75106a59899e5f32ef56e8a5e.jpg",
       "ffg": 440
     }
   ]

--- a/data/pilots/resistance/scavenged-yt-1300.json
+++ b/data/pilots/resistance/scavenged-yt-1300.json
@@ -66,7 +66,8 @@
       "limited": 0,
       "xws": "resistancesympathizer",
       "text": "After witnessing the Hosnian Cataclysm, some spacers willingly aided the Resistance with whatever ships they had.",
-      "image": "http://www.infinitearenas.com/xw2browse/images/resistance/resistance-sympathizer.jpg",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/28411b84c1b15f0bfa9928f2206e44f5.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/3e567923957881e9a4dbef46789c7fbf.jpg",
       "cost": 68,
       "slots": ["Crew", "Crew", "Gunner", "Illicit", "Modification", "Title"],
       "ffg": 430
@@ -78,7 +79,8 @@
       "limited": 1,
       "xws": "chewbacca-scavengedyt1300",
       "ability": "After a friendly ship at range 0/3 is destroyed, you may perform an action. Then you may perform a bonus attack.",
-      "image": "http://www.infinitearenas.com/xw2browse/images/resistance/chewbacca.jpg",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/422fc30e0e10445e80b304ef2d96dc06.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/c40ec30b7df138c4510b08f4f02d54b5.jpg",
       "cost": 72,
       "slots": [
         "Talent",
@@ -98,7 +100,8 @@
       "limited": 1,
       "xws": "hansolo-scavengedyt1300",
       "ability": "SETUP: You can be placed anywhere in the play area beyond range 3 of enemy ships.",
-      "image": "http://www.infinitearenas.com/xw2browse/images/resistance/han-solo.jpg",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/5816bd53c272ed50096e22ae1af2b38a.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/15263defc98e4a54d76ae9224534dacf.jpg",
       "cost": 76,
       "slots": [
         "Talent",
@@ -118,7 +121,8 @@
       "limited": 1,
       "xws": "rey",
       "ability": "While you defend or perform an attack, if the enemy ship is in your [Front Arc], you may spend 1 [Force] to change 1 of your blank results to an [Evade] or [Hit] result.",
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/f9/27/f9276fd7-52fd-4b05-8599-05039fa479e6/swz19_a2_reys-pilot.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/0ee7006e6cc51d8c08b784c9b770f1b0.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/1ff06aeff0d74773e9c9f3846b38b75d.jpg",
       "force": { "value": 2, "recovers": 1, "side": ["light"] },
       "cost": 80,
       "slots": [

--- a/data/pilots/resistance/t-70-x-wing.json
+++ b/data/pilots/resistance/t-70-x-wing.json
@@ -46,7 +46,8 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/ea/60/ea60fada-8e09-4d9e-9dee-c47492e65124/swz25_poe_a1.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/14c504c0815213a66010c4013d9296ee.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/cb8efd0b723b8ceb0c35b7a64b309bf2.jpg",
       "cost": 68,
       "charges": { "value": 1, "recovers": 1 },
       "slots": [
@@ -69,7 +70,8 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/ec/05/ec050670-3a1c-4581-8829-fcc60c3cf8e6/swz25_blue-sqd_a1.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/a82a39a4c9baf883fbc6ae353abdd2ec.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/8ceeaf3d985f16da8b8d5a1ebc49ea2b.jpg",
       "cost": 46,
       "slots": ["Tech", "Astromech", "Modification", "Configuration", "Title"],
       "ffg": 426
@@ -84,7 +86,8 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/dc/0c/dc0c0e5c-1679-401e-aeb7-cb28085c194e/swz25_red-sqd_a1.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/58967d94cfef285c4df2fdbb77fd0502.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/0e847453270afe089ea331316f7b7731.jpg",
       "cost": 48,
       "slots": ["Tech", "Astromech", "Modification", "Configuration", "Title"],
       "ffg": 425
@@ -99,7 +102,8 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/d8/6e/d86ed567-822a-4c5f-b367-ed0a8e7c802d/swz25_black-sqd-ace_a1.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/d2b6a5166b3fd985df5d1941408b58e1.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/e75228d8174f7879c51157fdd9b26e61.jpg",
       "cost": 50,
       "slots": [
         "Talent",
@@ -131,6 +135,8 @@
         "Configuration",
         "Title"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/f77180ae05fd919a0dff2225380246a6.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/ff73537d7ab2f063e7a510c05013269e.jpg",
       "ffg": 419
     },
     {
@@ -144,7 +150,6 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/90/fc/90fc30fb-db99-46cb-8761-89b6536286eb/swz25_joph_a1.png",
       "cost": 52,
       "slots": [
         "Talent",
@@ -154,6 +159,8 @@
         "Configuration",
         "Title"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/df85f5b77e16363a05c8f68792440166.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/b5b43d179b039649e764e6bd4f212a29.jpg",
       "ffg": 424
     },
     {
@@ -163,7 +170,6 @@
       "limited": 1,
       "xws": "karekun",
       "ability": "While you boost, you may use the [1[Turn Left]] or [1[Turn Right]] template instead.",
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/42/59/42597afe-f592-4bac-98ad-f70e876fb451/swz25_kare_a1.png",
       "shipAbility": {
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
@@ -177,6 +183,8 @@
         "Configuration",
         "Title"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/6edb8ed4cbf882bf6dbe7a37b5981d85.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/f121bc27f2b283258a65d348bcafe40d.jpg",
       "ffg": 421
     },
     {
@@ -190,7 +198,8 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/5c/57/5c572491-e1c7-4618-bb2d-7de20511d82c/swz25_lt-bastian_a1.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/3f43d6b3c6e87bde6a681e9d4421dec8.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/52f96e7e98dc51c1280052514e303704.jpg",
       "cost": 48,
       "slots": ["Tech", "Astromech", "Modification", "Configuration", "Title"],
       "ffg": 449
@@ -215,6 +224,8 @@
         "Configuration",
         "Title"
       ],
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/00a3c393a33b33168bc61e47749e1474.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/5daa441317975eb576396af36e852f74.jpg",
       "ffg": 420
     },
     {
@@ -228,7 +239,8 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/0c/d5/0cd558ff-78ea-4c14-8c9a-0276e7daf716/swz25_jaycris_a1.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/5f3abacb9a081f5a3ca42f7a30da0e6c.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/8874efb312a64da49889c66f96338f9c.jpg",
       "cost": 50,
       "slots": ["Tech", "Astromech", "Modification", "Configuration", "Title"],
       "ffg": 450
@@ -244,7 +256,8 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "image": "http://www.infinitearenas.com/xw2browse/images/resistance/jessika-pava.jpg",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/bc26d8864f421f1362473aa4982108ba.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/05c48dc381e54c6951d3ee42d3587577.jpg",
       "cost": 52,
       "charges": { "value": 1, "recovers": 1 },
       "slots": ["Tech", "Astromech", "Modification", "Configuration", "Title"],
@@ -261,7 +274,8 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "image": "http://www.infinitearenas.com/xw2browse/images/resistance/temmin-wexley.jpg",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/bb98b7ea3a580542b586a9999fd352c9.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/6acd118b12a34136d4d1df6c765a0deb.jpg",
       "cost": 54,
       "slots": [
         "Talent",

--- a/data/pilots/scum-and-villainy/modified-tie-ln-fighter.json
+++ b/data/pilots/scum-and-villainy/modified-tie-ln-fighter.json
@@ -44,7 +44,8 @@
         "name": "Notched Stabilizers",
         "text": "While you move, you ignore asteroids."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/d5/af/d5af765f-4c49-4209-98a8-e76f52bf9608/swz23_ahhav.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/d58a0696c8d85a63e90eb8a1e522a54c.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/2d162fae88ae58b9eca31f7dc0b7a9da.jpg",
       "slots": ["Talent", "Modification"],
       "ffg": 442
     },
@@ -56,7 +57,8 @@
       "cost": 28,
       "xws": "captainseevor",
       "ability": "While you defend or perform an attack, before attack dice are rolled, if you are not in the enemy ship's [Bullseye Arc], you may spend 1 [Charge]. If you do, the enemy ship gains 1 jam token.",
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/c9/f5/c9f5de03-e3e2-45b9-a86e-10ba74d1baed/swz23_a1_captain-seevor.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/70b64586cc2eb05d10efc7ba8dfd69d0.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/6ead4bbfa14075a19972dc57b90a34e1.jpg",
       "charges": { "value": 1, "recovers": 1 },
       "shipAbility": {
         "name": "Notched Stabilizers",
@@ -77,7 +79,8 @@
         "name": "Notched Stabilizers",
         "text": "While you move, you ignore asteroids."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/a0/bf/a0bf95a7-36ba-4e1b-a946-2372bed3cf2a/swz23_foreman_proach.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/cfb3b5fa9d747afc3aa10f3b86f45818.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/f789aa53866112fc44fd27ed9e177993.jpg",
       "slots": ["Talent", "Modification"],
       "ffg": 441
     },
@@ -92,7 +95,8 @@
         "name": "Notched Stabilizers",
         "text": "While you move, you ignore asteroids."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/bf/da/bfda499f-603a-41c7-b2ee-50ffeeddb384/swz23_mining-guild-surveyor.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/3e5872dea32f2015bb6737592c21efaf.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/ad058d0b6d46f668f06bf0007207a30a.jpg",
       "slots": ["Talent", "Modification"],
       "ffg": 445
     },
@@ -109,7 +113,8 @@
         "text": "While you move, you ignore asteroids."
       },
       "charges": { "value": 1, "recovers": 1 },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/c1/78/c178c035-befe-44dd-bdb6-541c377ed85b/swz23_overseer-yushyn.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/6c9268d3e6cc6b671d6db6ac39fcad0f.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/1f454eb7c12b572103e59a9a782c3f50.jpg",
       "slots": ["Modification"],
       "ffg": 444
     },
@@ -124,7 +129,8 @@
         "name": "Notched Stabilizers",
         "text": "While you move, you ignore asteroids."
       },
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/53/32/5332ea1f-21df-4a19-bfd5-557b3f825e6d/swz23_mining-guild-sentry.png",
+      "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/6d67112b15c3c97bd3d4acf2c8d000ed.png",
+      "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/09c955b8008750a30fe398c200431160.jpg",
       "slots": ["Modification"],
       "ffg": 446
     }

--- a/data/upgrades/astromech.json
+++ b/data/upgrades/astromech.json
@@ -207,7 +207,8 @@
         "title": "R2-HA",
         "type": "Astromech",
         "ability": "While you defend, you may spend your lock on the attacker to reroll any number of your defense dice.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/2b/17/2b17e1c2-ba4f-4456-aba3-7b66a7a2d803/swz19_a2_r2-ha.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/b3e6d35ca6b6fd297312248ddf4e69a7.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/d72ab7fa7cd398d614466a98076a2e6b.jpg",
         "slots": ["Astromech"],
         "ffg": 482
       }
@@ -224,7 +225,8 @@
         "title": "BB-8",
         "type": "Astromech",
         "ability": "Before you execute a blue maneuver, you may spend 1 [Charge] to perform a [Barrel Roll] or [Boost] action.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/13/fe/13fe41a3-58df-41a7-ba97-38aed4a6c1fe/swz25_bb-8_a1.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/37297ef7839800afd543de5d1a363561.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/e8a75e0e143a5857ac3931d56ccde86c.jpg",
         "slots": ["Astromech"],
         "charges": {
           "value": 2,
@@ -245,7 +247,8 @@
         "title": "BB Astromech",
         "type": "Astromech",
         "ability": "Before you execute a blue maneuver, you may spend 1 [Charge] to perform a [Barrel Roll].",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/f8/fd/f8fd534a-43df-4285-a41c-1f8a789d06a5/swz25_bb-astromech_a1.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/010399f4054469aed3b04acba08d41b0.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/a2e3aaf77e8690a37e76ef4ae2087180.jpg",
         "slots": ["Astromech"],
         "charges": {
           "value": 2,
@@ -270,7 +273,8 @@
         "title": "M9-G8",
         "type": "Astromech",
         "ability": "While a ship you are locking performs an attack, you may choose 1 attack die. If you do, the attacker rerolls that die.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/ca/5f/ca5fc18f-26ae-41e2-8edf-e0ee93d872cb/swz25_m9-g8_a1.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/cd67f33e8aa52d2aeb07f432125a8c73.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/f810d46699343a134003deea0f423131.jpg",
         "slots": ["Astromech"],
         "ffg": 481
       }

--- a/data/upgrades/configuration.json
+++ b/data/upgrades/configuration.json
@@ -37,7 +37,8 @@
         "type": "Configuration",
         "ability": "Before you activate, you may flip this card.",
         "slots": ["Configuration"],
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/d4/6d/d46d332b-29a4-4cf6-be57-3078bf250931/swz25_s-foils-open_a1.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/e3b44142faf0f13e541bf674a6c06dbc.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/bf5e7b98158570f9d4fc259b5553f4ca.jpg",
         "ffg": 487
       }
     ],

--- a/data/upgrades/crew.json
+++ b/data/upgrades/crew.json
@@ -200,6 +200,8 @@
         "type": "Crew",
         "ability": "At the end of the Engagement Phase, each enemy ship at range 0-1 that is not stressed gains 1 stress token.",
         "slots": ["Crew"],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/784566afc8c540d5e392689865207059.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/71ad5db561ea39d9d59c4bbdc1b42f35.jpg",
         "ffg": 465
       }
     ],
@@ -416,6 +418,8 @@
         "type": "Crew",
         "ability": "While you perform a white [Coordinate] action, you may treat if as red. If you do, you may coordinate up to 2 additional ships of the same ship type, and each ship you coordinate must perform the same action, treating that action as red.",
         "slots": ["Crew"],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/fa0b8492eff625bc66f00bd561015465.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/94bee4960ca0fb907ba77d5cb2ff7abb.jpg",
         "ffg": 466
       }
     ],
@@ -647,6 +651,8 @@
         "conditions": ["illshowyouthedarkside"],
         "slots": ["Crew"],
         "force": { "value": 1, "recovers": 1 },
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/f60322a1f5ace7e45f6c7e0fa0200705.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/a61302c8e1cd180d4198e9ae75b82e91.jpg",
         "ffg": 467
       }
     ],
@@ -896,6 +902,8 @@
         "type": "Crew",
         "ability": "During the Activation or Engagement Phase, after an enemy ship in your [Front Arc] at range 0-1 gains a red or orange token, if you are not stressed, you may gain 1 stress token. If you do, that ship gains 1 additional token of the type that it gained.",
         "slots": ["Crew"],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/900397d209adfd3f7bd6429909cc20cc.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/007c0145ba0ec1c57de17c0448cafef2.jpg",
         "ffg": 468
       }
     ],
@@ -1020,6 +1028,8 @@
         "ability": "During the System Phase, you may choose any number of enemy ships beyond range 1. If you do, spend that many [Force] to flip each chosen ship's dial faceup.",
         "slots": ["Crew", "Crew"],
         "force": { "value": 1, "recovers": 1 },
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/5b699f8b5268e5290c42adce0fd2ee3e.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/3b29995fb9e419822a34c672f2543fa6.jpg",
         "ffg": 469
       }
     ],
@@ -1117,7 +1127,8 @@
         "title": "C-3PO",
         "type": "Crew",
         "ability": "While you coordinate, you can choose friendly ships beyond range 2 if they have [Calculate] on their action bar. After you perform the [Calculate] or [Coordinate] action, gain 1 calculate token.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/59/61/5961c0a7-3b16-424a-9b0c-6151b44fc7cd/swz19_a2_tfa-3p0.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/a0e80bb89748e7415e945a050f82ba84.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/1629b5a262f8b69e1dee4b841150c9b7.jpg",
         "slots": ["Crew"],
         "grants": [
           {
@@ -1146,7 +1157,8 @@
         "title": "Han Solo",
         "type": "Crew",
         "ability": "After you perform an [Evade] action, gain additional evade tokens equal to the number of enemy ships at range 0-1.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/5d/64/5d64e6da-db3c-414e-a10f-c9bf577e5de1/swz19_a2_old-han.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/622ea4b573afbb5c95b3e9f2989a8aef.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/af2ce405b6c28568aa2d66b78296b351.jpg",
         "slots": ["Crew"],
         "grants": [
           {
@@ -1170,7 +1182,8 @@
         "title": "Chewbacca",
         "type": "Crew",
         "ability": "Setup: Lose 1 [Charge]. After a friendly ship at range 0-3 is dealt 1 damage card, recover 1 [Charge]. While you perform an attack, you may spend 2 [Charge] to change 1 [Focus] result to a [Crit] result.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/d7/bc/d7bcf1f0-48e5-4566-8e6d-5be670c04858/swz19_a2_tfa-chewie.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/3090c218acff7dc71a81e791ce15860e.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/3d124811dd272ec2355a30903a827034.jpg",
         "slots": ["Crew"],
         "charges": { "value": 2, "recovers": 0 },
         "ffg": 473
@@ -1188,7 +1201,8 @@
         "title": "Rose Tico",
         "type": "Crew",
         "ability": "While you defend or perform a primary attack, you may spend 1 of your results to acquire a lock on the enemy ship.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/17/20/1720a677-330a-4165-b7a8-1594d62f72c6/swz19_a2_rose-tico.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/60ac08169a90794c33d1d582f1a08480.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/92a93952c31c95dff0fc96f31e88cfd3.jpg",
         "slots": ["Crew"],
         "ffg": 475
       }

--- a/data/upgrades/force-power.json
+++ b/data/upgrades/force-power.json
@@ -93,6 +93,8 @@
         "ability": "After you suffer 1 or more damage, recover that many [Force].",
         "slots": ["Force Power"],
         "restrictions": [{ "force_side": ["dark"] }],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/4a10b5c8a3d796116163a741d145f4e9.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/a373c947f0a56ee4bcf4223250326dc0.jpg",
         "ffg": 489
       }
     ],

--- a/data/upgrades/gunner.json
+++ b/data/upgrades/gunner.json
@@ -245,8 +245,10 @@
       {
         "title": "Special Forces Gunner",
         "type": "Gunner",
-        "ability": "...e you perform a primary [Front Arc] attack, ...your [Single Turret Arc] is in your [Front Arc], you may roll 1 additional attack die. ...er you perform a primary [Front Arc] attack, ...our [Single Turret Arc] is in your [Rear Arc], you may perform a bonus primary [Single Turret Arc] attack.",
+        "ability": "While you perform a primary [Front Arc] attack, if your [Single Turret Arc] is in your [Front Arc], you may roll 1 additional attack die. ...er you perform a primary [Front Arc] attack, if your [Single Turret Arc] is in your [Rear Arc], you may perform a bonus primary [Single Turret Arc] attack.",
         "slots": ["Gunner"],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/d3aed19c7eb6f9ebc2352ac49cdd6b87.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/b87bf63d7db6195febd879edc4880f13.jpg",
         "ffg": 470
       }
     ],
@@ -297,8 +299,9 @@
         "title": "Finn",
         "type": "Gunner",
         "ability": "While you defend or perform a primary attack, if the enemy ship is in your [Front Arc], you may add 1 blank result to your roll (this die can be rerolled or otherwise modified).",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/89/06/8906ae3a-46b0-45f2-8db9-21b81cb05e0a/swz19_a2_finn-gunner.png",
         "slots": ["Gunner"],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/79477be319935f42270f1712cd269dff.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/7d5d0c76d3c8fdbb5ec893c270eec7b2.jpg",
         "ffg": 476
       }
     ],
@@ -314,8 +317,9 @@
         "title": "Paige Tico",
         "type": "Gunner",
         "ability": "After you perform an attack, you may drop 1 bomb or rotate your [Single Turret Arc]. After you are destroyed, you may drop 1 bomb.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/1d/1b/1d1bade1-7afd-40e6-97ae-4430dfe9d169/swz19_a2_paig-tico.png",
         "slots": ["Gunner"],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/9dc15f634233b5daba107a07aa63d04c.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/a34ab7a76083f91577110d31d20b6e14.jpg",
         "ffg": 477
       }
     ],
@@ -333,6 +337,8 @@
         "ability": "While you defend or perform an attack, if the enemy ship is in your [Single Turret Arc], you may spend 1 [Force] to change 1 of your blank results to a [Hit] or [Crit] result.",
         "slots": ["Gunner"],
         "force": { "value": 1, "recovers": 1 },
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/e11aec8ae6ec855694947bc2f9d1917e.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/ab5eea679d5ca9369cd122bc65001119.jpg",
         "ffg": 478
       }
     ],

--- a/data/upgrades/talent.json
+++ b/data/upgrades/talent.json
@@ -176,6 +176,8 @@
         "type": "Talent",
         "ability": "While you defend or perform an attack, if you have only blank results and have 2 or more results, you may reroll any number of your dice.",
         "slots": ["Talent"],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/9f8baf4893cd90288df44b69b50fa788.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/0f6d1677c35001248d7768047c10aa87.jpg",
         "ffg": 471
       }
     ],

--- a/data/upgrades/tech.json
+++ b/data/upgrades/tech.json
@@ -9,6 +9,8 @@
         "type": "Tech",
         "ability": "While you perform an attack, you may spend 1 focus token to change 1 of your blank results to a [Hit] result.",
         "slots": ["Tech"],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/e77e204e6b7164f6a1d945b20a0c4359.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/e19aa7cd99df250715c17386135cd140.jpg",
         "ffg": 460
       }
     ],
@@ -26,7 +28,8 @@
         "type": "Tech",
         "ability": "After an enemy ship locks you, if you are not in that ship's [Bullseye Arc], that ship gains 1 stress token.",
         "slots": ["Tech"],
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/3c/6c/3c6c1f9b-e419-4b99-9336-79b6d2fb5a6e/swz22_ferrosphere_paint.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/55d8ff7d35b714d9c9a6ef1fd7732a60.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/55ff3d199702695f23631d85a25bbae6.jpg",
         "ffg": 488
       }
     ],
@@ -49,6 +52,8 @@
         "type": "Tech",
         "ability": "Setup: Before placing forces, you may... 0 and 6...",
         "slots": ["Tech"],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/a48713c6784bf33bd3f8b36eb19221c3.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/fa5c01453d7aa2e2f1f100593e79669d.jpg",
         "ffg": 461
       }
     ],
@@ -65,7 +70,8 @@
         "title": "Primed Thrusters",
         "type": "Tech",
         "ability": "While you have 2 or fewer stress tokens, you can perform [Barrel Roll] and [Boost] actions even while stressed.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/86/a1/86a1115b-eb55-491b-84e4-67e2b6124999/swz19_a1_primed-thrusters.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/a114625347a0f3088f4679f8107ab631.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/3789dd873db0d0c74293531bef49e16e.jpg",
         "slots": ["Tech"],
         "ffg": 463
       }
@@ -88,7 +94,8 @@
         "title": "Targeting Synchronizer",
         "type": "Tech",
         "ability": "While a friendly ship at range 1-2 performs an attack against a target you have locked, that ship ignores the [Lock] attack requirement.",
-        "image": "https://images-cdn.fantasyflightgames.com/filer_public/3a/f7/3af7d426-c7f1-456e-b2e7-dfb3b735f9da/swz19_a1_targeting-synchronizer.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/83782f01cd3486006c4d279864d2983a.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/1597042d794000fb34d1eee30cc10f35.jpg",
         "slots": ["Tech"],
         "ffg": 464
       }
@@ -107,6 +114,8 @@
         "type": "Tech",
         "ability": "While you fully execute a red maneuver, before the Check Difficulty step, you may perform 1 action.",
         "slots": ["Tech"],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/ace963fc4fe9d97f64ab8564dc4beae7.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/811e07d55f95e53fef3182020d8cbf6e.jpg",
         "ffg": 462
       }
     ],
@@ -124,6 +133,8 @@
         "type": "Tech",
         "ability": "While you coordinate or jam, if you have a lock on a ship, you may spend that lock to choose that ship, ignoring range restrictions.",
         "slots": ["Tech"],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/094f3bbc6e3041886398e9eaf692d4ab.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/14c54aef2e36ac34564194e4785c98ce.jpg",
         "ffg": 491
       }
     ],

--- a/data/upgrades/title.json
+++ b/data/upgrades/title.json
@@ -41,6 +41,8 @@
         "slots": ["Title"],
         "charges": { "value": 1, "recovers": 0 },
         "actions": [{ "type": "SLAM", "difficulty": "White" }],
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/3e9870bff7f61acc12970c254eaeca89.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/b617cc192e2ffb8368de79d69e1e7956.jpg",
         "ffg": 484
       }
     ],
@@ -443,7 +445,8 @@
         "title": "Rey's Millennium Falcon",
         "type": "Title",
         "ability": "If you have 2 or fewer stress tokens, you can execute red Segnor's Loop [[Segnor's Loop Left] or [Segnor's Loop Right]] maneuvers and perform [Boost] and [Rotate Arc] actions even while stressed.",
-        "images": "https://images-cdn.fantasyflightgames.com/filer_public/0b/fe/0bfe654e-156a-42e4-80d7-0a1653aefaed/swz19_a2_reys-falcon.png",
+        "image" : "https://sb-cdn.fantasyflightgames.com/card_images/en/23627443c7f5e7447c306ea7c6242634.png",
+        "artwork" : "https://sb-cdn.fantasyflightgames.com/card_art/905ee2a41b7d3b6d1f76294b4cd3e99e.jpg",
         "slots": ["Title"],
         "ffg": 485
       }


### PR DESCRIPTION
Added image and artwork URLs for Wave 2 (and some missing cards) from sb-cdn.fantasyflightgames.com. Replaced any image URLs from their web content filer (or from other unofficial sources.)