### PR TITLE
JSON schema + test for Upgrades

### DIFF
--- a/data/upgrades/tactical-relay.json
+++ b/data/upgrades/tactical-relay.json
@@ -12,7 +12,10 @@
         "slots": ["Tactical Relay"]
       }
     ],
-    "restrictions": [{ "factions": ["Separatist Alliance"] }],
+    "restrictions": [
+      { "factions": ["Separatist Alliance"] },
+      { "solitary": true }
+    ],
     "hyperspace": false
   },
   {

--- a/data/upgrades/title.json
+++ b/data/upgrades/title.json
@@ -49,7 +49,6 @@
     ],
     "cost": { "value": 2 },
     "restrictions": [{ "factions": ["Resistance"] }, { "ships": ["t70xwing"] }],
-    "image": "https://images-cdn.fantasyflightgames.com/filer_public/e2/e4/e2e492b1-66d9-4dcc-9af6-a1a4e07a7378/swz25_black-one_a1.png",
     "hyperspace": true
   },
   {
@@ -495,6 +494,7 @@
     "restrictions": [
       { "factions": ["Separatist Alliance"] },
       { "ships": ["belbullab22starfighter"] }
-    ]
+    ],
+    "hyperspace": false
   }
 ]

--- a/tests/schemas/pilot.schema.json
+++ b/tests/schemas/pilot.schema.json
@@ -11,7 +11,8 @@
     "conditions": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "pattern": "^[a-z0-9-]+$"
       }
     },
     "force": {

--- a/tests/schemas/pilot.schema.json
+++ b/tests/schemas/pilot.schema.json
@@ -2,9 +2,9 @@
   "properties": {
     "name": { "type": "string" },
     "caption": { "type": "string" },
-    "initiative": { "type": "number", "minimum": 0, "maximum": 6 },
-    "limited": { "type": "number", "minimum": 0 },
-    "cost": { "type": "number", "minimum": 0 },
+    "initiative": { "type": "integer", "minimum": 0, "maximum": 6 },
+    "limited": { "type": "integer", "minimum": 0 },
+    "cost": { "type": "integer", "minimum": 0 },
     "xws": { "type": "string", "pattern": "^[a-z0-9-]+$" },
     "ability": { "type": "string" },
     "text": { "type": "string" },
@@ -17,8 +17,8 @@
     "force": {
       "type": "object",
       "properties": {
-        "value": { "type": "number", "minimum": 0 },
-        "recovers": { "type": "number", "minimum": 0, "maximum": 1 },
+        "value": { "type": "integer", "minimum": 0 },
+        "recovers": { "type": "integer", "minimum": 0, "maximum": 1 },
         "side": {
           "type": "array",
           "items": {
@@ -33,8 +33,8 @@
     "charges": {
       "type": "object",
       "properties": {
-        "value": { "type": "number", "minimum": 0 },
-        "recovers": { "type": "number", "minimum": 0, "maximum": 1 }
+        "value": { "type": "integer", "minimum": 0 },
+        "recovers": { "type": "integer", "minimum": 0, "maximum": 1 }
       },
       "required": ["value", "recovers"],
       "additionalProperties": false
@@ -66,7 +66,7 @@
     },
     "image": { "type": "string" },
     "artwork": { "type": "string" },
-    "ffg": { "type": "number" },
+    "ffg": { "type": "integer" },
     "hyperspace": { "type": "boolean" },
     "alt": {
       "type": "array",

--- a/tests/schemas/ship.schema.json
+++ b/tests/schemas/ship.schema.json
@@ -2,8 +2,8 @@
   "properties": {
     "name": { "type": "string" },
     "xws": { "type": "string", "pattern": "^[a-z0-9-]+$" },
-    "ffg": { "type": "number", "minimum": 0 },
-    "cost": { "type": "number", "minimum": 0 },
+    "ffg": { "type": "integer", "minimum": 0 },
+    "cost": { "type": "integer", "minimum": 0 },
     "faction": {
       "type": "string",
       "enum": [
@@ -45,7 +45,7 @@
                 "enum": ["agility", "hull", "shields"]
               },
               "value": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0
               }
             },
@@ -71,7 +71,7 @@
                 ]
               },
               "value": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 1
               }
             },

--- a/tests/schemas/upgrade.schema.json
+++ b/tests/schemas/upgrade.schema.json
@@ -7,6 +7,7 @@
         {
           "type": "object",
           "additionalProperties": false,
+          "description": "Points cost",
           "properties": {
             "value": { "type": "integer", "minimum": 0 }
           }
@@ -14,6 +15,7 @@
         {
           "type": "object",
           "additionalProperties": false,
+          "description": "Points cost based on base size",
           "properties": {
             "variable": {
               "type": "string",
@@ -33,6 +35,7 @@
         },
         {
           "type": "object",
+          "description": "Points cost based on agility value",
           "additionalProperties": false,
           "properties": {
             "variable": {
@@ -44,6 +47,24 @@
               "additionalProperties": false,
               "patternProperties": {
                 "^[0-9]$": { "type": "integer", "minimum": 0 }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Points cost based on initiative value",
+          "additionalProperties": false,
+          "properties": {
+            "variable": {
+              "type": "string",
+              "const": "initiative"
+            },
+            "values": {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[0-6]$": { "type": "integer", "minimum": 0 }
               }
             }
           }
@@ -81,6 +102,14 @@
             "items": {
               "type": "string",
               "enum": ["Small", "Medium", "Large"]
+            }
+          },
+          "force_side": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": ["light", "dark"]
             }
           },
           "names": {
@@ -320,6 +349,6 @@
       }
     }
   },
-  "required": ["name", "hyperspace"],
+  "required": ["name", "hyperspace", "limited", "sides"],
   "additionalProperties": false
 }

--- a/tests/schemas/upgrade.schema.json
+++ b/tests/schemas/upgrade.schema.json
@@ -1,0 +1,325 @@
+{
+  "properties": {
+    "name": { "type": "string" },
+    "limited": { "type": "integer", "minimum": 0 },
+    "cost": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "value": { "type": "integer", "minimum": 0 }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "variable": {
+              "type": "string",
+              "const": "size"
+            },
+            "values": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "Small": { "type": "integer", "minimum": 0 },
+                "Medium": { "type": "integer", "minimum": 0 },
+                "Large": { "type": "integer", "minimum": 0 }
+              },
+              "required": ["Small", "Medium", "Large"]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "variable": {
+              "type": "string",
+              "const": "agility"
+            },
+            "values": {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[0-9]$": { "type": "integer", "minimum": 0 }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "xws": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+    "hyperspace": { "type": "boolean" },
+    "restrictions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "minProperties": 1,
+        "properties": {
+          "factions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": [
+                "Rebel Alliance",
+                "Galactic Empire",
+                "Scum and Villainy",
+                "Resistance",
+                "First Order",
+                "Galactic Republic",
+                "Separatist Alliance"
+              ]
+            }
+          },
+          "sizes": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": ["Small", "Medium", "Large"]
+            }
+          },
+          "names": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          },
+          "solitary": {
+            "type": "boolean"
+          },
+          "arcs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": [
+                "Double Turret Arc",
+                "Full Front Arc",
+                "Front Arc",
+                "Bullseye Arc",
+                "Single Turret Arc",
+                "Rear Arc"
+              ]
+            }
+          },
+          "action": {
+            "type": "object",
+            "properties": {
+              "difficulty": {
+                "type": "string",
+                "enum": ["Red", "White", "Purple"]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Boost",
+                  "Focus",
+                  "Evade",
+                  "Lock",
+                  "Barrel Roll",
+                  "Reinforce",
+                  "Cloak",
+                  "Coordinate",
+                  "Calculate",
+                  "Jam",
+                  "Reload",
+                  "SLAM",
+                  "Rotate Arc"
+                ]
+              }
+            },
+            "required": ["type"],
+            "additionalProperties": false
+          },
+          "ships": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": [
+                "modifiedyt1300lightfreighter",
+                "starviperclassattackplatform",
+                "scurrgh6bomber",
+                "yt2400lightfreighter",
+                "auzituckgunship",
+                "kihraxzfighter",
+                "sheathipedeclassshuttle",
+                "quadrijettransferspacetug",
+                "firesprayclasspatrolcraft",
+                "tielnfighter",
+                "btla4ywing",
+                "tieadvancedx1",
+                "alphaclassstarwing",
+                "ut60duwing",
+                "tieskstriker",
+                "asf01bwing",
+                "tieddefender",
+                "tiesabomber",
+                "tiecapunisher",
+                "aggressorassaultfighter",
+                "g1astarfighter",
+                "vcx100lightfreighter",
+                "yv666lightfreighter",
+                "tieadvancedv1",
+                "lambdaclasst4ashuttle",
+                "tiephphantom",
+                "vt49decimator",
+                "tieagaggressor",
+                "btls8kwing",
+                "arc170starfighter",
+                "attackshuttle",
+                "t65xwing",
+                "hwk290lightfreighter",
+                "rz1awing",
+                "fangfighter",
+                "z95af4headhunter",
+                "m12lkimogilafighter",
+                "ewing",
+                "tieininterceptor",
+                "lancerclasspursuitcraft",
+                "tiereaper",
+                "m3ainterceptor",
+                "jumpmaster5000",
+                "customizedyt1300lightfreighter",
+                "escapecraft",
+                "tiefofighter",
+                "tiesffighter",
+                "upsilonclassshuttle",
+                "tievnsilencer",
+                "t70xwing",
+                "rz2awing",
+                "mg100starfortress",
+                "modifiedtielnfighter",
+                "scavengedyt1300",
+                "belbullab22starfighter",
+                "delta7aethersprite",
+                "vultureclassdroidfighter"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "sides": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": {
+        "type": "object",
+        "required": ["title", "slots", "type"],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Astromech",
+              "Cannon",
+              "Configuration",
+              "Crew",
+              "Device",
+              "Force Power",
+              "Gunner",
+              "Illicit",
+              "Missile",
+              "Modification",
+              "Sensor",
+              "Tactical Relay",
+              "Talent",
+              "Tech",
+              "Title",
+              "Torpedo",
+              "Turret"
+            ]
+          },
+          "slots": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": [
+                "Astromech",
+                "Cannon",
+                "Configuration",
+                "Crew",
+                "Device",
+                "Force Power",
+                "Gunner",
+                "Illicit",
+                "Missile",
+                "Modification",
+                "Sensor",
+                "Tactical Relay",
+                "Talent",
+                "Tech",
+                "Title",
+                "Torpedo",
+                "Turret"
+              ]
+            }
+          },
+          "image": { "type": "string" },
+          "artwork": { "type": "string" },
+          "ffg": { "type": "integer" },
+          "attack": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["arc", "value", "ordnance", "minrange", "maxrange"],
+            "properties": {
+              "arc": {
+                "type": "string",
+                "enum": [
+                  "Double Turret Arc",
+                  "Full Front Arc",
+                  "Front Arc",
+                  "Bullseye Arc",
+                  "Single Turret Arc",
+                  "Rear Arc"
+                ]
+              },
+              "value": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "minrange": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 3
+              },
+              "maxrange": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 3
+              },
+              "ordnance": {
+                "type": "boolean"
+              }
+            }
+          },
+          "alt": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "properties": {
+                "image": { "type": "string" },
+                "source": { "type": "string" }
+              },
+              "required": ["image", "source"],
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": ["name", "hyperspace"],
+  "additionalProperties": false
+}

--- a/tests/upgrades-schema.test.js
+++ b/tests/upgrades-schema.test.js
@@ -1,0 +1,24 @@
+const path = require("path");
+const { matchers } = require("jest-json-schema");
+expect.extend(matchers);
+
+const { upgrades: upgradeFiles } = require("../data/manifest.json");
+
+const upgradeSchema = require("./schemas/upgrade.schema.json");
+
+describe("Upgrades", () => {
+  upgradeFiles.forEach(file => {
+    const upgrades = require(`../${file}`);
+    const filename = path.basename(file, path.extname(file));
+    describe(`${filename}`, () => {
+      upgrades.forEach(u => {
+        const testName = u.name
+          ? `${u.name} (${u.xws || `unknown xws`})`
+          : `(unknown upgrade)`;
+        test(testName, () => {
+          expect(u).toMatchSchema(upgradeSchema);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This will validate all upgrades against a JSON schema to make sure the structure and values are correct.

This schema is super long and fairly incomprehensible. It should probably be broken down into smaller pieces to be more maintainable.

Example error:
```
$ jest tests/**-schema.test.js
 FAIL  tests/upgrades-schema.test.js
  ● Upgrades › force-power › Hate (hate)

    expect(received).toMatchSchema(schema)

    received
      should have required property 'hyperspace'
```