### PR TITLE
Added card-types and upgrade-types metadata

### DIFF
--- a/data/card-types/card-types.json
+++ b/data/card-types/card-types.json
@@ -1,0 +1,12 @@
+[
+    {
+        "type" : "Pilots",
+        "xws" : "pilots",
+        "ffg" : 1
+    },
+    {
+        "type" : "Upgrades",
+        "xws" : "upgrades",
+        "ffg" : 2
+    }
+]

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -130,5 +130,7 @@
     "data/quick-builds/scum-and-villainy.json",
     "data/quick-builds/galactic-empire.json",
     "data/quick-builds/resistance.json"
-  ]
+  ],
+  "card-types" : "data/card-types/card-types.json",
+  "upgrade-types" : "data/upgrade-types/upgrade-types.json"
 }

--- a/data/upgrade-types/upgrade-types.json
+++ b/data/upgrade-types/upgrade-types.json
@@ -1,0 +1,82 @@
+[
+    {
+        "name" : "Talent",
+        "xws" : "talent",
+        "ffg" : 1
+    },
+    {
+        "name" : "Sensor",
+        "xws" : "sensor",
+        "ffg" : 2
+    },
+    {
+        "name" : "Cannon",
+        "xws" : "cannon",
+        "ffg" : 3
+    },
+    {
+        "name" : "Turret",
+        "xws" : "turret",
+        "ffg" : 4
+    },
+    {
+        "name" : "Torpedo",
+        "xws" : "torpedo",
+        "ffg" : 5
+    },
+    {
+        "name" : "Missile",
+        "xws" : "missile",
+        "ffg" : 6
+    },
+    {
+        "name" : "Crew",
+        "xws" : "crew",
+        "ffg" : 8
+    },
+    {
+        "name" : "Astromech",
+        "xws" : "astromech",
+        "ffg" : 10
+    },
+    {
+        "name" : "Device",
+        "xws" : "device",
+        "ffg" : 12
+    },
+    {
+        "name" : "Illicit",
+        "xws" : "illicit",
+        "ffg" : 13
+    },
+    {
+        "name" : "Modification",
+        "xws" : "modification",
+        "ffg" : 14
+    },
+    {
+        "name" : "Title",
+        "xws" : "title",
+        "ffg" : 15
+    },
+    {
+        "gunner" : "Gunner",
+        "xws" : "gunner",
+        "ffg" : 16
+    },
+    {
+        "name" : "Force Power",
+        "xws" : "force-power",
+        "ffg" : 17
+    },
+    {
+        "name" : "Configuration",
+        "xws" : "configuration",
+        "ffg" : 18
+    },
+    {
+        "name" : "Tech",
+        "xws" : "tech",
+        "ffg" : 19
+    }
+]


### PR DESCRIPTION
Upgrade Types metadata will assist with automatic squadbuilder.ffg.com/api/cards/{id} scraping. 