### PR TITLE
Add Hyperspace legality to all cards

### DIFF
--- a/data/pilots/first-order/tie-fo-fighter.json
+++ b/data/pilots/first-order/tie-fo-fighter.json
@@ -24,41 +24,16 @@
   ],
   "faction": "First Order",
   "stats": [
-    {
-      "arc": "Front Arc",
-      "type": "attack",
-      "value": 2
-    },
-    {
-      "type": "agility",
-      "value": 3
-    },
-    {
-      "type": "hull",
-      "value": 3
-    },
-    {
-      "type": "shields",
-      "value": 1
-    }
+    { "arc": "Front Arc", "type": "attack", "value": 2 },
+    { "type": "agility", "value": 3 },
+    { "type": "hull", "value": 3 },
+    { "type": "shields", "value": 1 }
   ],
   "actions": [
-    {
-      "difficulty": "White",
-      "type": "Focus"
-    },
-    {
-      "difficulty": "White",
-      "type": "Evade"
-    },
-    {
-      "difficulty": "White",
-      "type": "Lock"
-    },
-    {
-      "difficulty": "White",
-      "type": "Barrel Roll"
-    }
+    { "difficulty": "White", "type": "Focus" },
+    { "difficulty": "White", "type": "Evade" },
+    { "difficulty": "White", "type": "Lock" },
+    { "difficulty": "White", "type": "Barrel Roll" }
   ],
   "icon": "https://sb-cdn.fantasyflightgames.com/ship_types/I_TIEfo.png",
   "pilots": [
@@ -73,7 +48,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/c7994885b38757f92bdf3a98c37b3c96.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/c6a43d25d22d4112dd7e968cab4eb3d5.jpg",
       "slots": ["Talent", "Tech", "Modification"],
-      "ffg": 397
+      "ffg": 397,
+      "hyperspace": true
     },
     {
       "name": "Commander Malarus",
@@ -87,7 +63,8 @@
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/d9cfa6aacc29d55a47aaa0d9f75d362e.jpg",
       "slots": ["Talent", "Tech", "Modification"],
       "charges": { "value": 2, "recovers": 0 },
-      "ffg": 452
+      "ffg": 452,
+      "hyperspace": true
     },
     {
       "name": "\"Scorch\"",
@@ -100,7 +77,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/9dd11d408bb869cb947663fc29622833.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/dd225b2dab46b921e622dca6d799591f.jpg",
       "slots": ["Talent", "Tech", "Modification"],
-      "ffg": 398
+      "ffg": 398,
+      "hyperspace": true
     },
     {
       "name": "\"Static\"",
@@ -113,7 +91,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/2481fe5d98026e086a901d83dbe87018.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/30e0837d4877df289c220ea0ae174078.jpg",
       "slots": ["Talent", "Tech", "Modification"],
-      "ffg": 399
+      "ffg": 399,
+      "hyperspace": true
     },
     {
       "name": "\"Longshot\"",
@@ -126,7 +105,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/d0e698f59696c15b60d7eaa1e2d51eeb.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/31ad38b2fc0d39f37ad82e1c70f62135.jpg",
       "slots": ["Talent", "Tech", "Modification"],
-      "ffg": 400
+      "ffg": 400,
+      "hyperspace": true
     },
     {
       "name": "Omega Squadron Ace",
@@ -138,7 +118,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/97e72d0f5dc8c2dd21a355e3258f37dd.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/4e5010f7b60902288dac36bf646dcde9.jpg",
       "slots": ["Talent", "Tech", "Modification"],
-      "ffg": 403
+      "ffg": 403,
+      "hyperspace": true
     },
     {
       "name": "\"Muse\"",
@@ -151,7 +132,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/7de4e91de0906eb548bfe3a08a1b6abe.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/d3f8b9baf0bbd8a7d2b785a616dacbcf.jpg",
       "slots": ["Talent", "Tech", "Modification"],
-      "ffg": 401
+      "ffg": 401,
+      "hyperspace": true
     },
     {
       "name": "TN-3465",
@@ -164,7 +146,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/333cbf0da8849edb38c4e93944d8fe57.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/9fce0e75539a225e9ff1536e466c3c13.jpg",
       "slots": ["Tech", "Modification"],
-      "ffg": 453
+      "ffg": 453,
+      "hyperspace": true
     },
     {
       "name": "Zeta Squadron Pilot",
@@ -176,7 +159,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/be1062b6a7a8e4644223146342990a02.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/d20d6cc2a052afc783d535c802874d23.jpg",
       "slots": ["Tech", "Modification"],
-      "ffg": 404
+      "ffg": 404,
+      "hyperspace": true
     },
     {
       "name": "Epsilon Squadron Cadet",
@@ -188,7 +172,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/e911cd18f04225bbd36c48114b56f3cc.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/610cb198e4cda75aab0207841c6e4a87.jpg",
       "slots": ["Tech", "Modification"],
-      "ffg": 405
+      "ffg": 405,
+      "hyperspace": true
     },
     {
       "name": "Lieutenant Rivas",
@@ -201,7 +186,8 @@
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/66f969d008fc995bd940bf1ab647109f.jpg",
       "ability": "After a ship at range 1-2 gains a red or orange token, if you do not have that ship locked, you may acquire a lock on that ship.",
       "slots": ["Tech", "Modification"],
-      "ffg": 454
+      "ffg": 454,
+      "hyperspace": true
     },
     {
       "name": "\"Null\"",
@@ -214,7 +200,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/79a9d780d3540647af1e057113869294.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/eb788d9622d096c6d96c96cf20dc1939.jpg",
       "slots": ["Talent", "Tech", "Modification"],
-      "ffg": 402
+      "ffg": 402,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/first-order/tie-sf-fighter.json
+++ b/data/pilots/first-order/tie-sf-fighter.json
@@ -79,7 +79,8 @@
       "charges": { "value": 1, "recovers": 1 },
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/d038dadd7a62bbe2de89d3866e1a3639.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/86f8ccc959081a43dc4d0dbeb921d0ba.jpg",
-      "ffg": 406
+      "ffg": 406,
+      "hyperspace": true
     },
     {
       "name": "\"Backdraft\"",
@@ -103,7 +104,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/317cc5350980277f1d389ed618030d85.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/6c3a06877712596601ba1cc4ec533626.jpg",
-      "ffg": 407
+      "ffg": 407,
+      "hyperspace": true
     },
     {
       "name": "Omega Squadron Expert",
@@ -126,7 +128,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/784d00f653ff7cd58cb634c7a59e47c1.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/2caf1312bd6aba3630ef6edc1ff81f53.jpg",
-      "ffg": 408
+      "ffg": 408,
+      "hyperspace": true
     },
     {
       "name": "Zeta Squadron Survivor",
@@ -142,7 +145,8 @@
       "slots": ["Sensor", "Tech", "Missile", "Gunner", "Modification"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/848db1993150bda19217e2c14b3c3df6.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/55f72ce4974962db5b2ab3fac316b896.jpg",
-      "ffg": 409
+      "ffg": 409,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/first-order/tie-vn-silencer.json
+++ b/data/pilots/first-order/tie-vn-silencer.json
@@ -24,41 +24,16 @@
   ],
   "faction": "First Order",
   "stats": [
-    {
-      "arc": "Front Arc",
-      "type": "attack",
-      "value": 3
-    },
-    {
-      "type": "agility",
-      "value": 3
-    },
-    {
-      "type": "hull",
-      "value": 4
-    },
-    {
-      "type": "shields",
-      "value": 2
-    }
+    { "arc": "Front Arc", "type": "attack", "value": 3 },
+    { "type": "agility", "value": 3 },
+    { "type": "hull", "value": 4 },
+    { "type": "shields", "value": 2 }
   ],
   "actions": [
-    {
-      "difficulty": "White",
-      "type": "Focus"
-    },
-    {
-      "difficulty": "White",
-      "type": "Lock"
-    },
-    {
-      "difficulty": "White",
-      "type": "Barrel Roll"
-    },
-    {
-      "difficulty": "White",
-      "type": "Boost"
-    }
+    { "difficulty": "White", "type": "Focus" },
+    { "difficulty": "White", "type": "Lock" },
+    { "difficulty": "White", "type": "Barrel Roll" },
+    { "difficulty": "White", "type": "Boost" }
   ],
   "icon": "https://sb-cdn.fantasyflightgames.com/ship_types/I_TIESilencer.png",
   "pilots": [
@@ -77,7 +52,8 @@
       "slots": ["Talent", "Tech", "Torpedo", "Missile", "Modification"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/c5659b210e13b4e11fdd5f1396f2847c.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/20308b5887fb20d6b8ecdb3ede0bede3.jpg",
-      "ffg": 415
+      "ffg": 415,
+      "hyperspace": true
     },
     {
       "name": "Kylo Ren",
@@ -96,7 +72,8 @@
       "slots": ["Force Power", "Tech", "Torpedo", "Missile", "Modification"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/71dbde337b9ff5aab897781d40d8f653.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/80b87be22656fc01742fca490193d440.jpg",
-      "ffg": 414
+      "ffg": 414,
+      "hyperspace": true
     },
     {
       "name": "First Order Test Pilot",
@@ -112,7 +89,8 @@
       "slots": ["Talent", "Tech", "Torpedo", "Missile", "Modification"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/568abbcd68bb174173da4e7ee92051e3.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/86349c032fc169cb2000d3db7c9fbef4.jpg",
-      "ffg": 416
+      "ffg": 416,
+      "hyperspace": true
     },
     {
       "name": "\"Recoil\"",
@@ -129,7 +107,8 @@
       "slots": ["Talent", "Tech", "Torpedo", "Missile", "Modification"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/ab11858b2b9ac5c8bbfb2dc21023ba34.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/c4590088696ecc687f5c0f004d1d97ab.jpg",
-      "ffg": 455
+      "ffg": 455,
+      "hyperspace": true
     },
     {
       "name": "\"Avenger\"",
@@ -146,7 +125,8 @@
       "slots": ["Talent", "Tech", "Torpedo", "Missile", "Modification"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/d90d3057ead18b5df5f6de55a199a4cd.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/3778411ec66e33951231314e909b981d.jpg",
-      "ffg": 456
+      "ffg": 456,
+      "hyperspace": true
     },
     {
       "name": "Sienar-Jaemus Engineer",
@@ -162,7 +142,8 @@
       "slots": ["Tech", "Torpedo", "Missile", "Modification"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/8f7c4680fbc001169baf6538ab259e9b.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/18b2a1b00b2f8c6669b6b1d1b278dcf2.jpg",
-      "ffg": 417
+      "ffg": 417,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/first-order/upsilon-class-command-shuttle.json
+++ b/data/pilots/first-order/upsilon-class-command-shuttle.json
@@ -23,45 +23,17 @@
   ],
   "faction": "First Order",
   "stats": [
-    {
-      "type": "attack",
-      "value": "4",
-      "arc": "Front Arc"
-    },
-    {
-      "type": "agility",
-      "value": 1
-    },
-    {
-      "type": "hull",
-      "value": 6
-    },
-    {
-      "type": "shields",
-      "value": 6
-    }
+    { "type": "attack", "value": "4", "arc": "Front Arc" },
+    { "type": "agility", "value": 1 },
+    { "type": "hull", "value": 6 },
+    { "type": "shields", "value": 6 }
   ],
   "actions": [
-    {
-      "difficulty": "White",
-      "type": "Focus"
-    },
-    {
-      "difficulty": "White",
-      "type": "Lock"
-    },
-    {
-      "difficulty": "White",
-      "type": "Reinforce"
-    },
-    {
-      "difficulty": "White",
-      "type": "Coordinate"
-    },
-    {
-      "difficulty": "White",
-      "type": "Jam"
-    }
+    { "difficulty": "White", "type": "Focus" },
+    { "difficulty": "White", "type": "Lock" },
+    { "difficulty": "White", "type": "Reinforce" },
+    { "difficulty": "White", "type": "Coordinate" },
+    { "difficulty": "White", "type": "Jam" }
   ],
   "icon": "https://sb-cdn.fantasyflightgames.com/ship_types/I_UpsilonShuttle.png",
   "pilots": [
@@ -89,7 +61,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/e4acd80da2c39e25d4f999cb7c314fe5.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/4505cb1930309673fe5592dbc112d733.jpg",
-      "ffg": 412
+      "ffg": 412,
+      "hyperspace": true
     },
     {
       "name": "Major Stridan",
@@ -115,7 +88,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/8420beca035dedf1596c7c99255fb2e7.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/862f9dcc1ce9809f9a394d8f0b05f268.jpg",
-      "ffg": 410
+      "ffg": 410,
+      "hyperspace": true
     },
     {
       "name": "Petty Officer Thanisson",
@@ -125,10 +99,7 @@
       "limited": 1,
       "cost": 60,
       "size": "Large",
-      "charges": {
-        "value": 1,
-        "recovers": 1
-      },
+      "charges": { "value": 1, "recovers": 1 },
       "ability": "During the Activation or Engagement Phase, after a ship in your [Front Arc] at range 0-2 gains 1 stress token, you may spend 1 [Charge]. If you do, that ship gains 1 tractor token.",
       "shipAbility": {
         "name": "Linked Battery",
@@ -146,7 +117,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/3a2232a5238d8bf5e7538fe1d6003dbc.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/24a40f6ec1875bfae9e7531b02252993.jpg",
-      "ffg": 458
+      "ffg": 458,
+      "hyperspace": true
     },
     {
       "name": "Starkiller Base Pilot",
@@ -154,10 +126,7 @@
       "initiative": 2,
       "limited": 0,
       "cost": 56,
-      "charges": {
-        "value": 1,
-        "recovers": 1
-      },
+      "charges": { "value": 1, "recovers": 1 },
       "text": "The Upsilon-class command shuttle serves as a base of operations for many of the First Order's senior officers and agents. Its powerful sensors and communications equipment allow them to orchestrate the spread of terror across the galaxy.",
       "shipAbility": {
         "name": "Linked Battery",
@@ -175,7 +144,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/41f6d936f14a058ed1c5e6ac12de37c2.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/1ea0266ea42691778e8ecff6a5b50e45.jpg",
-      "ffg": 413
+      "ffg": 413,
+      "hyperspace": true
     },
     {
       "name": "Lieutenant Tavson",
@@ -185,10 +155,7 @@
       "cost": 62,
       "xws": "lieutenanttavson",
       "ability": "After you suffer damage, you may spend 1 [Charge] to perform an action.",
-      "charges": {
-        "value": 2,
-        "recovers": 1
-      },
+      "charges": { "value": 2, "recovers": 1 },
       "shipAbility": {
         "name": "Linked Battery",
         "text": "Whlie you perform a [Cannon] attack, roll 1 additional die."
@@ -205,7 +172,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/20fbf3ed79c50d2082cdb44caac26064.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/151154b50732a6dd42b411fc312137b9.jpg",
-      "ffg": 411
+      "ffg": 411,
+      "hyperspace": true
     },
     {
       "name": "Captain Cardinal",
@@ -219,10 +187,7 @@
         "name": "Linked Battery",
         "text": "Whlie you perform a [Cannon] attack, roll 1 additional die."
       },
-      "charges": {
-        "value": 2,
-        "recovers": 0
-      },
+      "charges": { "value": 2, "recovers": 0 },
       "slots": [
         "Sensor",
         "Tech",
@@ -235,7 +200,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/be29a69f75726ad48f607eecca671e01.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/a88822cc408323e561efd9e2acb83f2a.jpg",
-      "ffg": 457
+      "ffg": 457,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/galactic-empire/alpha-class-star-wing.json
+++ b/data/pilots/galactic-empire/alpha-class-star-wing.json
@@ -52,7 +52,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_136.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_136.jpg",
-      "ffg": 136
+      "ffg": 136,
+      "hyperspace": false
     },
     {
       "name": "Major Vynder",
@@ -72,7 +73,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_135.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_135.jpg",
-      "ffg": 135
+      "ffg": 135,
+      "hyperspace": false
     },
     {
       "name": "Nu Squadron Pilot",
@@ -90,7 +92,8 @@
         "Configuration"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
-      "ffg": 138
+      "ffg": 138,
+      "hyperspace": false
     },
     {
       "name": "Rho Squadron Pilot",
@@ -109,7 +112,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_137.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_137.jpg",
-      "ffg": 137
+      "ffg": 137,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/galactic-empire/lambda-class-t-4a-shuttle.json
+++ b/data/pilots/galactic-empire/lambda-class-t-4a-shuttle.json
@@ -44,7 +44,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
       "slots": ["Sensor", "Cannon", "Crew", "Crew", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
-      "ffg": 142
+      "ffg": 142,
+      "hyperspace": false
     },
     {
       "name": "Colonel Jendon",
@@ -58,7 +59,8 @@
       "charges": { "value": 2, "recovers": 0 },
       "slots": ["Sensor", "Cannon", "Crew", "Crew", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_143.jpg",
-      "ffg": 143
+      "ffg": 143,
+      "hyperspace": false
     },
     {
       "name": "Lieutenant Sai",
@@ -71,7 +73,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_144.png",
       "slots": ["Sensor", "Cannon", "Crew", "Crew", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_144.jpg",
-      "ffg": 144
+      "ffg": 144,
+      "hyperspace": false
     },
     {
       "name": "Omicron Group Pilot",
@@ -83,7 +86,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_145.png",
       "slots": ["Sensor", "Cannon", "Crew", "Crew", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_145.jpg",
-      "ffg": 145
+      "ffg": 145,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/galactic-empire/tie-advanced-v1.json
+++ b/data/pilots/galactic-empire/tie-advanced-v1.json
@@ -58,7 +58,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
       "slots": ["Talent", "Sensor", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
-      "ffg": 101
+      "ffg": 101,
+      "hyperspace": false
     },
     {
       "name": "Grand Inquisitor",
@@ -72,7 +73,8 @@
       "force": { "value": 2, "recovers": 1, "side": ["dark"] },
       "slots": ["Force Power", "Sensor", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_99.jpg",
-      "ffg": 99
+      "ffg": 99,
+      "hyperspace": false
     },
     {
       "name": "Inquisitor",
@@ -85,7 +87,8 @@
       "force": { "value": 1, "recovers": 1, "side": ["dark"] },
       "slots": ["Force Power", "Sensor", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
-      "ffg": 102
+      "ffg": 102,
+      "hyperspace": false
     },
     {
       "name": "Seventh Sister",
@@ -99,7 +102,8 @@
       "force": { "value": 2, "recovers": 1, "side": ["dark"] },
       "slots": ["Force Power", "Sensor", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_100.jpg",
-      "ffg": 100
+      "ffg": 100,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/galactic-empire/tie-advanced-x1.json
+++ b/data/pilots/galactic-empire/tie-advanced-x1.json
@@ -63,7 +63,8 @@
       },
       "slots": ["Force Power", "Sensor", "Missile", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
-      "ffg": 93
+      "ffg": 93,
+      "hyperspace": true
     },
     {
       "name": "Maarek Stele",
@@ -80,7 +81,8 @@
       },
       "slots": ["Talent", "Sensor", "Missile", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_94.jpg",
-      "ffg": 94
+      "ffg": 94,
+      "hyperspace": true
     },
     {
       "name": "Storm Squadron Ace",
@@ -96,7 +98,8 @@
       },
       "slots": ["Talent", "Sensor", "Missile", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
-      "ffg": 97
+      "ffg": 97,
+      "hyperspace": true
     },
     {
       "name": "Tempest Squadron Pilot",
@@ -118,7 +121,8 @@
       "slots": ["Sensor", "Missile", "Modification"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_98.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_98.jpg",
-      "ffg": 98
+      "ffg": 98,
+      "hyperspace": true
     },
     {
       "name": "Ved Foslo",
@@ -135,7 +139,8 @@
       },
       "slots": ["Talent", "Sensor", "Missile", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_95.jpg",
-      "ffg": 95
+      "ffg": 95,
+      "hyperspace": true
     },
     {
       "name": "Zertik Strom",
@@ -152,7 +157,8 @@
       },
       "slots": ["Sensor", "Missile", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_96.jpg",
-      "ffg": 96
+      "ffg": 96,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/galactic-empire/tie-ag-aggressor.json
+++ b/data/pilots/galactic-empire/tie-ag-aggressor.json
@@ -56,7 +56,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_128.jpg",
-      "ffg": 128
+      "ffg": 128,
+      "hyperspace": false
     },
     {
       "name": "Lieutenant Kestal",
@@ -76,7 +77,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_127.jpg",
-      "ffg": 127
+      "ffg": 127,
+      "hyperspace": false
     },
     {
       "name": "Onyx Squadron Scout",
@@ -95,7 +97,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
-      "ffg": 129
+      "ffg": 129,
+      "hyperspace": false
     },
     {
       "name": "Sienar Specialist",
@@ -107,7 +110,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
       "slots": ["Turret", "Missile", "Missile", "Gunner", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
-      "ffg": 130
+      "ffg": 130,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/galactic-empire/tie-ca-punisher.json
+++ b/data/pilots/galactic-empire/tie-ca-punisher.json
@@ -60,7 +60,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_140.jpg",
-      "ffg": 140
+      "ffg": 140,
+      "hyperspace": false
     },
     {
       "name": "\"Redline\"",
@@ -82,7 +83,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_139.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_139.jpg",
-      "ffg": 139
+      "ffg": 139,
+      "hyperspace": false
     },
     {
       "name": "Cutlass Squadron Pilot",
@@ -103,7 +105,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_141.jpg",
-      "ffg": 141
+      "ffg": 141,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/galactic-empire/tie-d-defender.json
+++ b/data/pilots/galactic-empire/tie-d-defender.json
@@ -54,7 +54,8 @@
       },
       "slots": ["Talent", "Sensor", "Cannon", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_123.jpg",
-      "ffg": 123
+      "ffg": 123,
+      "hyperspace": false
     },
     {
       "name": "Countess Ryad",
@@ -71,7 +72,8 @@
       },
       "slots": ["Talent", "Sensor", "Cannon", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_124.jpg",
-      "ffg": 124
+      "ffg": 124,
+      "hyperspace": false
     },
     {
       "name": "Delta Squadron Pilot",
@@ -87,7 +89,8 @@
       },
       "slots": ["Sensor", "Cannon", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_126.jpg",
-      "ffg": 126
+      "ffg": 126,
+      "hyperspace": false
     },
     {
       "name": "Onyx Squadron Ace",
@@ -103,7 +106,8 @@
       },
       "slots": ["Talent", "Sensor", "Cannon", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_125.jpg",
-      "ffg": 125
+      "ffg": 125,
+      "hyperspace": false
     },
     {
       "name": "Rexler Brath",
@@ -120,7 +124,8 @@
       },
       "slots": ["Talent", "Sensor", "Cannon", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
-      "ffg": 122
+      "ffg": 122,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/galactic-empire/tie-interceptor.json
+++ b/data/pilots/galactic-empire/tie-interceptor.json
@@ -50,7 +50,8 @@
       },
       "slots": ["Modification", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_106.jpg",
-      "ffg": 106
+      "ffg": 106,
+      "hyperspace": false
     },
     {
       "name": "Saber Squadron Ace",
@@ -66,7 +67,8 @@
       },
       "slots": ["Talent", "Modification", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_105.jpg",
-      "ffg": 105
+      "ffg": 105,
+      "hyperspace": false
     },
     {
       "name": "Soontir Fel",
@@ -83,7 +85,8 @@
       },
       "slots": ["Talent", "Modification", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
-      "ffg": 103
+      "ffg": 103,
+      "hyperspace": false
     },
     {
       "name": "Turr Phennir",
@@ -100,7 +103,8 @@
       },
       "slots": ["Talent", "Modification", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_104.jpg",
-      "ffg": 104
+      "ffg": 104,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/galactic-empire/tie-ln-fighter.json
+++ b/data/pilots/galactic-empire/tie-ln-fighter.json
@@ -45,7 +45,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_81.png",
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_81.jpg",
-      "ffg": 81
+      "ffg": 81,
+      "hyperspace": true
     },
     {
       "name": "\"Mauler\" Mithel",
@@ -58,7 +59,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_80.png",
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_80.jpg",
-      "ffg": 80
+      "ffg": 80,
+      "hyperspace": true
     },
     {
       "name": "\"Night Beast\"",
@@ -71,7 +73,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_88.png",
       "slots": ["Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_88.jpg",
-      "ffg": 88
+      "ffg": 88,
+      "hyperspace": true
     },
     {
       "name": "\"Scourge\" Skutu",
@@ -84,7 +87,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_82.png",
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_82.jpg",
-      "ffg": 82
+      "ffg": 82,
+      "hyperspace": true
     },
     {
       "name": "\"Wampa\"",
@@ -98,7 +102,8 @@
       "charges": { "value": 1, "recovers": 1 },
       "slots": ["Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_89.jpg",
-      "ffg": 89
+      "ffg": 89,
+      "hyperspace": true
     },
     {
       "name": "Academy Pilot",
@@ -116,7 +121,8 @@
       ],
       "slots": ["Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_92.jpg",
-      "ffg": 92
+      "ffg": 92,
+      "hyperspace": true
     },
     {
       "name": "Black Squadron Ace",
@@ -134,7 +140,8 @@
         }
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_90.jpg",
-      "ffg": 90
+      "ffg": 90,
+      "hyperspace": true
     },
     {
       "name": "Del Meeko",
@@ -147,7 +154,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_85.png",
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_85.jpg",
-      "ffg": 85
+      "ffg": 85,
+      "hyperspace": true
     },
     {
       "name": "Gideon Hask",
@@ -160,7 +168,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_84.png",
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_84.jpg",
-      "ffg": 84
+      "ffg": 84,
+      "hyperspace": true
     },
     {
       "name": "Iden Versio",
@@ -174,7 +183,8 @@
       "charges": { "value": 1, "recovers": 0 },
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_83.jpg",
-      "ffg": 83
+      "ffg": 83,
+      "hyperspace": true
     },
     {
       "name": "Obsidian Squadron Pilot",
@@ -192,7 +202,8 @@
       ],
       "slots": ["Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_91.jpg",
-      "ffg": 91
+      "ffg": 91,
+      "hyperspace": true
     },
     {
       "name": "Seyn Marana",
@@ -206,7 +217,8 @@
       "charges": { "value": 1, "recovers": 0 },
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_86.jpg",
-      "ffg": 86
+      "ffg": 86,
+      "hyperspace": true
     },
     {
       "name": "Valen Rudor",
@@ -219,7 +231,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_87.png",
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_87.jpg",
-      "ffg": 87
+      "ffg": 87,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/galactic-empire/tie-ph-phantom.json
+++ b/data/pilots/galactic-empire/tie-ph-phantom.json
@@ -52,7 +52,8 @@
       },
       "slots": ["Talent", "Sensor", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_132.jpg",
-      "ffg": 132
+      "ffg": 132,
+      "hyperspace": false
     },
     {
       "name": "\"Whisper\"",
@@ -69,7 +70,8 @@
       },
       "slots": ["Talent", "Sensor", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_131.jpg",
-      "ffg": 131
+      "ffg": 131,
+      "hyperspace": false
     },
     {
       "name": "Imdaar Test Pilot",
@@ -85,7 +87,8 @@
       },
       "slots": ["Sensor", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
-      "ffg": 134
+      "ffg": 134,
+      "hyperspace": false
     },
     {
       "name": "Sigma Squadron Ace",
@@ -101,7 +104,8 @@
       },
       "slots": ["Talent", "Sensor", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_133.jpg",
-      "ffg": 133
+      "ffg": 133,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/galactic-empire/tie-reaper.json
+++ b/data/pilots/galactic-empire/tie-reaper.json
@@ -51,7 +51,8 @@
       },
       "slots": ["Crew", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_115.jpg",
-      "ffg": 115
+      "ffg": 115,
+      "hyperspace": true
     },
     {
       "name": "Captain Feroph",
@@ -68,7 +69,8 @@
       },
       "slots": ["Talent", "Crew", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
-      "ffg": 114
+      "ffg": 114,
+      "hyperspace": true
     },
     {
       "name": "Major Vermeil",
@@ -85,7 +87,8 @@
       },
       "slots": ["Talent", "Crew", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_113.jpg",
-      "ffg": 113
+      "ffg": 113,
+      "hyperspace": true
     },
     {
       "name": "Scarif Base Pilot",
@@ -107,7 +110,8 @@
       },
       "slots": ["Crew", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_116.jpg",
-      "ffg": 116
+      "ffg": 116,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/galactic-empire/tie-sa-bomber.json
+++ b/data/pilots/galactic-empire/tie-sa-bomber.json
@@ -62,7 +62,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
-      "ffg": 110
+      "ffg": 110,
+      "hyperspace": false
     },
     {
       "name": "Captain Jonus",
@@ -88,7 +89,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_108.jpg",
-      "ffg": 108
+      "ffg": 108,
+      "hyperspace": false
     },
     {
       "name": "Gamma Squadron Ace",
@@ -113,7 +115,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_111.jpg",
-      "ffg": 111
+      "ffg": 111,
+      "hyperspace": false
     },
     {
       "name": "Major Rhymer",
@@ -139,7 +142,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_109.jpg",
-      "ffg": 109
+      "ffg": 109,
+      "hyperspace": false
     },
     {
       "name": "Scimitar Squadron Pilot",
@@ -163,7 +167,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_112.jpg",
-      "ffg": 112
+      "ffg": 112,
+      "hyperspace": false
     },
     {
       "name": "Tomax Bren",
@@ -189,7 +194,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
-      "ffg": 107
+      "ffg": 107,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/galactic-empire/tie-sk-striker.json
+++ b/data/pilots/galactic-empire/tie-sk-striker.json
@@ -49,7 +49,8 @@
       },
       "slots": ["Talent", "Gunner", "Device", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
-      "ffg": 118
+      "ffg": 118,
+      "hyperspace": true
     },
     {
       "name": "\"Duchess\"",
@@ -66,7 +67,8 @@
       },
       "slots": ["Talent", "Gunner", "Device", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_117.jpg",
-      "ffg": 117
+      "ffg": 117,
+      "hyperspace": true
     },
     {
       "name": "\"Pure Sabacc\"",
@@ -83,7 +85,8 @@
       },
       "slots": ["Talent", "Gunner", "Device", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_119.jpg",
-      "ffg": 119
+      "ffg": 119,
+      "hyperspace": true
     },
     {
       "name": "Black Squadron Scout",
@@ -99,7 +102,8 @@
       },
       "slots": ["Talent", "Gunner", "Device", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_120.jpg",
-      "ffg": 120
+      "ffg": 120,
+      "hyperspace": true
     },
     {
       "name": "Planetary Sentinel",
@@ -115,7 +119,8 @@
       },
       "slots": ["Gunner", "Device", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_121.jpg",
-      "ffg": 121
+      "ffg": 121,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/galactic-empire/vt-49-decimator.json
+++ b/data/pilots/galactic-empire/vt-49-decimator.json
@@ -57,7 +57,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
-      "ffg": 146
+      "ffg": 146,
+      "hyperspace": false
     },
     {
       "name": "Patrol Leader",
@@ -77,7 +78,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_148.jpg",
-      "ffg": 148
+      "ffg": 148,
+      "hyperspace": false
     },
     {
       "name": "Rear Admiral Chiraneau",
@@ -99,7 +101,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
-      "ffg": 147
+      "ffg": 147,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/galactic-republic/arc-170-starfighter.json
+++ b/data/pilots/galactic-republic/arc-170-starfighter.json
@@ -21,42 +21,16 @@
   ],
   "faction": "Galactic Republic",
   "stats": [
-    {
-      "arc": "Front Arc",
-      "type": "attack",
-      "value": 3
-    },
-    {
-      "arc": "Rear Arc",
-      "type": "attack",
-      "value": 2
-    },
-    {
-      "type": "agility",
-      "value": 1
-    },
-    {
-      "type": "hull",
-      "value": 6
-    },
-    {
-      "type": "shields",
-      "value": 3
-    }
+    { "arc": "Front Arc", "type": "attack", "value": 3 },
+    { "arc": "Rear Arc", "type": "attack", "value": 2 },
+    { "type": "agility", "value": 1 },
+    { "type": "hull", "value": 6 },
+    { "type": "shields", "value": 3 }
   ],
   "actions": [
-    {
-      "difficulty": "White",
-      "type": "Focus"
-    },
-    {
-      "difficulty": "White",
-      "type": "Lock"
-    },
-    {
-      "difficulty": "Red",
-      "type": "Barrel Roll"
-    }
+    { "difficulty": "White", "type": "Focus" },
+    { "difficulty": "White", "type": "Lock" },
+    { "difficulty": "Red", "type": "Barrel Roll" }
   ],
   "pilots": [
     {
@@ -74,7 +48,8 @@
         "Gunner",
         "Astromech",
         "Modification"
-      ]
+      ],
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/galactic-republic/delta-7-aethersprite.json
+++ b/data/pilots/galactic-republic/delta-7-aethersprite.json
@@ -24,45 +24,17 @@
   ],
   "faction": "Galactic Republic",
   "stats": [
-    {
-      "arc": "Front Arc",
-      "type": "attack",
-      "value": 2
-    },
-    {
-      "type": "agility",
-      "value": 3
-    },
-    {
-      "type": "hull",
-      "value": 3
-    },
-    {
-      "type": "shields",
-      "value": 1
-    }
+    { "arc": "Front Arc", "type": "attack", "value": 2 },
+    { "type": "agility", "value": 3 },
+    { "type": "hull", "value": 3 },
+    { "type": "shields", "value": 1 }
   ],
   "actions": [
-    {
-      "difficulty": "White",
-      "type": "Focus"
-    },
-    {
-      "difficulty": "Purple",
-      "type": "Evade"
-    },
-    {
-      "difficulty": "White",
-      "type": "Lock"
-    },
-    {
-      "difficulty": "White",
-      "type": "Barrel Roll"
-    },
-    {
-      "difficulty": "White",
-      "type": "Boost"
-    }
+    { "difficulty": "White", "type": "Focus" },
+    { "difficulty": "Purple", "type": "Evade" },
+    { "difficulty": "White", "type": "Lock" },
+    { "difficulty": "White", "type": "Barrel Roll" },
+    { "difficulty": "White", "type": "Boost" }
   ],
   "pilots": [
     {
@@ -73,7 +45,8 @@
       "shipAbility": {
         "name": "Unknown",
         "text": "After you fully execute a maneuver, you may spend 1 [Force] to perform a [Boost] or [Barrel Roll] action."
-      }
+      },
+      "hyperspace": false
     },
     {
       "name": "Obi-Wan Kenobi",
@@ -83,7 +56,8 @@
       "shipAbility": {
         "name": "Unknown",
         "text": "After you fully execute a maneuver, you may spend 1 [Force] to perform a [Boost] or [Barrel Roll] action."
-      }
+      },
+      "hyperspace": false
     },
     {
       "name": "Anakin Skywalker",
@@ -93,7 +67,8 @@
       "shipAbility": {
         "name": "Unknown",
         "text": "After you fully execute a maneuver, you may spend 1 [Force] to perform a [Boost] or [Barrel Roll] action."
-      }
+      },
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/galactic-republic/v-19-torrent-starfighter.json
+++ b/data/pilots/galactic-republic/v-19-torrent-starfighter.json
@@ -23,40 +23,18 @@
   ],
   "faction": "Galactic Republic",
   "stats": [
-    {
-      "type": "attack",
-      "arc": "Front Arc",
-      "value": 2
-    },
-    {
-      "type": "agility",
-      "value": 2
-    },
-    {
-      "type": "hull",
-      "value": 5
-    }
+    { "type": "attack", "arc": "Front Arc", "value": 2 },
+    { "type": "agility", "value": 2 },
+    { "type": "hull", "value": 5 }
   ],
   "actions": [
-    {
-      "type": "Focus",
-      "difficulty": "White"
-    },
-    {
-      "type": "Evade",
-      "difficulty": "White"
-    },
-    {
-      "type": "Lock",
-      "difficulty": "White"
-    },
+    { "type": "Focus", "difficulty": "White" },
+    { "type": "Evade", "difficulty": "White" },
+    { "type": "Lock", "difficulty": "White" },
     {
       "type": "Barrel Roll",
       "difficulty": "White",
-      "linked": {
-        "type": "Evade",
-        "difficulty": "Red"
-      }
+      "linked": { "type": "Evade", "difficulty": "Red" }
     }
   ],
   "pilots": []

--- a/data/pilots/rebel-alliance/a-sf-01-b-wing.json
+++ b/data/pilots/rebel-alliance/a-sf-01-b-wing.json
@@ -57,7 +57,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
-      "ffg": 25
+      "ffg": 25,
+      "hyperspace": false
     },
     {
       "name": "Blue Squadron Pilot",
@@ -75,7 +76,8 @@
         }
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
-      "ffg": 26
+      "ffg": 26,
+      "hyperspace": false
     },
     {
       "name": "Braylen Stramm",
@@ -95,7 +97,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
-      "ffg": 23
+      "ffg": 23,
+      "hyperspace": false
     },
     {
       "name": "Ten Numb",
@@ -115,7 +118,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
-      "ffg": 24
+      "ffg": 24,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/rebel-alliance/arc-170-starfighter.json
+++ b/data/pilots/rebel-alliance/arc-170-starfighter.json
@@ -53,7 +53,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
-      "ffg": 66
+      "ffg": 66,
+      "hyperspace": false
     },
     {
       "name": "Ibtisam",
@@ -73,7 +74,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
-      "ffg": 68
+      "ffg": 68,
+      "hyperspace": false
     },
     {
       "name": "Norra Wexley",
@@ -93,7 +95,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
-      "ffg": 65
+      "ffg": 65,
+      "hyperspace": false
     },
     {
       "name": "Shara Bey",
@@ -113,7 +116,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
-      "ffg": 67
+      "ffg": 67,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/rebel-alliance/attack-shuttle.json
+++ b/data/pilots/rebel-alliance/attack-shuttle.json
@@ -55,7 +55,8 @@
       },
       "slots": ["Turret", "Crew", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
-      "ffg": 37
+      "ffg": 37,
+      "hyperspace": false
     },
     {
       "name": "Ezra Bridger",
@@ -73,7 +74,8 @@
       },
       "slots": ["Force Power", "Turret", "Crew", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
-      "ffg": 36
+      "ffg": 36,
+      "hyperspace": false
     },
     {
       "name": "Hera Syndulla",
@@ -90,7 +92,8 @@
       },
       "slots": ["Talent", "Turret", "Crew", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
-      "ffg": 34
+      "ffg": 34,
+      "hyperspace": false
     },
     {
       "name": "Sabine Wren",
@@ -107,7 +110,8 @@
       },
       "slots": ["Talent", "Turret", "Crew", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
-      "ffg": 35
+      "ffg": 35,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/rebel-alliance/auzituck-gunship.json
+++ b/data/pilots/rebel-alliance/auzituck-gunship.json
@@ -44,7 +44,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
       "slots": ["Crew", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
-      "ffg": 33
+      "ffg": 33,
+      "hyperspace": false
     },
     {
       "name": "Lowhhrick",
@@ -57,7 +58,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
       "slots": ["Talent", "Crew", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
-      "ffg": 32
+      "ffg": 32,
+      "hyperspace": false
     },
     {
       "name": "Wullffwarro",
@@ -70,7 +72,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
       "slots": ["Talent", "Crew", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
-      "ffg": 31
+      "ffg": 31,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/rebel-alliance/btl-a4-y-wing.json
+++ b/data/pilots/rebel-alliance/btl-a4-y-wing.json
@@ -54,7 +54,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_14.jpg",
-      "ffg": 14
+      "ffg": 14,
+      "hyperspace": true
     },
     {
       "name": "Evaan Verlaine",
@@ -75,7 +76,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
-      "ffg": 16
+      "ffg": 16,
+      "hyperspace": true
     },
     {
       "name": "Gold Squadron Veteran",
@@ -101,7 +103,8 @@
         }
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_17.jpg",
-      "ffg": 17
+      "ffg": 17,
+      "hyperspace": true
     },
     {
       "name": "Gray Squadron Bomber",
@@ -120,7 +123,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
-      "ffg": 18
+      "ffg": 18,
+      "hyperspace": true
     },
     {
       "name": "Horton Salm",
@@ -141,7 +145,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
-      "ffg": 15
+      "ffg": 15,
+      "hyperspace": true
     },
     {
       "name": "Norra Wexley",
@@ -162,7 +167,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_13.jpg",
-      "ffg": 13
+      "ffg": 13,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/rebel-alliance/btl-s8-k-wing.json
+++ b/data/pilots/rebel-alliance/btl-s8-k-wing.json
@@ -52,7 +52,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
-      "ffg": 63
+      "ffg": 63,
+      "hyperspace": false
     },
     {
       "name": "Miranda Doni",
@@ -74,7 +75,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
-      "ffg": 62
+      "ffg": 62,
+      "hyperspace": false
     },
     {
       "name": "Warden Squadron Pilot",
@@ -95,7 +97,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
-      "ffg": 64
+      "ffg": 64,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/rebel-alliance/e-wing.json
+++ b/data/pilots/rebel-alliance/e-wing.json
@@ -64,7 +64,8 @@
       },
       "slots": ["Talent", "Sensor", "Torpedo", "Astromech", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
-      "ffg": 50
+      "ffg": 50,
+      "hyperspace": false
     },
     {
       "name": "Gavin Darklighter",
@@ -81,7 +82,8 @@
       },
       "slots": ["Talent", "Sensor", "Torpedo", "Astromech", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
-      "ffg": 51
+      "ffg": 51,
+      "hyperspace": false
     },
     {
       "name": "Knave Squadron Escort",
@@ -97,7 +99,8 @@
       },
       "slots": ["Sensor", "Torpedo", "Astromech", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
-      "ffg": 53
+      "ffg": 53,
+      "hyperspace": false
     },
     {
       "name": "Rogue Squadron Escort",
@@ -113,7 +116,8 @@
       },
       "slots": ["Talent", "Sensor", "Torpedo", "Astromech", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
-      "ffg": 52
+      "ffg": 52,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/rebel-alliance/hwk-290-light-freighter.json
+++ b/data/pilots/rebel-alliance/hwk-290-light-freighter.json
@@ -62,7 +62,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
-      "ffg": 42
+      "ffg": 42,
+      "hyperspace": false
     },
     {
       "name": "Kyle Katarn",
@@ -82,7 +83,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
-      "ffg": 43
+      "ffg": 43,
+      "hyperspace": false
     },
     {
       "name": "Rebel Scout",
@@ -94,7 +96,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
       "slots": ["Crew", "Device", "Modification", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
-      "ffg": 45
+      "ffg": 45,
+      "hyperspace": false
     },
     {
       "name": "Roark Garnet",
@@ -114,7 +117,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
-      "ffg": 44
+      "ffg": 44,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/rebel-alliance/modified-yt-1300-light-freighter.json
+++ b/data/pilots/rebel-alliance/modified-yt-1300-light-freighter.json
@@ -58,7 +58,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
-      "ffg": 71
+      "ffg": 71,
+      "hyperspace": true
     },
     {
       "name": "Han Solo",
@@ -80,7 +81,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
-      "ffg": 69
+      "ffg": 69,
+      "hyperspace": true
     },
     {
       "name": "Lando Calrissian",
@@ -102,7 +104,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_70.jpg",
-      "ffg": 70
+      "ffg": 70,
+      "hyperspace": true
     },
     {
       "name": "Outer Rim Smuggler",
@@ -122,7 +125,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
-      "ffg": 72
+      "ffg": 72,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/rebel-alliance/rz-1-a-wing.json
+++ b/data/pilots/rebel-alliance/rz-1-a-wing.json
@@ -53,7 +53,8 @@
       },
       "slots": ["Talent", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
-      "ffg": 20
+      "ffg": 20,
+      "hyperspace": false
     },
     {
       "name": "Green Squadron Pilot",
@@ -69,7 +70,8 @@
       },
       "slots": ["Talent", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
-      "ffg": 21
+      "ffg": 21,
+      "hyperspace": false
     },
     {
       "name": "Jake Farrell",
@@ -86,7 +88,8 @@
       },
       "slots": ["Talent", "Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_19.jpg",
-      "ffg": 19
+      "ffg": 19,
+      "hyperspace": false
     },
     {
       "name": "Phoenix Squadron Pilot",
@@ -102,7 +105,8 @@
       },
       "slots": ["Missile"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_22.jpg",
-      "ffg": 22
+      "ffg": 22,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/rebel-alliance/sheathipede-class-shuttle.json
+++ b/data/pilots/rebel-alliance/sheathipede-class-shuttle.json
@@ -50,7 +50,8 @@
       },
       "slots": ["Talent", "Crew", "Astromech", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
-      "ffg": 40
+      "ffg": 40,
+      "hyperspace": false
     },
     {
       "name": "AP-5",
@@ -71,7 +72,8 @@
       },
       "slots": ["Talent", "Crew", "Astromech", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
-      "ffg": 41
+      "ffg": 41,
+      "hyperspace": false
     },
     {
       "name": "Ezra Bridger",
@@ -89,7 +91,8 @@
       },
       "slots": ["Force Power", "Crew", "Astromech", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
-      "ffg": 39
+      "ffg": 39,
+      "hyperspace": false
     },
     {
       "name": "Fenn Rau",
@@ -106,7 +109,8 @@
       },
       "slots": ["Talent", "Crew", "Astromech", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
-      "ffg": 38
+      "ffg": 38,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/rebel-alliance/t-65-x-wing.json
+++ b/data/pilots/rebel-alliance/t-65-x-wing.json
@@ -47,7 +47,8 @@
       "slots": ["Torpedo", "Astromech", "Modification", "Configuration"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
-      "ffg": 7
+      "ffg": 7,
+      "hyperspace": true
     },
     {
       "name": "Blue Squadron Escort",
@@ -65,7 +66,8 @@
         }
       ],
       "slots": ["Torpedo", "Astromech", "Modification", "Configuration"],
-      "ffg": 11
+      "ffg": 11,
+      "hyperspace": true
     },
     {
       "name": "Cavern Angels Zealot",
@@ -83,7 +85,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
-      "ffg": 12
+      "ffg": 12,
+      "hyperspace": true
     },
     {
       "name": "Edrio Two Tubes",
@@ -102,7 +105,8 @@
         "Configuration"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
-      "ffg": 9
+      "ffg": 9,
+      "hyperspace": true
     },
     {
       "name": "Garven Dreis",
@@ -121,7 +125,8 @@
         "Configuration"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
-      "ffg": 4
+      "ffg": 4,
+      "hyperspace": true
     },
     {
       "name": "Jek Porkins",
@@ -140,7 +145,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
-      "ffg": 5
+      "ffg": 5,
+      "hyperspace": true
     },
     {
       "name": "Kullbee Sperado",
@@ -160,7 +166,8 @@
         "Configuration"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
-      "ffg": 6
+      "ffg": 6,
+      "hyperspace": true
     },
     {
       "name": "Leevan Tenza",
@@ -180,7 +187,8 @@
         "Configuration"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
-      "ffg": 8
+      "ffg": 8,
+      "hyperspace": true
     },
     {
       "name": "Luke Skywalker",
@@ -210,7 +218,8 @@
         "Configuration"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
-      "ffg": 2
+      "ffg": 2,
+      "hyperspace": true
     },
     {
       "name": "Red Squadron Veteran",
@@ -228,7 +237,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_10.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_10.jpg",
-      "ffg": 10
+      "ffg": 10,
+      "hyperspace": true
     },
     {
       "name": "Thane Kyrell",
@@ -247,7 +257,8 @@
         "Configuration"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
-      "ffg": 3
+      "ffg": 3,
+      "hyperspace": true
     },
     {
       "name": "Wedge Antilles",
@@ -266,7 +277,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
-      "ffg": 1
+      "ffg": 1,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/rebel-alliance/tie-ln-fighter.json
+++ b/data/pilots/rebel-alliance/tie-ln-fighter.json
@@ -45,7 +45,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
       "slots": ["Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
-      "ffg": 49
+      "ffg": 49,
+      "hyperspace": false
     },
     {
       "name": "Captain Rex",
@@ -59,7 +60,8 @@
       "conditions": ["suppressivefire"],
       "slots": ["Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
-      "ffg": 48
+      "ffg": 48,
+      "hyperspace": false
     },
     {
       "name": "Ezra Bridger",
@@ -73,7 +75,8 @@
       "force": { "value": 1, "recovers": 1, "side": ["light"] },
       "slots": ["Force Power", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
-      "ffg": 46
+      "ffg": 46,
+      "hyperspace": false
     },
     {
       "name": "Sabine Wren",
@@ -86,7 +89,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
-      "ffg": 47
+      "ffg": 47,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/rebel-alliance/ut-60d-u-wing.json
+++ b/data/pilots/rebel-alliance/ut-60d-u-wing.json
@@ -50,7 +50,8 @@
         "Configuration"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
-      "ffg": 58
+      "ffg": 58,
+      "hyperspace": true
     },
     {
       "name": "Blue Squadron Scout",
@@ -62,7 +63,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
       "slots": ["Sensor", "Crew", "Crew", "Modification", "Configuration"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
-      "ffg": 60
+      "ffg": 60,
+      "hyperspace": false
     },
     {
       "name": "Bodhi Rook",
@@ -82,7 +84,8 @@
         "Configuration"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
-      "ffg": 54
+      "ffg": 54,
+      "hyperspace": false
     },
     {
       "name": "Cassian Andor",
@@ -102,7 +105,8 @@
         "Configuration"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
-      "ffg": 56
+      "ffg": 56,
+      "hyperspace": false
     },
     {
       "name": "Heff Tobber",
@@ -122,7 +126,8 @@
         "Configuration"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
-      "ffg": 59
+      "ffg": 59,
+      "hyperspace": false
     },
     {
       "name": "Magva Yarro",
@@ -143,7 +148,8 @@
         "Configuration"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
-      "ffg": 57
+      "ffg": 57,
+      "hyperspace": true
     },
     {
       "name": "Partisan Renegade",
@@ -162,7 +168,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
-      "ffg": 61
+      "ffg": 61,
+      "hyperspace": true
     },
     {
       "name": "Saw Gerrera",
@@ -189,7 +196,8 @@
         }
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
-      "ffg": 55
+      "ffg": 55,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/rebel-alliance/vcx-100-light-freighter.json
+++ b/data/pilots/rebel-alliance/vcx-100-light-freighter.json
@@ -64,7 +64,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
-      "ffg": 75
+      "ffg": 75,
+      "hyperspace": false
     },
     {
       "name": "Hera Syndulla",
@@ -90,7 +91,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
-      "ffg": 73
+      "ffg": 73,
+      "hyperspace": false
     },
     {
       "name": "Kanan Jarrus",
@@ -117,7 +119,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
-      "ffg": 74
+      "ffg": 74,
+      "hyperspace": false
     },
     {
       "name": "Lothal Rebel",
@@ -141,7 +144,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
-      "ffg": 76
+      "ffg": 76,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/rebel-alliance/yt-2400-light-freighter.json
+++ b/data/pilots/rebel-alliance/yt-2400-light-freighter.json
@@ -65,7 +65,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_78.jpg",
-      "ffg": 78
+      "ffg": 78,
+      "hyperspace": false
     },
     {
       "name": "Dash Rendar",
@@ -90,7 +91,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_77.jpg",
-      "ffg": 77
+      "ffg": 77,
+      "hyperspace": false
     },
     {
       "name": "Wild Space Fringer",
@@ -113,7 +115,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_79.jpg",
-      "ffg": 79
+      "ffg": 79,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/rebel-alliance/z-95-af4-headhunter.json
+++ b/data/pilots/rebel-alliance/z-95-af4-headhunter.json
@@ -46,7 +46,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
       "slots": ["Talent", "Missile", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
-      "ffg": 27
+      "ffg": 27,
+      "hyperspace": false
     },
     {
       "name": "Bandit Squadron Pilot",
@@ -58,7 +59,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
       "slots": ["Missile", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
-      "ffg": 30
+      "ffg": 30,
+      "hyperspace": false
     },
     {
       "name": "Lieutenant Blount",
@@ -71,7 +73,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
       "slots": ["Talent", "Missile", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
-      "ffg": 28
+      "ffg": 28,
+      "hyperspace": false
     },
     {
       "name": "Tala Squadron Pilot",
@@ -83,7 +86,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
       "slots": ["Talent", "Missile", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
-      "ffg": 29
+      "ffg": 29,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/resistance/mg-100-starfortress-sf-17.json
+++ b/data/pilots/resistance/mg-100-starfortress-sf-17.json
@@ -21,46 +21,17 @@
   ],
   "faction": "Resistance",
   "stats": [
-    {
-      "arc": "Front Arc",
-      "type": "attack",
-      "value": 3
-    },
-    {
-      "arc": "Double Turret Arc",
-      "type": "attack",
-      "value": 2
-    },
-    {
-      "type": "agility",
-      "value": 1
-    },
-    {
-      "type": "hull",
-      "value": 9
-    },
-    {
-      "type": "shields",
-      "value": 3
-    }
+    { "arc": "Front Arc", "type": "attack", "value": 3 },
+    { "arc": "Double Turret Arc", "type": "attack", "value": 2 },
+    { "type": "agility", "value": 1 },
+    { "type": "hull", "value": 9 },
+    { "type": "shields", "value": 3 }
   ],
   "actions": [
-    {
-      "difficulty": "White",
-      "type": "Focus"
-    },
-    {
-      "difficulty": "White",
-      "type": "Lock"
-    },
-    {
-      "difficulty": "White",
-      "type": "Rotate Arc"
-    },
-    {
-      "difficulty": "White",
-      "type": "Reload"
-    }
+    { "difficulty": "White", "type": "Focus" },
+    { "difficulty": "White", "type": "Lock" },
+    { "difficulty": "White", "type": "Rotate Arc" },
+    { "difficulty": "White", "type": "Reload" }
   ],
   "icon": "https://sb-cdn.fantasyflightgames.com/ship_types/I_StarFortress.png",
   "pilots": [
@@ -83,7 +54,8 @@
         "Device",
         "Modification"
       ],
-      "ffg": 434
+      "ffg": 434,
+      "hyperspace": true
     },
     {
       "name": "Cat",
@@ -105,7 +77,8 @@
         "Device",
         "Modification"
       ],
-      "ffg": 433
+      "ffg": 433,
+      "hyperspace": true
     },
     {
       "name": "Vennie",
@@ -127,7 +100,8 @@
         "Device",
         "Modification"
       ],
-      "ffg": 448
+      "ffg": 448,
+      "hyperspace": true
     },
     {
       "name": "Ben Teene",
@@ -150,7 +124,8 @@
         "Device",
         "Modification"
       ],
-      "ffg": 432
+      "ffg": 432,
+      "hyperspace": true
     },
     {
       "name": "Edon Kappehl",
@@ -172,7 +147,8 @@
         "Device",
         "Modification"
       ],
-      "ffg": 447
+      "ffg": 447,
+      "hyperspace": true
     },
     {
       "name": "Finch Dallow",
@@ -194,7 +170,8 @@
         "Device",
         "Modification"
       ],
-      "ffg": 431
+      "ffg": 431,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/resistance/rz-2-a-wing.json
+++ b/data/pilots/resistance/rz-2-a-wing.json
@@ -51,7 +51,8 @@
       "slots": ["Talent", "Talent", "Tech", "Missile"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/e15d3e2a2fc082b95a64a83df0c96f7f.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/b97a025a7859f54bbc68374ff5d8116e.jpg",
-      "ffg": 435
+      "ffg": 435,
+      "hyperspace": true
     },
     {
       "name": "Tallissan Lintra",
@@ -69,7 +70,8 @@
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/ee8c3c26ce6432d7581c5f61392597bc.jpg",
       "charges": { "value": 1, "recovers": 1 },
       "slots": ["Talent", "Talent", "Tech", "Missile"],
-      "ffg": 436
+      "ffg": 436,
+      "hyperspace": true
     },
     {
       "name": "Zari Bangel",
@@ -86,7 +88,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/d7f37dbb86bb706dd535e9a65b69149a.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/2fe44e1e5496645c16f4d2189a1746e3.jpg",
       "slots": ["Talent", "Talent", "Tech", "Missile"],
-      "ffg": 438
+      "ffg": 438,
+      "hyperspace": true
     },
     {
       "name": "Greer Sonnel",
@@ -103,7 +106,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/7fc7b194b02ad7af6adf4ef9b79108d1.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/84bf1ce21926d4500b54e122da01b162.jpg",
       "slots": ["Talent", "Talent", "Tech", "Missile"],
-      "ffg": 437
+      "ffg": 437,
+      "hyperspace": true
     },
     {
       "name": "Green Squadron Expert",
@@ -119,7 +123,8 @@
       "slots": ["Talent", "Talent", "Tech", "Missile"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/3f7ad9efb4c5af8b4d1f5c07a3c7538b.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/8427bdfb1cf9497a9ab797e2c955ba41.jpg",
-      "ffg": 439
+      "ffg": 439,
+      "hyperspace": true
     },
     {
       "name": "Blue Squadron Recruit",
@@ -135,7 +140,8 @@
       "slots": ["Tech", "Missile"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/e033b2729305ac0b678d6031ada7b2b8.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/3df643a75106a59899e5f32ef56e8a5e.jpg",
-      "ffg": 440
+      "ffg": 440,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/resistance/scavenged-yt-1300.json
+++ b/data/pilots/resistance/scavenged-yt-1300.json
@@ -23,41 +23,16 @@
   ],
   "faction": "Resistance",
   "stats": [
-    {
-      "arc": "Double Turret Arc",
-      "type": "attack",
-      "value": 3
-    },
-    {
-      "type": "agility",
-      "value": 1
-    },
-    {
-      "type": "hull",
-      "value": 8
-    },
-    {
-      "type": "shields",
-      "value": 3
-    }
+    { "arc": "Double Turret Arc", "type": "attack", "value": 3 },
+    { "type": "agility", "value": 1 },
+    { "type": "hull", "value": 8 },
+    { "type": "shields", "value": 3 }
   ],
   "actions": [
-    {
-      "difficulty": "White",
-      "type": "Focus"
-    },
-    {
-      "difficulty": "White",
-      "type": "Lock"
-    },
-    {
-      "difficulty": "Red",
-      "type": "Boost"
-    },
-    {
-      "difficulty": "Red",
-      "type": "Rotate Arc"
-    }
+    { "difficulty": "White", "type": "Focus" },
+    { "difficulty": "White", "type": "Lock" },
+    { "difficulty": "Red", "type": "Boost" },
+    { "difficulty": "Red", "type": "Rotate Arc" }
   ],
   "icon": "https://sb-cdn.fantasyflightgames.com/ship_types/I_Falcon_Resistance.png",
   "pilots": [
@@ -79,7 +54,8 @@
         "Modification",
         "Title"
       ],
-      "ffg": 430
+      "ffg": 430,
+      "hyperspace": true
     },
     {
       "name": "Chewbacca",
@@ -101,7 +77,8 @@
         "Modification",
         "Title"
       ],
-      "ffg": 429
+      "ffg": 429,
+      "hyperspace": true
     },
     {
       "name": "Han Solo",
@@ -123,7 +100,8 @@
         "Modification",
         "Title"
       ],
-      "ffg": 427
+      "ffg": 427,
+      "hyperspace": true
     },
     {
       "name": "Rey",
@@ -146,7 +124,8 @@
         "Modification",
         "Title"
       ],
-      "ffg": 428
+      "ffg": 428,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/resistance/t-70-x-wing.json
+++ b/data/pilots/resistance/t-70-x-wing.json
@@ -59,7 +59,8 @@
         "Configuration",
         "Title"
       ],
-      "ffg": 418
+      "ffg": 418,
+      "hyperspace": true
     },
     {
       "name": "Blue Squadron Rookie",
@@ -75,7 +76,8 @@
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/8ceeaf3d985f16da8b8d5a1ebc49ea2b.jpg",
       "cost": 46,
       "slots": ["Tech", "Astromech", "Modification", "Configuration", "Title"],
-      "ffg": 426
+      "ffg": 426,
+      "hyperspace": true
     },
     {
       "name": "Red Squadron Expert",
@@ -98,7 +100,8 @@
         "Configuration",
         "Title"
       ],
-      "ffg": 425
+      "ffg": 425,
+      "hyperspace": true
     },
     {
       "name": "Black Squadron Ace",
@@ -121,7 +124,8 @@
         "Configuration",
         "Title"
       ],
-      "ffg": 451
+      "ffg": 451,
+      "hyperspace": true
     },
     {
       "name": "Ello Asty",
@@ -145,7 +149,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/f77180ae05fd919a0dff2225380246a6.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/ff73537d7ab2f063e7a510c05013269e.jpg",
-      "ffg": 419
+      "ffg": 419,
+      "hyperspace": true
     },
     {
       "name": "Joph Seastriker",
@@ -169,7 +174,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/df85f5b77e16363a05c8f68792440166.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/b5b43d179b039649e764e6bd4f212a29.jpg",
-      "ffg": 424
+      "ffg": 424,
+      "hyperspace": true
     },
     {
       "name": "Kare Kun",
@@ -193,7 +199,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/6edb8ed4cbf882bf6dbe7a37b5981d85.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/f121bc27f2b283258a65d348bcafe40d.jpg",
-      "ffg": 421
+      "ffg": 421,
+      "hyperspace": true
     },
     {
       "name": "Lieutenant Bastian",
@@ -210,7 +217,8 @@
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/52f96e7e98dc51c1280052514e303704.jpg",
       "cost": 48,
       "slots": ["Tech", "Astromech", "Modification", "Configuration", "Title"],
-      "ffg": 449
+      "ffg": 449,
+      "hyperspace": true
     },
     {
       "name": "Nien Nunb",
@@ -234,7 +242,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/00a3c393a33b33168bc61e47749e1474.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/5daa441317975eb576396af36e852f74.jpg",
-      "ffg": 420
+      "ffg": 420,
+      "hyperspace": true
     },
     {
       "name": "Jaycris Tubbs",
@@ -251,7 +260,8 @@
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/8874efb312a64da49889c66f96338f9c.jpg",
       "cost": 50,
       "slots": ["Tech", "Astromech", "Modification", "Configuration", "Title"],
-      "ffg": 450
+      "ffg": 450,
+      "hyperspace": true
     },
     {
       "name": "Jessika Pava",
@@ -269,7 +279,8 @@
       "cost": 52,
       "charges": { "value": 1, "recovers": 1 },
       "slots": ["Tech", "Astromech", "Modification", "Configuration", "Title"],
-      "ffg": 423
+      "ffg": 423,
+      "hyperspace": true
     },
     {
       "name": "Temmin Wexley",
@@ -293,7 +304,8 @@
         "Configuration",
         "Title"
       ],
-      "ffg": 422
+      "ffg": 422,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/aggressor-assault-fighter.json
+++ b/data/pilots/scum-and-villainy/aggressor-assault-fighter.json
@@ -61,7 +61,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_197.jpg",
-      "ffg": 197
+      "ffg": 197,
+      "hyperspace": false
     },
     {
       "name": "IG-88B",
@@ -93,7 +94,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_198.jpg",
-      "ffg": 198
+      "ffg": 198,
+      "hyperspace": false
     },
     {
       "name": "IG-88C",
@@ -119,7 +121,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
-      "ffg": 199
+      "ffg": 199,
+      "hyperspace": false
     },
     {
       "name": "IG-88D",
@@ -145,7 +148,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_200.jpg",
-      "ffg": 200
+      "ffg": 200,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/btl-a4-y-wing.json
+++ b/data/pilots/scum-and-villainy/btl-a4-y-wing.json
@@ -53,7 +53,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_168.jpg",
-      "ffg": 168
+      "ffg": 168,
+      "hyperspace": false
     },
     {
       "name": "Drea Renthal",
@@ -75,7 +76,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
-      "ffg": 166
+      "ffg": 166,
+      "hyperspace": false
     },
     {
       "name": "Hired Gun",
@@ -96,7 +98,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
-      "ffg": 167
+      "ffg": 167,
+      "hyperspace": false
     },
     {
       "name": "Kavil",
@@ -118,7 +121,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_165.jpg",
-      "ffg": 165
+      "ffg": 165,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/customized-yt-1300-light-freighter.json
+++ b/data/pilots/scum-and-villainy/customized-yt-1300-light-freighter.json
@@ -55,7 +55,8 @@
       ],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
-      "ffg": 225
+      "ffg": 225,
+      "hyperspace": true
     },
     {
       "name": "Han Solo",
@@ -77,7 +78,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
-      "ffg": 222
+      "ffg": 222,
+      "hyperspace": true
     },
     {
       "name": "L3-37",
@@ -104,7 +106,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_224.jpg",
-      "ffg": 224
+      "ffg": 224,
+      "hyperspace": true
     },
     {
       "name": "Lando Calrissian",
@@ -126,7 +129,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
-      "ffg": 223
+      "ffg": 223,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/escape-craft.json
+++ b/data/pilots/scum-and-villainy/escape-craft.json
@@ -53,7 +53,8 @@
       },
       "slots": [],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_229.jpg",
-      "ffg": 229
+      "ffg": 229,
+      "hyperspace": true
     },
     {
       "name": "L3-37",
@@ -75,7 +76,8 @@
       },
       "slots": ["Talent", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
-      "ffg": 228
+      "ffg": 228,
+      "hyperspace": true
     },
     {
       "name": "Lando Calrissian",
@@ -93,7 +95,8 @@
       "slots": ["Talent", "Crew", "Modification"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_226.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_226.jpg",
-      "ffg": 226
+      "ffg": 226,
+      "hyperspace": true
     },
     {
       "name": "Outer Rim Pioneer",
@@ -110,7 +113,8 @@
       },
       "slots": ["Talent", "Crew", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
-      "ffg": 227
+      "ffg": 227,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/fang-fighter.json
+++ b/data/pilots/scum-and-villainy/fang-fighter.json
@@ -59,7 +59,8 @@
       },
       "slots": ["Talent", "Torpedo"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
-      "ffg": 155
+      "ffg": 155,
+      "hyperspace": true
     },
     {
       "name": "Joy Rekkoff",
@@ -76,7 +77,8 @@
       },
       "slots": ["Talent", "Torpedo"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_157.jpg",
-      "ffg": 157
+      "ffg": 157,
+      "hyperspace": true
     },
     {
       "name": "Kad Solus",
@@ -93,7 +95,8 @@
       },
       "slots": ["Talent", "Torpedo"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_158.jpg",
-      "ffg": 158
+      "ffg": 158,
+      "hyperspace": true
     },
     {
       "name": "Old Teroch",
@@ -110,7 +113,8 @@
       },
       "slots": ["Talent", "Torpedo"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_156.jpg",
-      "ffg": 156
+      "ffg": 156,
+      "hyperspace": true
     },
     {
       "name": "Skull Squadron Pilot",
@@ -126,7 +130,8 @@
       },
       "slots": ["Talent", "Torpedo"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
-      "ffg": 159
+      "ffg": 159,
+      "hyperspace": true
     },
     {
       "name": "Zealous Recruit",
@@ -142,7 +147,8 @@
       },
       "slots": ["Torpedo"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_160.jpg",
-      "ffg": 160
+      "ffg": 160,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/firespray-class-patrol-craft.json
+++ b/data/pilots/scum-and-villainy/firespray-class-patrol-craft.json
@@ -64,7 +64,8 @@
         }
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_149.jpg",
-      "ffg": 149
+      "ffg": 149,
+      "hyperspace": true
     },
     {
       "name": "Bounty Hunter",
@@ -84,7 +85,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_154.jpg",
-      "ffg": 154
+      "ffg": 154,
+      "hyperspace": true
     },
     {
       "name": "Emon Azzameen",
@@ -106,7 +108,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_150.jpg",
-      "ffg": 150
+      "ffg": 150,
+      "hyperspace": true
     },
     {
       "name": "Kath Scarlet",
@@ -128,7 +131,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
-      "ffg": 151
+      "ffg": 151,
+      "hyperspace": true
     },
     {
       "name": "Koshka Frost",
@@ -150,7 +154,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_152.jpg",
-      "ffg": 152
+      "ffg": 152,
+      "hyperspace": true
     },
     {
       "name": "Krassis Trelix",
@@ -172,7 +177,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_153.jpg",
-      "ffg": 153
+      "ffg": 153,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/g-1a-starfighter.json
+++ b/data/pilots/scum-and-villainy/g-1a-starfighter.json
@@ -52,7 +52,8 @@
         { "difficulty": "White", "type": "Jam" }
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_201.jpg",
-      "ffg": 201
+      "ffg": 201,
+      "hyperspace": false
     },
     {
       "name": "Gand Findsman",
@@ -64,7 +65,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
       "slots": ["Sensor", "Crew", "Illicit", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
-      "ffg": 203
+      "ffg": 203,
+      "hyperspace": false
     },
     {
       "name": "Zuckuss",
@@ -83,7 +85,8 @@
       ],
       "slots": ["Talent", "Sensor", "Crew", "Illicit", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_202.jpg",
-      "ffg": 202
+      "ffg": 202,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/hwk-290-light-freighter.json
+++ b/data/pilots/scum-and-villainy/hwk-290-light-freighter.json
@@ -64,7 +64,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_174.jpg",
-      "ffg": 174
+      "ffg": 174,
+      "hyperspace": false
     },
     {
       "name": "Palob Godalhi",
@@ -85,7 +86,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
-      "ffg": 175
+      "ffg": 175,
+      "hyperspace": false
     },
     {
       "name": "Spice Runner",
@@ -104,7 +106,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_177.jpg",
-      "ffg": 177
+      "ffg": 177,
+      "hyperspace": false
     },
     {
       "name": "Torkil Mux",
@@ -124,7 +127,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_176.jpg",
-      "ffg": 176
+      "ffg": 176,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/jumpmaster-5000.json
+++ b/data/pilots/scum-and-villainy/jumpmaster-5000.json
@@ -53,7 +53,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_217.png",
       "slots": ["Crew", "Torpedo", "Illicit", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_217.jpg",
-      "ffg": 217
+      "ffg": 217,
+      "hyperspace": false
     },
     {
       "name": "Dengar",
@@ -80,7 +81,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_214.jpg",
-      "ffg": 214
+      "ffg": 214,
+      "hyperspace": false
     },
     {
       "name": "Manaroo",
@@ -100,7 +102,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
-      "ffg": 215
+      "ffg": 215,
+      "hyperspace": false
     },
     {
       "name": "Tel Trevura",
@@ -121,7 +124,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_216.jpg",
-      "ffg": 216
+      "ffg": 216,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/kihraxz-fighter.json
+++ b/data/pilots/scum-and-villainy/kihraxz-fighter.json
@@ -52,7 +52,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
-      "ffg": 195
+      "ffg": 195,
+      "hyperspace": false
     },
     {
       "name": "Captain Jostero",
@@ -71,7 +72,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_194.jpg",
-      "ffg": 194
+      "ffg": 194,
+      "hyperspace": false
     },
     {
       "name": "Cartel Marauder",
@@ -89,7 +91,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_196.jpg",
-      "ffg": 196
+      "ffg": 196,
+      "hyperspace": false
     },
     {
       "name": "Graz",
@@ -109,7 +112,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_192.jpg",
-      "ffg": 192
+      "ffg": 192,
+      "hyperspace": false
     },
     {
       "name": "Talonbane Cobra",
@@ -129,7 +133,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
-      "ffg": 191
+      "ffg": 191,
+      "hyperspace": false
     },
     {
       "name": "Viktor Hel",
@@ -149,7 +154,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_193.jpg",
-      "ffg": 193
+      "ffg": 193,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/lancer-class-pursuit-craft.json
+++ b/data/pilots/scum-and-villainy/lancer-class-pursuit-craft.json
@@ -56,7 +56,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_219.jpg",
-      "ffg": 219
+      "ffg": 219,
+      "hyperspace": false
     },
     {
       "name": "Ketsu Onyo",
@@ -76,7 +77,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_218.jpg",
-      "ffg": 218
+      "ffg": 218,
+      "hyperspace": false
     },
     {
       "name": "Sabine Wren",
@@ -96,7 +98,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_220.jpg",
-      "ffg": 220
+      "ffg": 220,
+      "hyperspace": false
     },
     {
       "name": "Shadowport Hunter",
@@ -108,7 +111,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_221.png",
       "slots": ["Crew", "Illicit", "Illicit", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_221.jpg",
-      "ffg": 221
+      "ffg": 221,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/m12-l-kimogila-fighter.json
+++ b/data/pilots/scum-and-villainy/m12-l-kimogila-fighter.json
@@ -57,7 +57,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_209.jpg",
-      "ffg": 209
+      "ffg": 209,
+      "hyperspace": false
     },
     {
       "name": "Dalan Oberos",
@@ -82,7 +83,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_208.jpg",
-      "ffg": 208
+      "ffg": 208,
+      "hyperspace": false
     },
     {
       "name": "Torani Kulda",
@@ -106,7 +108,8 @@
         "Modification"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
-      "ffg": 207
+      "ffg": 207,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/m3-a-interceptor.json
+++ b/data/pilots/scum-and-villainy/m3-a-interceptor.json
@@ -50,7 +50,8 @@
       },
       "slots": ["Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_190.jpg",
-      "ffg": 190
+      "ffg": 190,
+      "hyperspace": false
     },
     {
       "name": "Genesis Red",
@@ -67,7 +68,8 @@
       },
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_184.jpg",
-      "ffg": 184
+      "ffg": 184,
+      "hyperspace": false
     },
     {
       "name": "Inaldra",
@@ -84,7 +86,8 @@
       },
       "slots": ["Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
-      "ffg": 187
+      "ffg": 187,
+      "hyperspace": false
     },
     {
       "name": "Laetin A'shera",
@@ -101,7 +104,8 @@
       },
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_185.jpg",
-      "ffg": 185
+      "ffg": 185,
+      "hyperspace": false
     },
     {
       "name": "Quinn Jast",
@@ -118,7 +122,8 @@
       },
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_186.jpg",
-      "ffg": 186
+      "ffg": 186,
+      "hyperspace": false
     },
     {
       "name": "Serissu",
@@ -135,7 +140,8 @@
       },
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
-      "ffg": 183
+      "ffg": 183,
+      "hyperspace": false
     },
     {
       "name": "Sunny Bounder",
@@ -152,7 +158,8 @@
       },
       "slots": ["Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_188.jpg",
-      "ffg": 188
+      "ffg": 188,
+      "hyperspace": false
     },
     {
       "name": "Tansarii Point Veteran",
@@ -168,7 +175,8 @@
       },
       "slots": ["Talent", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_189.jpg",
-      "ffg": 189
+      "ffg": 189,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/modified-tie-ln-fighter.json
+++ b/data/pilots/scum-and-villainy/modified-tie-ln-fighter.json
@@ -48,7 +48,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/d58a0696c8d85a63e90eb8a1e522a54c.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/2d162fae88ae58b9eca31f7dc0b7a9da.jpg",
       "slots": ["Talent", "Modification"],
-      "ffg": 442
+      "ffg": 442,
+      "hyperspace": true
     },
     {
       "name": "Captain Seevor",
@@ -66,7 +67,8 @@
         "text": "While you move, you ignore asteroids."
       },
       "slots": ["Talent", "Modification"],
-      "ffg": 443
+      "ffg": 443,
+      "hyperspace": true
     },
     {
       "name": "Foreman Proach",
@@ -83,7 +85,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/cfb3b5fa9d747afc3aa10f3b86f45818.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/f789aa53866112fc44fd27ed9e177993.jpg",
       "slots": ["Talent", "Modification"],
-      "ffg": 441
+      "ffg": 441,
+      "hyperspace": true
     },
     {
       "name": "Mining Guild Surveyor",
@@ -99,7 +102,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/3e5872dea32f2015bb6737592c21efaf.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/ad058d0b6d46f668f06bf0007207a30a.jpg",
       "slots": ["Talent", "Modification"],
-      "ffg": 445
+      "ffg": 445,
+      "hyperspace": true
     },
     {
       "name": "Overseer Yushyn",
@@ -117,7 +121,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/6c9268d3e6cc6b671d6db6ac39fcad0f.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/1f454eb7c12b572103e59a9a782c3f50.jpg",
       "slots": ["Modification"],
-      "ffg": 444
+      "ffg": 444,
+      "hyperspace": true
     },
     {
       "name": "Mining Guild Sentry",
@@ -133,7 +138,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/6d67112b15c3c97bd3d4acf2c8d000ed.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/09c955b8008750a30fe398c200431160.jpg",
       "slots": ["Modification"],
-      "ffg": 446
+      "ffg": 446,
+      "hyperspace": true
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/quadrijet-transfer-spacetug.json
+++ b/data/pilots/scum-and-villainy/quadrijet-transfer-spacetug.json
@@ -51,7 +51,8 @@
       },
       "slots": ["Talent", "Tech", "Crew", "Device", "Illicit", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_161.jpg",
-      "ffg": 161
+      "ffg": 161,
+      "hyperspace": false
     },
     {
       "name": "Jakku Gunrunner",
@@ -67,7 +68,8 @@
       },
       "slots": ["Tech", "Crew", "Device", "Illicit", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
-      "ffg": 164
+      "ffg": 164,
+      "hyperspace": false
     },
     {
       "name": "Sarco Plank",
@@ -84,7 +86,8 @@
       },
       "slots": ["Tech", "Crew", "Device", "Illicit", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_162.jpg",
-      "ffg": 162
+      "ffg": 162,
+      "hyperspace": false
     },
     {
       "name": "Unkar Plutt",
@@ -101,7 +104,8 @@
       },
       "slots": ["Tech", "Crew", "Device", "Illicit", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
-      "ffg": 163
+      "ffg": 163,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/scurrg-h-6-bomber.json
+++ b/data/pilots/scum-and-villainy/scurrg-h-6-bomber.json
@@ -55,7 +55,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_204.jpg",
-      "ffg": 204
+      "ffg": 204,
+      "hyperspace": false
     },
     {
       "name": "Lok Revenant",
@@ -67,7 +68,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_206.png",
       "slots": ["Turret", "Crew", "Device", "Device", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_206.jpg",
-      "ffg": 206
+      "ffg": 206,
+      "hyperspace": false
     },
     {
       "name": "Sol Sixxa",
@@ -88,7 +90,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_205.jpg",
-      "ffg": 205
+      "ffg": 205,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/starviper-class-attack-platform.json
+++ b/data/pilots/scum-and-villainy/starviper-class-attack-platform.json
@@ -58,7 +58,8 @@
       },
       "slots": ["Talent", "Sensor", "Torpedo", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_181.jpg",
-      "ffg": 181
+      "ffg": 181,
+      "hyperspace": false
     },
     {
       "name": "Black Sun Enforcer",
@@ -74,7 +75,8 @@
       },
       "slots": ["Sensor", "Torpedo", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_182.jpg",
-      "ffg": 182
+      "ffg": 182,
+      "hyperspace": false
     },
     {
       "name": "Dalan Oberos",
@@ -91,7 +93,8 @@
       },
       "slots": ["Talent", "Sensor", "Torpedo", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
-      "ffg": 179
+      "ffg": 179,
+      "hyperspace": false
     },
     {
       "name": "Guri",
@@ -122,7 +125,8 @@
       },
       "slots": ["Talent", "Sensor", "Torpedo", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_178.jpg",
-      "ffg": 178
+      "ffg": 178,
+      "hyperspace": false
     },
     {
       "name": "Prince Xizor",
@@ -139,7 +143,8 @@
       },
       "slots": ["Talent", "Sensor", "Torpedo", "Modification", "Title"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_180.jpg",
-      "ffg": 180
+      "ffg": 180,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/yv-666-light-freighter.json
+++ b/data/pilots/scum-and-villainy/yv-666-light-freighter.json
@@ -61,7 +61,8 @@
         }
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_210.jpg",
-      "ffg": 210
+      "ffg": 210,
+      "hyperspace": false
     },
     {
       "name": "Latts Razzi",
@@ -84,7 +85,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_212.jpg",
-      "ffg": 212
+      "ffg": 212,
+      "hyperspace": false
     },
     {
       "name": "Moralo Eval",
@@ -108,7 +110,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
-      "ffg": 211
+      "ffg": 211,
+      "hyperspace": false
     },
     {
       "name": "Trandoshan Slaver",
@@ -130,7 +133,8 @@
         "Title"
       ],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_213.jpg",
-      "ffg": 213
+      "ffg": 213,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/scum-and-villainy/z-95-af4-headhunter.json
+++ b/data/pilots/scum-and-villainy/z-95-af4-headhunter.json
@@ -45,7 +45,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_173.png",
       "slots": ["Missile", "Illicit", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_173.jpg",
-      "ffg": 173
+      "ffg": 173,
+      "hyperspace": false
     },
     {
       "name": "Black Sun Soldier",
@@ -57,7 +58,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_172.png",
       "slots": ["Talent", "Missile", "Illicit", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_172.jpg",
-      "ffg": 172
+      "ffg": 172,
+      "hyperspace": false
     },
     {
       "name": "Kaa'to Leeachos",
@@ -70,7 +72,8 @@
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_170.png",
       "slots": ["Talent", "Missile", "Illicit", "Modification"],
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_170.jpg",
-      "ffg": 170
+      "ffg": 170,
+      "hyperspace": false
     },
     {
       "name": "N'dru Suhlak",
@@ -83,7 +86,8 @@
       "slots": ["Talent", "Missile", "Illicit", "Modification"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_169.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_169.jpg",
-      "ffg": 169
+      "ffg": 169,
+      "hyperspace": false
     },
     {
       "name": "Nashtah Pup",
@@ -100,7 +104,8 @@
       "slots": ["Missile", "Illicit", "Modification"],
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
-      "ffg": 171
+      "ffg": 171,
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/separatist-alliance/belbullab-22-starfighter.json
+++ b/data/pilots/separatist-alliance/belbullab-22-starfighter.json
@@ -24,12 +24,7 @@
     "5FW"
   ],
   "faction": "Separatist Alliance",
-  "stats": [
-    {
-      "type": "shield",
-      "value": 2
-    }
-  ],
+  "stats": [{ "type": "shield", "value": 2 }],
   "actions": [],
   "pilots": []
 }

--- a/data/pilots/separatist-alliance/sith-infiltrator.json
+++ b/data/pilots/separatist-alliance/sith-infiltrator.json
@@ -25,37 +25,15 @@
   ],
   "faction": "Separatist Alliance",
   "stats": [
-    {
-      "arc": "Front Arc",
-      "type": "attack",
-      "value": 3
-    },
-    {
-      "type": "agility",
-      "value": 1
-    },
-    {
-      "type": "hull",
-      "value": 6
-    },
-    {
-      "type": "shields",
-      "value": 4
-    }
+    { "arc": "Front Arc", "type": "attack", "value": 3 },
+    { "type": "agility", "value": 1 },
+    { "type": "hull", "value": 6 },
+    { "type": "shields", "value": 4 }
   ],
   "actions": [
-    {
-      "difficulty": "White",
-      "type": "Focus"
-    },
-    {
-      "difficulty": "White",
-      "type": "Lock"
-    },
-    {
-      "difficulty": "Red",
-      "type": "Barrel Roll"
-    }
+    { "difficulty": "White", "type": "Focus" },
+    { "difficulty": "White", "type": "Lock" },
+    { "difficulty": "Red", "type": "Barrel Roll" }
   ],
   "pilots": [
     {
@@ -66,7 +44,8 @@
       "xws": "darthmaul",
       "force": { "value": 3, "recovers": 1, "side": ["dark"] },
       "ability": "After you perform an attack, you may spend 2 [Force] to perform a bonus primary attack against a different target. If your attack missed, you may perform that bonus primary attack against the same target instead.",
-      "image": "https://images-cdn.fantasyflightgames.com/filer_public/35/d8/35d8295c-1018-4ed7-94a0-c0bff4e6fbbc/swz30_darth-maul.png"
+      "image": "https://images-cdn.fantasyflightgames.com/filer_public/35/d8/35d8295c-1018-4ed7-94a0-c0bff4e6fbbc/swz30_darth-maul.png",
+      "hyperspace": false
     }
   ]
 }

--- a/data/pilots/separatist-alliance/vulture-class-droid-fighter.json
+++ b/data/pilots/separatist-alliance/vulture-class-droid-fighter.json
@@ -33,10 +33,7 @@
     {
       "difficulty": "White",
       "type": "Barrel Roll",
-      "linked": {
-        "difficulty": "Red",
-        "type": "Calculate"
-      }
+      "linked": { "difficulty": "Red", "type": "Calculate" }
     }
   ],
   "pilots": [
@@ -48,7 +45,8 @@
       "shipAbility": {
         "name": "Unknown",
         "text": "While you defend or perform an attack, you may spend 1 calculate token from a friendly ship at range 0-1 to change 1 [Focus] result to an [Evade] or [Hit] result."
-      }
+      },
+      "hyperspace": false
     }
   ]
 }

--- a/data/upgrades/astromech.json
+++ b/data/upgrades/astromech.json
@@ -14,7 +14,8 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": false
   },
   {
     "name": "\"Genius\"",
@@ -32,7 +33,8 @@
       }
     ],
     "cost": { "value": 0 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "R2 Astromech",
@@ -50,7 +52,8 @@
         "ffg": 282
       }
     ],
-    "cost": { "value": 6 }
+    "cost": { "value": 6 },
+    "hyperspace": true
   },
   {
     "name": "R2-D2",
@@ -69,7 +72,8 @@
       }
     ],
     "cost": { "value": 8 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "R3 Astromech",
@@ -86,7 +90,8 @@
         "ffg": 283
       }
     ],
-    "cost": { "value": 3 }
+    "cost": { "value": 3 },
+    "hyperspace": true
   },
   {
     "name": "R4 Astromech",
@@ -104,7 +109,8 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "sizes": ["Small"] }]
+    "restrictions": [{ "sizes": ["Small"] }],
+    "hyperspace": true
   },
   {
     "name": "R5 Astromech",
@@ -122,7 +128,8 @@
         "ffg": 285
       }
     ],
-    "cost": { "value": 5 }
+    "cost": { "value": 5 },
+    "hyperspace": true
   },
   {
     "name": "R5-D8",
@@ -141,7 +148,8 @@
       }
     ],
     "cost": { "value": 7 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "R5-P8",
@@ -160,7 +168,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "R5-TK",
@@ -178,7 +187,8 @@
       }
     ],
     "cost": { "value": 1 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "R5-X3",
@@ -197,7 +207,8 @@
       }
     ],
     "cost": { "value": 5 },
-    "restrictions": [{ "factions": ["Resistance"] }]
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   },
   {
     "name": "R2-HA",
@@ -215,7 +226,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "factions": ["Resistance"] }]
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   },
   {
     "name": "BB-8",
@@ -229,15 +241,13 @@
         "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/37297ef7839800afd543de5d1a363561.png",
         "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/e8a75e0e143a5857ac3931d56ccde86c.jpg",
         "slots": ["Astromech"],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        },
+        "charges": { "value": 2, "recovers": 0 },
         "ffg": 479
       }
     ],
     "cost": { "value": 8 },
-    "restrictions": [{ "factions": ["Resistance"] }]
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   },
   {
     "name": "BB Astromech",
@@ -251,19 +261,13 @@
         "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/010399f4054469aed3b04acba08d41b0.png",
         "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/a2e3aaf77e8690a37e76ef4ae2087180.jpg",
         "slots": ["Astromech"],
-        "charges": {
-          "value": 2,
-          "recovers": 0
-        },
+        "charges": { "value": 2, "recovers": 0 },
         "ffg": 480
       }
     ],
     "cost": { "value": 5 },
-    "restrictions": [
-      {
-        "factions": ["Resistance"]
-      }
-    ]
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   },
   {
     "name": "M9-G8",
@@ -281,10 +285,7 @@
       }
     ],
     "cost": { "value": 7 },
-    "restrictions": [
-      {
-        "factions": ["Resistance"]
-      }
-    ]
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   }
 ]

--- a/data/upgrades/cannon.json
+++ b/data/upgrades/cannon.json
@@ -21,7 +21,8 @@
         "ffg": 256
       }
     ],
-    "cost": { "value": 4 }
+    "cost": { "value": 4 },
+    "hyperspace": true
   },
   {
     "name": "Ion Cannon",
@@ -45,7 +46,8 @@
         "ffg": 257
       }
     ],
-    "cost": { "value": 5 }
+    "cost": { "value": 5 },
+    "hyperspace": false
   },
   {
     "name": "Jamming Beam",
@@ -69,7 +71,8 @@
         "ffg": 258
       }
     ],
-    "cost": { "value": 2 }
+    "cost": { "value": 2 },
+    "hyperspace": false
   },
   {
     "name": "Tractor Beam",
@@ -93,6 +96,7 @@
         "ffg": 259
       }
     ],
-    "cost": { "value": 3 }
+    "cost": { "value": 3 },
+    "hyperspace": false
   }
 ]

--- a/data/upgrades/configuration.json
+++ b/data/upgrades/configuration.json
@@ -12,20 +12,14 @@
         "grants": [
           {
             "type": "action",
-            "value": {
-              "type": "Barrel Roll",
-              "difficulty": "White"
-            }
+            "value": { "type": "Barrel Roll", "difficulty": "White" }
           },
           {
             "type": "action",
             "value": {
               "type": "Focus",
               "difficulty": "White",
-              "linked": {
-                "type": "Barrel Roll",
-                "difficulty": "Red"
-              }
+              "linked": { "type": "Barrel Roll", "difficulty": "Red" }
             }
           }
         ],
@@ -43,7 +37,8 @@
       }
     ],
     "cost": { "value": 0 },
-    "restrictions": [{ "ships": ["t70xwing"] }]
+    "restrictions": [{ "ships": ["t70xwing"] }],
+    "hyperspace": true
   },
   {
     "name": "Os-1 Arsenal Loadout",
@@ -65,7 +60,8 @@
       }
     ],
     "cost": { "value": 0 },
-    "restrictions": [{ "ships": ["alphaclassstarwing"] }]
+    "restrictions": [{ "ships": ["alphaclassstarwing"] }],
+    "hyperspace": false
   },
   {
     "name": "Pivot Wing",
@@ -92,7 +88,8 @@
       }
     ],
     "cost": { "value": 0 },
-    "restrictions": [{ "ships": ["ut60duwing"] }]
+    "restrictions": [{ "ships": ["ut60duwing"] }],
+    "hyperspace": true
   },
   {
     "name": "Servomotor S-foils",
@@ -141,7 +138,8 @@
       }
     ],
     "cost": { "value": 0 },
-    "restrictions": [{ "ships": ["t65xwing"] }]
+    "restrictions": [{ "ships": ["t65xwing"] }],
+    "hyperspace": true
   },
   {
     "name": "Xg-1 Assault Configuration",
@@ -160,7 +158,8 @@
       }
     ],
     "cost": { "value": 0 },
-    "restrictions": [{ "ships": ["alphaclassstarwing"] }]
+    "restrictions": [{ "ships": ["alphaclassstarwing"] }],
+    "hyperspace": false
   },
   {
     "name": "Grappling Struts",
@@ -182,7 +181,8 @@
     "restrictions": [
       { "action": { "type": "Calculate", "difficulty": "White" } },
       { "factions": ["Separatist Alliance"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Delta-7B",
@@ -194,26 +194,14 @@
         "type": "Configuration",
         "slots": ["Configuration"],
         "grants": [
-          {
-            "type": "stat",
-            "value": "agility",
-            "amount": -1
-          },
-          {
-            "type": "stat",
-            "value": "shield",
-            "amount": 2
-          },
-          {
-            "type": "stat",
-            "value": "attack",
-            "arc": "Front Arc",
-            "amount": 1
-          }
+          { "type": "stat", "value": "agility", "amount": -1 },
+          { "type": "stat", "value": "shield", "amount": 2 },
+          { "type": "stat", "value": "attack", "arc": "Front Arc", "amount": 1 }
         ]
       }
     ],
-    "restrictions": [{ "ships": ["delta7aethersprite"] }]
+    "restrictions": [{ "ships": ["delta7aethersprite"] }],
+    "hyperspace": false
   },
   {
     "name": "Calibrated Laser Targeting",
@@ -228,10 +216,7 @@
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/4a/32/4a32d934-9d57-433c-8fb6-ce6c1cb52224/swz34_calibrated-laser-targeting.png"
       }
     ],
-    "restrictions": [
-      {
-        "ships": ["delta7aethersprite"]
-      }
-    ]
+    "restrictions": [{ "ships": ["delta7aethersprite"] }],
+    "hyperspace": false
   }
 ]

--- a/data/upgrades/crew.json
+++ b/data/upgrades/crew.json
@@ -15,7 +15,8 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": false
   },
   {
     "name": "\"Zeb\" Orrelios",
@@ -33,7 +34,8 @@
       }
     ],
     "cost": { "value": 1 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": false
   },
   {
     "name": "0-0-0",
@@ -53,7 +55,8 @@
     "cost": { "value": 3 },
     "restrictions": [
       { "factions": ["Scum and Villainy"], "names": ["Darth Vader"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "4-LOM",
@@ -71,7 +74,8 @@
       }
     ],
     "cost": { "value": 3 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "Admiral Sloane",
@@ -89,7 +93,8 @@
       }
     ],
     "cost": { "value": 10 },
-    "restrictions": [{ "factions": ["Galactic Empire"] }]
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "hyperspace": false
   },
   {
     "name": "Agent Kallus",
@@ -108,7 +113,8 @@
       }
     ],
     "cost": { "value": 6 },
-    "restrictions": [{ "factions": ["Galactic Empire"] }]
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "hyperspace": false
   },
   {
     "name": "Baze Malbus",
@@ -126,7 +132,8 @@
       }
     ],
     "cost": { "value": 8 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": false
   },
   {
     "name": "Boba Fett",
@@ -144,7 +151,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": true
   },
   {
     "name": "C-3PO",
@@ -170,7 +178,8 @@
       }
     ],
     "cost": { "value": 12 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "Cad Bane",
@@ -188,7 +197,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "Captain Phasma",
@@ -206,7 +216,8 @@
       }
     ],
     "cost": { "value": 5 },
-    "restrictions": [{ "factions": ["First Order"] }]
+    "restrictions": [{ "factions": ["First Order"] }],
+    "hyperspace": true
   },
   {
     "name": "Cassian Andor",
@@ -224,7 +235,8 @@
       }
     ],
     "cost": { "value": 6 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": false
   },
   {
     "name": "Chewbacca",
@@ -243,7 +255,8 @@
       }
     ],
     "cost": { "value": 5 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "Chewbacca",
@@ -261,7 +274,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": true
   },
   {
     "name": "Ciena Ree",
@@ -282,7 +296,8 @@
     "restrictions": [
       { "factions": ["Galactic Empire"] },
       { "action": { "type": "Coordinate" } }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Cikatro Vizago",
@@ -300,7 +315,8 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "Darth Vader",
@@ -319,7 +335,8 @@
       }
     ],
     "cost": { "value": 14 },
-    "restrictions": [{ "factions": ["Galactic Empire"] }]
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "hyperspace": false
   },
   {
     "name": "Death Troopers",
@@ -337,7 +354,8 @@
       }
     ],
     "cost": { "value": 6 },
-    "restrictions": [{ "factions": ["Galactic Empire"] }]
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "hyperspace": true
   },
   {
     "name": "Director Krennic",
@@ -370,7 +388,8 @@
       }
     ],
     "cost": { "value": 5 },
-    "restrictions": [{ "factions": ["Galactic Empire"] }]
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "hyperspace": true
   },
   {
     "name": "Emperor Palpatine",
@@ -389,7 +408,8 @@
       }
     ],
     "cost": { "value": 13 },
-    "restrictions": [{ "factions": ["Galactic Empire"] }]
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "hyperspace": false
   },
   {
     "name": "Freelance Slicer",
@@ -406,7 +426,8 @@
         "ffg": 271
       }
     ],
-    "cost": { "value": 3 }
+    "cost": { "value": 3 },
+    "hyperspace": false
   },
   {
     "name": "General Hux",
@@ -424,7 +445,8 @@
       }
     ],
     "cost": { "value": 10 },
-    "restrictions": [{ "factions": ["First Order"] }]
+    "restrictions": [{ "factions": ["First Order"] }],
+    "hyperspace": true
   },
   {
     "name": "GNK \"Gonk\" Droid",
@@ -442,7 +464,8 @@
         "ffg": 272
       }
     ],
-    "cost": { "value": 10 }
+    "cost": { "value": 10 },
+    "hyperspace": false
   },
   {
     "name": "Grand Inquisitor",
@@ -461,7 +484,8 @@
       }
     ],
     "cost": { "value": 16 },
-    "restrictions": [{ "factions": ["Galactic Empire"] }]
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "hyperspace": false
   },
   {
     "name": "Grand Moff Tarkin",
@@ -483,7 +507,8 @@
     "restrictions": [
       { "factions": ["Galactic Empire"] },
       { "action": { "type": "Lock" } }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Hera Syndulla",
@@ -501,7 +526,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": false
   },
   {
     "name": "IG-88D",
@@ -527,7 +553,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "ISB Slicer",
@@ -545,7 +572,8 @@
       }
     ],
     "cost": { "value": 3 },
-    "restrictions": [{ "factions": ["Galactic Empire"] }]
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "hyperspace": true
   },
   {
     "name": "Informant",
@@ -563,7 +591,8 @@
         "ffg": 273
       }
     ],
-    "cost": { "value": 5 }
+    "cost": { "value": 5 },
+    "hyperspace": true
   },
   {
     "name": "Jabba the Hutt",
@@ -582,7 +611,8 @@
       }
     ],
     "cost": { "value": 8 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "Jyn Erso",
@@ -600,7 +630,8 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": false
   },
   {
     "name": "Kanan Jarrus",
@@ -619,7 +650,8 @@
       }
     ],
     "cost": { "value": 14 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": false
   },
   {
     "name": "Ketsu Onyo",
@@ -637,7 +669,8 @@
       }
     ],
     "cost": { "value": 5 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "Kylo Ren",
@@ -657,7 +690,8 @@
       }
     ],
     "cost": { "value": 11 },
-    "restrictions": [{ "factions": ["First Order"] }]
+    "restrictions": [{ "factions": ["First Order"] }],
+    "hyperspace": true
   },
   {
     "name": "L3-37",
@@ -683,7 +717,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": true
   },
   {
     "name": "Lando Calrissian",
@@ -701,7 +736,8 @@
       }
     ],
     "cost": { "value": 8 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": true
   },
   {
     "name": "Lando Calrissian",
@@ -719,7 +755,8 @@
       }
     ],
     "cost": { "value": 5 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "Latts Razzi",
@@ -737,7 +774,8 @@
       }
     ],
     "cost": { "value": 7 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "Leia Organa",
@@ -756,7 +794,8 @@
       }
     ],
     "cost": { "value": 8 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "Magva Yarro",
@@ -774,7 +813,8 @@
       }
     ],
     "cost": { "value": 7 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "Maul",
@@ -798,7 +838,8 @@
     "cost": { "value": 13 },
     "restrictions": [
       { "factions": ["Scum and Villainy"], "names": ["Ezra Bridger"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Minister Tua",
@@ -816,7 +857,8 @@
       }
     ],
     "cost": { "value": 7 },
-    "restrictions": [{ "factions": ["Galactic Empire"] }]
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "hyperspace": false
   },
   {
     "name": "Moff Jerjerrod",
@@ -838,7 +880,8 @@
     "restrictions": [
       { "factions": ["Galactic Empire"] },
       { "action": { "type": "Coordinate" } }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Nien Nunb",
@@ -856,7 +899,8 @@
       }
     ],
     "cost": { "value": 5 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "Novice Technician",
@@ -873,7 +917,8 @@
         "ffg": 274
       }
     ],
-    "cost": { "value": 4 }
+    "cost": { "value": 4 },
+    "hyperspace": false
   },
   {
     "name": "Perceptive Copilot",
@@ -890,7 +935,8 @@
         "ffg": 275
       }
     ],
-    "cost": { "value": 10 }
+    "cost": { "value": 10 },
+    "hyperspace": true
   },
   {
     "name": "Petty Officer Thanisson",
@@ -908,7 +954,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "factions": ["First Order"] }]
+    "restrictions": [{ "factions": ["First Order"] }],
+    "hyperspace": true
   },
   {
     "name": "Qi'ra",
@@ -926,7 +973,8 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": true
   },
   {
     "name": "R2-D2",
@@ -944,7 +992,8 @@
       }
     ],
     "cost": { "value": 8 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "Sabine Wren",
@@ -962,7 +1011,8 @@
       }
     ],
     "cost": { "value": 3 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": false
   },
   {
     "name": "Saw Gerrera",
@@ -980,7 +1030,8 @@
       }
     ],
     "cost": { "value": 8 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "Seasoned Navigator",
@@ -997,7 +1048,8 @@
         "ffg": 276
       }
     ],
-    "cost": { "value": 5 }
+    "cost": { "value": 5 },
+    "hyperspace": true
   },
   {
     "name": "Seventh Sister",
@@ -1016,7 +1068,8 @@
       }
     ],
     "cost": { "value": 12 },
-    "restrictions": [{ "factions": ["Galactic Empire"] }]
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "hyperspace": false
   },
   {
     "name": "Supreme Leader Snoke",
@@ -1035,7 +1088,8 @@
       }
     ],
     "cost": { "value": 13 },
-    "restrictions": [{ "factions": ["First Order"] }]
+    "restrictions": [{ "factions": ["First Order"] }],
+    "hyperspace": true
   },
   {
     "name": "Tactical Officer",
@@ -1063,7 +1117,8 @@
     "cost": { "value": 2 },
     "restrictions": [
       { "action": { "type": "Coordinate", "difficulty": "Red" } }
-    ]
+    ],
+    "hyperspace": true
   },
   {
     "name": "Tobias Beckett",
@@ -1081,7 +1136,8 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": true
   },
   {
     "name": "Unkar Plutt",
@@ -1099,7 +1155,8 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "Zuckuss",
@@ -1117,7 +1174,8 @@
       }
     ],
     "cost": { "value": 3 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "C-3PO",
@@ -1147,7 +1205,8 @@
       }
     ],
     "cost": { "value": 6 },
-    "restrictions": [{ "factions": ["Resistance"] }]
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   },
   {
     "name": "Han Solo",
@@ -1172,7 +1231,8 @@
       }
     ],
     "cost": { "value": 6 },
-    "restrictions": [{ "factions": ["Resistance"] }]
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   },
   {
     "name": "Chewbacca",
@@ -1191,7 +1251,8 @@
       }
     ],
     "cost": { "value": 5 },
-    "restrictions": [{ "factions": ["Resistance"] }]
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   },
   {
     "name": "Rose Tico",
@@ -1209,6 +1270,7 @@
       }
     ],
     "cost": { "value": 9 },
-    "restrictions": [{ "factions": ["Resistance"] }]
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   }
 ]

--- a/data/upgrades/device.json
+++ b/data/upgrades/device.json
@@ -20,7 +20,8 @@
         "ffg": 392
       }
     ],
-    "cost": { "value": 5 }
+    "cost": { "value": 5 },
+    "hyperspace": false
   },
   {
     "name": "Conner Nets",
@@ -43,7 +44,8 @@
         "ffg": 393
       }
     ],
-    "cost": { "value": 6 }
+    "cost": { "value": 6 },
+    "hyperspace": true
   },
   {
     "name": "Proton Bombs",
@@ -66,7 +68,8 @@
         "ffg": 394
       }
     ],
-    "cost": { "value": 5 }
+    "cost": { "value": 5 },
+    "hyperspace": true
   },
   {
     "name": "Proximity Mines",
@@ -89,7 +92,8 @@
         "ffg": 395
       }
     ],
-    "cost": { "value": 6 }
+    "cost": { "value": 6 },
+    "hyperspace": true
   },
   {
     "name": "Seismic Charges",
@@ -112,6 +116,7 @@
         "ffg": 396
       }
     ],
-    "cost": { "value": 3 }
+    "cost": { "value": 3 },
+    "hyperspace": true
   }
 ]

--- a/data/upgrades/force-power.json
+++ b/data/upgrades/force-power.json
@@ -14,7 +14,8 @@
         "ffg": 248
       }
     ],
-    "cost": { "value": 3 }
+    "cost": { "value": 3 },
+    "hyperspace": true
   },
   {
     "name": "Instinctive Aim",
@@ -31,7 +32,8 @@
         "ffg": 249
       }
     ],
-    "cost": { "value": 2 }
+    "cost": { "value": 2 },
+    "hyperspace": true
   },
   {
     "name": "Sense",
@@ -48,7 +50,8 @@
         "ffg": 250
       }
     ],
-    "cost": { "value": 6 }
+    "cost": { "value": 6 },
+    "hyperspace": true
   },
   {
     "name": "Supernatural Reflexes",
@@ -66,7 +69,8 @@
       }
     ],
     "cost": { "value": 12 },
-    "restrictions": [{ "sizes": ["Small"] }]
+    "restrictions": [{ "sizes": ["Small"] }],
+    "hyperspace": true
   },
   {
     "name": "Brilliant Evasion",
@@ -80,7 +84,8 @@
         "slots": ["Force Power"],
         "image": "https://images-cdn.fantasyflightgames.com/filer_public/d0/a4/d0a49094-b246-4345-9f65-846b070e9fc6/swz34_brilliant-evasion.png"
       }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Hate",
@@ -98,9 +103,8 @@
         "ffg": 489
       }
     ],
-    "cost": {
-      "value": 3
-    }
+    "cost": { "value": 3 },
+    "hyperspace": true
   },
   {
     "name": "Predictive Shot",
@@ -117,8 +121,7 @@
         "ffg": 490
       }
     ],
-    "cost": {
-      "value": 4
-    }
+    "cost": { "value": 4 },
+    "hyperspace": true
   }
 ]

--- a/data/upgrades/gunner.json
+++ b/data/upgrades/gunner.json
@@ -14,7 +14,8 @@
         "ffg": 388
       }
     ],
-    "cost": { "value": 10 }
+    "cost": { "value": 10 },
+    "hyperspace": true
   },
   {
     "name": "BT-1",
@@ -34,7 +35,8 @@
     "cost": { "value": 2 },
     "restrictions": [
       { "factions": ["Scum and Villainy"], "names": ["Darth Vader"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Bistan",
@@ -52,7 +54,8 @@
       }
     ],
     "cost": { "value": 14 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": false
   },
   {
     "name": "Bossk",
@@ -70,7 +73,8 @@
       }
     ],
     "cost": { "value": 10 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "Dengar",
@@ -89,7 +93,8 @@
       }
     ],
     "cost": { "value": 6 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "Ezra Bridger",
@@ -108,7 +113,8 @@
       }
     ],
     "cost": { "value": 18 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": false
   },
   {
     "name": "Fifth Brother",
@@ -127,7 +133,8 @@
       }
     ],
     "cost": { "value": 12 },
-    "restrictions": [{ "factions": ["Galactic Empire"] }]
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "hyperspace": false
   },
   {
     "name": "Greedo",
@@ -146,7 +153,8 @@
       }
     ],
     "cost": { "value": 1 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": false
   },
   {
     "name": "Han Solo",
@@ -164,7 +172,8 @@
       }
     ],
     "cost": { "value": 12 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "Han Solo",
@@ -182,7 +191,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": true
   },
   {
     "name": "Hotshot Gunner",
@@ -199,7 +209,8 @@
         "ffg": 278
       }
     ],
-    "cost": { "value": 7 }
+    "cost": { "value": 7 },
+    "hyperspace": true
   },
   {
     "name": "Luke Skywalker",
@@ -218,7 +229,8 @@
       }
     ],
     "cost": { "value": 30 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "Skilled Bombardier",
@@ -235,7 +247,8 @@
         "ffg": 279
       }
     ],
-    "cost": { "value": 2 }
+    "cost": { "value": 2 },
+    "hyperspace": true
   },
   {
     "name": "Special Forces Gunner",
@@ -256,7 +269,8 @@
     "restrictions": [
       { "factions": ["First Order"] },
       { "ships": ["tiesffighter"] }
-    ]
+    ],
+    "hyperspace": true
   },
   {
     "name": "Veteran Tail Gunner",
@@ -274,7 +288,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "arcs": ["Rear Arc"] }]
+    "restrictions": [{ "arcs": ["Rear Arc"] }],
+    "hyperspace": true
   },
   {
     "name": "Veteran Turret Gunner",
@@ -292,7 +307,8 @@
       }
     ],
     "cost": { "value": 8 },
-    "restrictions": [{ "action": { "type": "Rotate Arc" } }]
+    "restrictions": [{ "action": { "type": "Rotate Arc" } }],
+    "hyperspace": true
   },
   {
     "name": "Finn",
@@ -310,7 +326,8 @@
       }
     ],
     "cost": { "value": 10 },
-    "restrictions": [{ "factions": ["Resistance"] }]
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   },
   {
     "name": "Paige Tico",
@@ -328,7 +345,8 @@
       }
     ],
     "cost": { "value": 7 },
-    "restrictions": [{ "factions": ["Resistance"] }]
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   },
   {
     "name": "Rey",
@@ -347,6 +365,7 @@
       }
     ],
     "restrictions": [{ "factions": ["Resistance"] }],
-    "cost": { "value": 14 }
+    "cost": { "value": 14 },
+    "hyperspace": true
   }
 ]

--- a/data/upgrades/illicit.json
+++ b/data/upgrades/illicit.json
@@ -16,7 +16,8 @@
       }
     ],
     "cost": { "value": 5 },
-    "restrictions": [{ "sizes": ["Small", "Medium"] }]
+    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "hyperspace": false
   },
   {
     "name": "Contraband Cybernetics",
@@ -34,7 +35,8 @@
         "ffg": 287
       }
     ],
-    "cost": { "value": 5 }
+    "cost": { "value": 5 },
+    "hyperspace": false
   },
   {
     "name": "Deadman's Switch",
@@ -51,7 +53,8 @@
         "ffg": 288
       }
     ],
-    "cost": { "value": 2 }
+    "cost": { "value": 2 },
+    "hyperspace": true
   },
   {
     "name": "Feedback Array",
@@ -68,7 +71,8 @@
         "ffg": 289
       }
     ],
-    "cost": { "value": 4 }
+    "cost": { "value": 4 },
+    "hyperspace": false
   },
   {
     "name": "Inertial Dampeners",
@@ -85,7 +89,8 @@
         "ffg": 290
       }
     ],
-    "cost": { "value": 1 }
+    "cost": { "value": 1 },
+    "hyperspace": true
   },
   {
     "name": "Rigged Cargo Chute",
@@ -109,6 +114,7 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "sizes": ["Medium", "Large"] }]
+    "restrictions": [{ "sizes": ["Medium", "Large"] }],
+    "hyperspace": true
   }
 ]

--- a/data/upgrades/missile.json
+++ b/data/upgrades/missile.json
@@ -22,7 +22,8 @@
         "ffg": 265
       }
     ],
-    "cost": { "value": 6 }
+    "cost": { "value": 6 },
+    "hyperspace": false
   },
   {
     "name": "Cluster Missiles",
@@ -47,7 +48,8 @@
         "ffg": 266
       }
     ],
-    "cost": { "value": 5 }
+    "cost": { "value": 5 },
+    "hyperspace": true
   },
   {
     "name": "Concussion Missiles",
@@ -72,7 +74,8 @@
         "ffg": 267
       }
     ],
-    "cost": { "value": 6 }
+    "cost": { "value": 6 },
+    "hyperspace": true
   },
   {
     "name": "Homing Missiles",
@@ -97,7 +100,8 @@
         "ffg": 268
       }
     ],
-    "cost": { "value": 3 }
+    "cost": { "value": 3 },
+    "hyperspace": true
   },
   {
     "name": "Ion Missiles",
@@ -122,7 +126,8 @@
         "ffg": 269
       }
     ],
-    "cost": { "value": 4 }
+    "cost": { "value": 4 },
+    "hyperspace": true
   },
   {
     "name": "Proton Rockets",
@@ -147,7 +152,8 @@
         "ffg": 270
       }
     ],
-    "cost": { "value": 7 }
+    "cost": { "value": 7 },
+    "hyperspace": true
   },
   {
     "name": "Energy-Shell Charges",
@@ -173,6 +179,7 @@
     "restrictions": [
       { "action": { "type": "Calculate", "difficulty": "White" } },
       { "factions": ["Separatist Alliance"] }
-    ]
+    ],
+    "hyperspace": false
   }
 ]

--- a/data/upgrades/modification.json
+++ b/data/upgrades/modification.json
@@ -16,7 +16,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "sizes": ["Medium", "Large"] }]
+    "restrictions": [{ "sizes": ["Medium", "Large"] }],
+    "hyperspace": false
   },
   {
     "name": "Advanced SLAM",
@@ -34,7 +35,8 @@
       }
     ],
     "cost": { "value": 3 },
-    "restrictions": [{ "action": { "type": "SLAM", "difficulty": "White" } }]
+    "restrictions": [{ "action": { "type": "SLAM", "difficulty": "White" } }],
+    "hyperspace": false
   },
   {
     "name": "Afterburners",
@@ -53,7 +55,8 @@
       }
     ],
     "cost": { "value": 8 },
-    "restrictions": [{ "sizes": ["Small"] }]
+    "restrictions": [{ "sizes": ["Small"] }],
+    "hyperspace": true
   },
   {
     "name": "Electronic Baffle",
@@ -70,7 +73,8 @@
         "ffg": 295
       }
     ],
-    "cost": { "value": 2 }
+    "cost": { "value": 2 },
+    "hyperspace": false
   },
   {
     "name": "Engine Upgrade",
@@ -99,7 +103,8 @@
       "variable": "size",
       "values": { "Small": 3, "Medium": 6, "Large": 9 }
     },
-    "restrictions": [{ "action": { "type": "Boost", "difficulty": "Red" } }]
+    "restrictions": [{ "action": { "type": "Boost", "difficulty": "Red" } }],
+    "hyperspace": true
   },
   {
     "name": "Hull Upgrade",
@@ -120,7 +125,8 @@
     "cost": {
       "variable": "agility",
       "values": { "0": 2, "1": 3, "2": 5, "3": 7 }
-    }
+    },
+    "hyperspace": true
   },
   {
     "name": "Munitions Failsafe",
@@ -137,7 +143,8 @@
         "ffg": 298
       }
     ],
-    "cost": { "value": 2 }
+    "cost": { "value": 2 },
+    "hyperspace": true
   },
   {
     "name": "Shield Upgrade",
@@ -164,7 +171,8 @@
     "cost": {
       "variable": "agility",
       "values": { "0": 3, "1": 4, "2": 6, "3": 8 }
-    }
+    },
+    "hyperspace": true
   },
   {
     "name": "Static Discharge Vanes",
@@ -181,7 +189,8 @@
         "ffg": 300
       }
     ],
-    "cost": { "value": 6 }
+    "cost": { "value": 6 },
+    "hyperspace": true
   },
   {
     "name": "Stealth Device",
@@ -202,7 +211,8 @@
     "cost": {
       "variable": "agility",
       "values": { "0": 3, "1": 4, "2": 6, "3": 8 }
-    }
+    },
+    "hyperspace": true
   },
   {
     "name": "Tactical Scrambler",
@@ -220,6 +230,7 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "sizes": ["Medium", "Large"] }]
+    "restrictions": [{ "sizes": ["Medium", "Large"] }],
+    "hyperspace": false
   }
 ]

--- a/data/upgrades/sensor.json
+++ b/data/upgrades/sensor.json
@@ -14,7 +14,8 @@
         "ffg": 252
       }
     ],
-    "cost": { "value": 8 }
+    "cost": { "value": 8 },
+    "hyperspace": true
   },
   {
     "name": "Collision Detector",
@@ -32,7 +33,8 @@
         "ffg": 253
       }
     ],
-    "cost": { "value": 5 }
+    "cost": { "value": 5 },
+    "hyperspace": true
   },
   {
     "name": "Fire-Control System",
@@ -49,7 +51,8 @@
         "ffg": 254
       }
     ],
-    "cost": { "value": 3 }
+    "cost": { "value": 3 },
+    "hyperspace": true
   },
   {
     "name": "Trajectory Simulator",
@@ -66,6 +69,7 @@
         "ffg": 255
       }
     ],
-    "cost": { "value": 3 }
+    "cost": { "value": 3 },
+    "hyperspace": true
   }
 ]

--- a/data/upgrades/tactical-relay.json
+++ b/data/upgrades/tactical-relay.json
@@ -12,6 +12,7 @@
         "slots": ["Tactical Relay"]
       }
     ],
-    "restrictions": [{ "factions": ["Separatist Alliance"] }]
+    "restrictions": [{ "factions": ["Separatist Alliance"] }],
+    "hyperspace": false
   }
 ]

--- a/data/upgrades/talent.json
+++ b/data/upgrades/talent.json
@@ -15,7 +15,8 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "action": { "type": "Focus" } }]
+    "restrictions": [{ "action": { "type": "Focus" } }],
+    "hyperspace": true
   },
   {
     "name": "Crack Shot",
@@ -33,7 +34,8 @@
         "ffg": 230
       }
     ],
-    "cost": { "value": 1 }
+    "cost": { "value": 1 },
+    "hyperspace": true
   },
   {
     "name": "Daredevil",
@@ -54,7 +56,8 @@
     "restrictions": [
       { "sizes": ["Small"] },
       { "action": { "type": "Boost", "difficulty": "White" } }
-    ]
+    ],
+    "hyperspace": true
   },
   {
     "name": "Debris Gambit",
@@ -80,7 +83,8 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "sizes": ["Small", "Medium"] }]
+    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "hyperspace": false
   },
   {
     "name": "Elusive",
@@ -99,7 +103,8 @@
       }
     ],
     "cost": { "value": 3 },
-    "restrictions": [{ "sizes": ["Small", "Medium"] }]
+    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "hyperspace": true
   },
   {
     "name": "Expert Handling",
@@ -130,7 +135,8 @@
     },
     "restrictions": [
       { "action": { "type": "Barrel Roll", "difficulty": "Red" } }
-    ]
+    ],
+    "hyperspace": true
   },
   {
     "name": "Fanatical",
@@ -147,7 +153,8 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "factions": ["First Order"] }]
+    "restrictions": [{ "factions": ["First Order"] }],
+    "hyperspace": true
   },
   {
     "name": "Fearless",
@@ -165,7 +172,8 @@
       }
     ],
     "cost": { "value": 3 },
-    "restrictions": [{ "factions": ["Scum and Villainy"] }]
+    "restrictions": [{ "factions": ["Scum and Villainy"] }],
+    "hyperspace": true
   },
   {
     "name": "Heroic",
@@ -183,7 +191,8 @@
       }
     ],
     "cost": { "value": 1 },
-    "restrictions": [{ "factions": ["Resistance"] }]
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   },
   {
     "name": "Intimidation",
@@ -200,7 +209,8 @@
         "ffg": 236
       }
     ],
-    "cost": { "value": 3 }
+    "cost": { "value": 3 },
+    "hyperspace": true
   },
   {
     "name": "Juke",
@@ -224,7 +234,8 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "sizes": ["Small", "Medium"] }]
+    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "hyperspace": true
   },
   {
     "name": "Lone Wolf",
@@ -242,7 +253,8 @@
         "ffg": 238
       }
     ],
-    "cost": { "value": 4 }
+    "cost": { "value": 4 },
+    "hyperspace": true
   },
   {
     "name": "Marksmanship",
@@ -259,7 +271,8 @@
         "ffg": 239
       }
     ],
-    "cost": { "value": 1 }
+    "cost": { "value": 1 },
+    "hyperspace": true
   },
   {
     "name": "Outmaneuver",
@@ -276,7 +289,8 @@
         "ffg": 240
       }
     ],
-    "cost": { "value": 6 }
+    "cost": { "value": 6 },
+    "hyperspace": true
   },
   {
     "name": "Predator",
@@ -293,7 +307,8 @@
         "ffg": 241
       }
     ],
-    "cost": { "value": 2 }
+    "cost": { "value": 2 },
+    "hyperspace": true
   },
   {
     "name": "Ruthless",
@@ -311,7 +326,8 @@
       }
     ],
     "cost": { "value": 1 },
-    "restrictions": [{ "factions": ["Galactic Empire"] }]
+    "restrictions": [{ "factions": ["Galactic Empire"] }],
+    "hyperspace": true
   },
   {
     "name": "Saturation Salvo",
@@ -329,7 +345,8 @@
       }
     ],
     "cost": { "value": 6 },
-    "restrictions": [{ "action": { "type": "Reload" } }]
+    "restrictions": [{ "action": { "type": "Reload" } }],
+    "hyperspace": false
   },
   {
     "name": "Selfless",
@@ -347,7 +364,8 @@
       }
     ],
     "cost": { "value": 3 },
-    "restrictions": [{ "factions": ["Rebel Alliance"] }]
+    "restrictions": [{ "factions": ["Rebel Alliance"] }],
+    "hyperspace": true
   },
   {
     "name": "Squad Leader",
@@ -372,7 +390,8 @@
         "ffg": 245
       }
     ],
-    "cost": { "value": 4 }
+    "cost": { "value": 4 },
+    "hyperspace": true
   },
   {
     "name": "Swarm Tactics",
@@ -389,7 +408,8 @@
         "ffg": 246
       }
     ],
-    "cost": { "value": 3 }
+    "cost": { "value": 3 },
+    "hyperspace": true
   },
   {
     "name": "Trick Shot",
@@ -406,6 +426,7 @@
         "ffg": 247
       }
     ],
-    "cost": { "value": 1 }
+    "cost": { "value": 1 },
+    "hyperspace": true
   }
 ]

--- a/data/upgrades/tech.json
+++ b/data/upgrades/tech.json
@@ -14,9 +14,8 @@
         "ffg": 460
       }
     ],
-    "cost": {
-      "value": 4
-    }
+    "cost": { "value": 4 },
+    "hyperspace": true
   },
   {
     "name": "Ferrosphere Paint",
@@ -33,14 +32,9 @@
         "ffg": 488
       }
     ],
-    "cost": {
-      "value": 6
-    },
-    "restrictions": [
-      {
-        "factions": ["Resistance"]
-      }
-    ]
+    "cost": { "value": 6 },
+    "restrictions": [{ "factions": ["Resistance"] }],
+    "hyperspace": true
   },
   {
     "name": "Hyperspace Tracking Data",
@@ -57,10 +51,9 @@
         "ffg": 461
       }
     ],
-    "cost": {
-      "value": 2
-    },
-    "restrictions": [{ "factions": ["First Order"] }, { "sizes": ["Large"] }]
+    "cost": { "value": 2 },
+    "restrictions": [{ "factions": ["First Order"] }, { "sizes": ["Large"] }],
+    "hyperspace": true
   },
   {
     "name": "Primed Thrusters",
@@ -77,14 +70,9 @@
         "ffg": 463
       }
     ],
-    "cost": {
-      "value": 8
-    },
-    "restrictions": [
-      {
-        "sizes": ["Small"]
-      }
-    ]
+    "cost": { "value": 8 },
+    "restrictions": [{ "sizes": ["Small"] }],
+    "hyperspace": true
   },
   {
     "name": "Targeting Synchronizer",
@@ -101,9 +89,8 @@
         "ffg": 464
       }
     ],
-    "cost": {
-      "value": 5
-    }
+    "cost": { "value": 5 },
+    "hyperspace": true
   },
   {
     "name": "Pattern Analyzer",
@@ -120,9 +107,8 @@
         "ffg": 462
       }
     ],
-    "cost": {
-      "value": 5
-    }
+    "cost": { "value": 5 },
+    "hyperspace": true
   },
   {
     "name": "Biohexacrypt Codes",
@@ -139,12 +125,11 @@
         "ffg": 491
       }
     ],
-    "cost": {
-      "value": 1
-    },
+    "cost": { "value": 1 },
     "restrictions": [
       { "factions": ["First Order"] },
       { "action": { "type": "Lock" } }
-    ]
+    ],
+    "hyperspace": false
   }
 ]

--- a/data/upgrades/title.json
+++ b/data/upgrades/title.json
@@ -27,7 +27,8 @@
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
       { "ships": ["firesprayclasspatrolcraft"] }
-    ]
+    ],
+    "hyperspace": true
   },
   {
     "name": "Black One",
@@ -48,7 +49,8 @@
     ],
     "cost": { "value": 2 },
     "restrictions": [{ "factions": ["Resistance"] }, { "ships": ["t70xwing"] }],
-    "image": "https://images-cdn.fantasyflightgames.com/filer_public/e2/e4/e2e492b1-66d9-4dcc-9af6-a1a4e07a7378/swz25_black-one_a1.png"
+    "image": "https://images-cdn.fantasyflightgames.com/filer_public/e2/e4/e2e492b1-66d9-4dcc-9af6-a1a4e07a7378/swz25_black-one_a1.png",
+    "hyperspace": true
   },
   {
     "name": "Dauntless",
@@ -69,7 +71,8 @@
     "restrictions": [
       { "factions": ["Galactic Empire"] },
       { "ships": ["vt49decimator"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Ghost",
@@ -90,7 +93,8 @@
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
       { "ships": ["vcx100lightfreighter"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Havoc",
@@ -116,7 +120,8 @@
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
       { "ships": ["scurrgh6bomber"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Hound's Tooth",
@@ -137,7 +142,8 @@
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
       { "ships": ["yv666lightfreighter"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "IG-2000",
@@ -158,7 +164,8 @@
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
       { "ships": ["aggressorassaultfighter"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Lando's Millennium Falcon",
@@ -179,7 +186,8 @@
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
       { "ships": ["customizedyt1300lightfreighter"] }
-    ]
+    ],
+    "hyperspace": true
   },
   {
     "name": "Marauder",
@@ -201,7 +209,8 @@
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
       { "ships": ["firesprayclasspatrolcraft"] }
-    ]
+    ],
+    "hyperspace": true
   },
   {
     "name": "Millennium Falcon",
@@ -230,7 +239,8 @@
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
       { "ships": ["modifiedyt1300lightfreighter"] }
-    ]
+    ],
+    "hyperspace": true
   },
   {
     "name": "Mist Hunter",
@@ -260,7 +270,8 @@
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
       { "ships": ["g1astarfighter"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Moldy Crow",
@@ -281,7 +292,8 @@
     "restrictions": [
       { "factions": ["Rebel Alliance", "Scum and Villainy"] },
       { "ships": ["hwk290lightfreighter"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Outrider",
@@ -302,7 +314,8 @@
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
       { "ships": ["yt2400lightfreighter"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Phantom",
@@ -323,7 +336,8 @@
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
       { "ships": ["attackshuttle", "sheathipedeclassshuttle"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Punishing One",
@@ -348,7 +362,8 @@
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
       { "ships": ["jumpmaster5000"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "ST-321",
@@ -369,7 +384,8 @@
     "restrictions": [
       { "factions": ["Galactic Empire"] },
       { "ships": ["lambdaclasst4ashuttle"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Shadow Caster",
@@ -390,7 +406,8 @@
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
       { "ships": ["lancerclasspursuitcraft"] }
-    ]
+    ],
+    "hyperspace": false
   },
   {
     "name": "Slave I",
@@ -412,7 +429,8 @@
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
       { "ships": ["firesprayclasspatrolcraft"] }
-    ]
+    ],
+    "hyperspace": true
   },
   {
     "name": "Virago",
@@ -435,7 +453,8 @@
       }
     ],
     "cost": { "value": 10 },
-    "restrictions": [{ "ships": ["starviperclassattackplatform"] }]
+    "restrictions": [{ "ships": ["starviperclassattackplatform"] }],
+    "hyperspace": false
   },
   {
     "name": "Rey's Millennium Falcon",
@@ -456,6 +475,7 @@
     "restrictions": [
       { "factions": ["Resistance"] },
       { "ships": ["scavengedyt1300"] }
-    ]
+    ],
+    "hyperspace": true
   }
 ]

--- a/data/upgrades/torpedo.json
+++ b/data/upgrades/torpedo.json
@@ -22,7 +22,8 @@
         "ffg": 262
       }
     ],
-    "cost": { "value": 6 }
+    "cost": { "value": 6 },
+    "hyperspace": false
   },
   {
     "name": "Ion Torpedoes",
@@ -47,7 +48,8 @@
         "ffg": 263
       }
     ],
-    "cost": { "value": 6 }
+    "cost": { "value": 6 },
+    "hyperspace": true
   },
   {
     "name": "Proton Torpedoes",
@@ -72,6 +74,7 @@
         "ffg": 264
       }
     ],
-    "cost": { "value": 9 }
+    "cost": { "value": 9 },
+    "hyperspace": true
   }
 ]

--- a/data/upgrades/turret.json
+++ b/data/upgrades/turret.json
@@ -29,7 +29,8 @@
         "ffg": 260
       }
     ],
-    "cost": { "value": 4 }
+    "cost": { "value": 4 },
+    "hyperspace": false
   },
   {
     "name": "Ion Cannon Turret",
@@ -61,6 +62,7 @@
         "ffg": 261
       }
     ],
-    "cost": { "value": 6 }
+    "cost": { "value": 6 },
+    "hyperspace": true
   }
 ]

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "validate:json": "jsonlint-cli data/**/*.json",
     "format": "prettier --print-width 80 --write 'data/**/*.json'",
     "changelog": "git log --pretty=format:'- %s (%h)' --no-merges",
-    "ffg2xws": "node scripts/ffg2xws.js && prettier --print-width 80 --write data/ffg-xws.json"
+    "ffg2xws": "node scripts/ffg2xws.js && prettier --print-width 80 --write data/ffg-xws.json",
+    "hyperspace": "node scripts/hyperspace.js && yarn format"
   },
   "devDependencies": {
     "jsonfile": "^5.0.0",
     "jsonlint-cli": "^1.0.1",
+    "node-fetch": "^2.3.0",
     "prettier": "^1.14.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "license": "MIT",
   "scripts": {
     "validate:json": "jsonlint-cli data/**/*.json",
-    "format": "prettier --print-width 80 --write 'data/**/*.json'",
+    "format": "prettier --loglevel warn --write 'data/**/*.json'",
     "changelog": "git log --pretty=format:'- %s (%h)' --no-merges",
-    "ffg2xws": "node scripts/ffg2xws.js && prettier --print-width 80 --write data/ffg-xws.json",
+    "ffg2xws": "node scripts/ffg2xws.js && prettier --write data/ffg-xws.json",
     "hyperspace": "node scripts/hyperspace.js && yarn format"
   },
   "devDependencies": {
@@ -16,5 +16,8 @@
     "jsonlint-cli": "^1.0.1",
     "node-fetch": "^2.3.0",
     "prettier": "^1.14.2"
+  },
+  "prettier": {
+    "printWidth": 80
   }
 }

--- a/scripts/hyperspace.js
+++ b/scripts/hyperspace.js
@@ -1,0 +1,60 @@
+const jsonfile = require("jsonfile");
+const fetch = require("node-fetch");
+
+const dataRoot = __dirname + "/../data";
+const manifest = require(`${dataRoot}/manifest.json`);
+
+const log = (...args) => console.log(...args);
+
+const getApiResponse = async endpoint => {
+  log(`Fetching API endpoint ${endpoint}`);
+  const response = await fetch(
+    `https://squadbuilder.fantasyflightgames.com/api${endpoint}`
+  );
+  return await response.json();
+};
+
+const getXWDFile = async path => await jsonfile.readFile(path);
+
+const run = async () => {
+  const { game_formats: gameformats } = await getApiResponse("/gameformats/");
+
+  const hyperspaceFormat = gameformats.find(
+    format => format.name === "Hyperspace"
+  );
+  if (!hyperspaceFormat) {
+    throw new Error("Could not find Hyperspace format");
+  }
+  log(`Found Hyperspace format:\n`, hyperspaceFormat);
+
+  const { cards: hyperspaceCards } = await getApiResponse(
+    `/cards/pilots/?game_format=${hyperspaceFormat.id}`
+  );
+  log(`Found ${hyperspaceCards.length} legal Hyperspace cards`);
+
+  const hyperspaceLegalIds = hyperspaceCards.map(cards => cards.id);
+
+  const shipsInProgress = [];
+  manifest.pilots.forEach(({ faction, ships }) => {
+    log(`Loading ${faction} ships`);
+    ships.forEach(path => {
+      const promise = getXWDFile(path)
+        .then(result => {
+          log(`Processing ${path}`);
+          result.pilots = result.pilots.map(pilot =>
+            Object.assign({}, pilot, {
+              hyperspace: hyperspaceLegalIds.indexOf(pilot.ffg) > -1
+            })
+          );
+          return result;
+        })
+        .then(newResult => jsonfile.writeFile(path, newResult));
+      shipsInProgress.push(promise);
+    });
+  });
+
+  await Promise.all(shipsInProgress);
+  log(`All done!`);
+};
+
+run();

--- a/scripts/hyperspace.js
+++ b/scripts/hyperspace.js
@@ -16,11 +16,6 @@ const getApiResponse = async endpoint => {
 
 const getXWDFile = async path => await jsonfile.readFile(path);
 
-const addHyperspaceLegality = hyperspaceLegalIds => item =>
-  Object.assign({}, item, {
-    hyperspace: hyperspaceLegalIds.indexOf(item.ffg) > -1
-  });
-
 const run = async () => {
   const { game_formats: gameformats } = await getApiResponse("/gameformats/");
 
@@ -59,7 +54,11 @@ const run = async () => {
         .then(result => {
           log(`Updating ${path}`);
           return Object.assign({}, result, {
-            pilots: result.pilots.map(addHyperspaceLegality(hyperspacePilotIds))
+            pilots: result.pilots.map(pilot =>
+              Object.assign({}, pilot, {
+                hyperspace: hyperspacePilotIds.indexOf(pilot.ffg) > -1
+              })
+            )
           });
         })
         .then(newResult => jsonfile.writeFile(path, newResult));
@@ -73,8 +72,8 @@ const run = async () => {
         log(`Updating ${path}`);
         return result.map(upgrade =>
           Object.assign({}, upgrade, {
-            sides: upgrade.sides.map(
-              addHyperspaceLegality(hyperspaceUpgradeIds)
+            hyperspace: upgrade.sides.every(
+              side => hyperspaceUpgradeIds.indexOf(side.ffg) > -1
             )
           })
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,6 +428,11 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
+  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
+
 "nomnom@>= 1.5.x":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"


### PR DESCRIPTION
This adds a new field to all cards to indicate legality in the Hyperspace game format.

This field can be update from the FFG API by running `yarn run hyperspace` (or `npm run hyperspace`).