### PR TITLE
Add new cards from Power and Profit article

### DIFF
--- a/data/upgrades/tactical-relay.json
+++ b/data/upgrades/tactical-relay.json
@@ -14,5 +14,24 @@
     ],
     "restrictions": [{ "factions": ["Separatist Alliance"] }],
     "hyperspace": false
+  },
+  {
+    "name": "TV-94",
+    "xws": "tv94",
+    "limited": 1,
+    "sides": [
+      {
+        "title": "TV-94",
+        "type": "Tactical Relay",
+        "ability": "While a friendly ship at range 0-3 performs a primary attack against a defender in its [Bullseye Arc], if there are 2 or fewer attack dice, it may spend 1 calculate token to add 1 [Hit] result.",
+        "image": "https://images-cdn.fantasyflightgames.com/filer_public/35/4b/354b3a7d-bffe-420f-9fbf-ada532a5058c/swz29_a2_tv94.png",
+        "slots": ["Tactical Relay"]
+      }
+    ],
+    "restrictions": [
+      { "factions": ["Separatist Alliance"] },
+      { "solitary": true }
+    ],
+    "hyperspace": false
   }
 ]

--- a/data/upgrades/talent.json
+++ b/data/upgrades/talent.json
@@ -428,5 +428,22 @@
     ],
     "cost": { "value": 1 },
     "hyperspace": true
+  },
+  {
+    "name": "Treacherous",
+    "xws": "treacherous",
+    "limited": 0,
+    "sides": [
+      {
+        "title": "Treacherous",
+        "type": "Talent",
+        "ability": "While you defend, you may choose a ship obstructing the attack and spend 1 [Charge]. If you do, cancel 1 [Hit] or [Crit] result, and the ship you chose gains 1 strain token. After a ship at range 0-3 is destroyed, recover 1 [Charge].",
+        "slots": ["Talent"],
+        "charges": { "value": 1, "recovers": 0 },
+        "image": "https://images-cdn.fantasyflightgames.com/filer_public/78/90/78904e32-b5ad-4fd5-989e-6040595b37b9/swz29_a2_treacherous.png"
+      }
+    ],
+    "hyperspace": false,
+    "restrictions": [{ "factions": ["Separatist Alliance"] }]
   }
 ]

--- a/data/upgrades/title.json
+++ b/data/upgrades/title.json
@@ -477,5 +477,30 @@
       { "ships": ["scavengedyt1300"] }
     ],
     "hyperspace": true
+  },
+  {
+    "name": "Soulless One",
+    "limited": 1,
+    "xws": "soullessone",
+    "sides": [
+      {
+        "title": "Soulless One",
+        "type": "Title",
+        "ability": "While you defend, if the attacker is outside your firing arc, you may reroll 1 defense die.",
+        "slots": ["Title"],
+        "grants": [
+          {
+            "type": "stat",
+            "value": "hull",
+            "amount": 2
+          }
+        ],
+        "image": "https://images-cdn.fantasyflightgames.com/filer_public/f3/18/f318bb11-2334-4b13-aee2-3930ed267cf0/swz29_a2_soulless-one.png"
+      }
+    ],
+    "restrictions": [
+      { "factions": [ "Separatist Alliance" ] },
+      { "ships": ["belbullab22starfighter"] }
+    ]
   }
 ]


### PR DESCRIPTION
This commit includes a new restriction "Solitary" which prevents you having any other solitary cards of the same type. I've taken a stab at representing it in the data, but I'm open to suggestions.