### PR TITLE
Delta-7B “shields”

### DIFF
--- a/data/upgrades/configuration.json
+++ b/data/upgrades/configuration.json
@@ -193,7 +193,7 @@
         "slots": ["Configuration"],
         "grants": [
           { "type": "stat", "value": "agility", "amount": -1 },
-          { "type": "stat", "value": "shield", "amount": 2 },
+          { "type": "stat", "value": "shields", "amount": 2 },
           { "type": "stat", "value": "attack", "arc": "Front Arc", "amount": 1 }
         ]
       }


### PR DESCRIPTION
Changed the value of the Delta-7B configuration to “shields” to make it consistent with the shields stat value used on ships and other upgrades.