### PR TITLE
JSON schema and tests for Quick Builds

### DIFF
--- a/data/quick-builds/first-order.json
+++ b/data/quick-builds/first-order.json
@@ -143,7 +143,7 @@
           "id": "quickdraw",
           "upgrades": {
             "talent": ["juke"],
-            "system": ["collisiondetector"],
+            "sensor": ["collisiondetector"],
             "gunner": ["hotshotgunner"],
             "modification": ["afterburners", "shieldupgrade"]
           }
@@ -171,7 +171,7 @@
           "upgrades": {
             "tech": ["patternanalyzer"],
             "missile": ["ionmissiles"],
-            "system": ["collisiondetector"],
+            "sensor": ["collisiondetector"],
             "gunner": ["specialforcesgunner"],
             "modification": ["shieldupgrade"]
           }
@@ -276,7 +276,7 @@
         {
           "id": "lieutenanttavson",
           "upgrades": {
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "cannon": ["ioncannon"],
             "crew": ["kyloren", "supremeleadersnoke"],
             "modification": ["shieldupgrade"]

--- a/data/quick-builds/galactic-empire.json
+++ b/data/quick-builds/galactic-empire.json
@@ -217,7 +217,7 @@
           "upgrades": {
             "force-power": ["supernaturalreflexes"],
             "missile": ["clustermissiles"],
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "modification": ["afterburners", "shieldupgrade"]
           }
         }
@@ -231,7 +231,7 @@
           "upgrades": {
             "talent": ["ruthless"],
             "missile": ["clustermissiles"],
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "modification": ["shieldupgrade"]
           }
         }
@@ -243,7 +243,7 @@
         {
           "id": "stormsquadronace",
           "upgrades": {
-            "system": ["firecontrolsystem"]
+            "sensor": ["firecontrolsystem"]
           }
         }
       ]
@@ -256,7 +256,7 @@
           "upgrades": {
             "talent": ["outmaneuver"],
             "missile": ["clustermissiles"],
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "modification": ["shieldupgrade"]
           }
         }
@@ -270,7 +270,7 @@
           "upgrades": {
             "talent": ["squadleader"],
             "missile": ["clustermissiles"],
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "modification": ["shieldupgrade"]
           }
         }
@@ -295,7 +295,7 @@
           "upgrades": {
             "title": ["st321"],
             "cannon": ["ioncannon"],
-            "system": ["collisiondetector"],
+            "sensor": ["collisiondetector"],
             "crew": ["darthvader", "freelanceslicer"]
           }
         }
@@ -308,9 +308,9 @@
           "id": "captainkagi",
           "upgrades": {
             "cannon": ["tractorbeam"],
-            "system": ["collisiondetector"],
+            "sensor": ["collisiondetector"],
             "crew": ["emperorpalpatine"],
-            "modificication": ["shieldupgrade", "staticdischargevanes"]
+            "modification": ["shieldupgrade", "staticdischargevanes"]
           }
         }
       ]
@@ -322,7 +322,7 @@
           "id": "lieutenantsai",
           "upgrades": {
             "cannon": ["jammingbeam"],
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "crew": ["cienaree", "gnkgonkdroid"]
           }
         }
@@ -400,7 +400,7 @@
           "id": "whisper",
           "upgrades": {
             "talent": ["juke"],
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "crew": ["agentkallus"],
             "modification": ["stealthdevice"]
           }
@@ -414,7 +414,7 @@
           "id": "sigmasquadronace",
           "upgrades": {
             "talent": ["predator"],
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "crew": ["grandinquisitor"]
           }
         }
@@ -427,7 +427,7 @@
           "id": "echo",
           "upgrades": {
             "talent": ["lonewolf"],
-            "system": ["collisiondetector"],
+            "sensor": ["collisiondetector"],
             "crew": ["perceptivecopilot"],
             "modification": ["stealthdevice"]
           }
@@ -536,7 +536,7 @@
           "id": "rexlerbrath",
           "upgrades": {
             "talent": ["juke"],
-            "system": ["collisiondetector"],
+            "sensor": ["collisiondetector"],
             "missile": ["clustermissiles"]
           }
         }
@@ -560,7 +560,7 @@
           "id": "colonelvessery",
           "upgrades": {
             "talent": ["juke"],
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "missile": ["clustermissiles"]
           }
         }
@@ -573,7 +573,7 @@
           "id": "onyxsquadronace",
           "upgrades": {
             "talent": ["elusive"],
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "missile": ["protonrockets"]
           }
         }
@@ -787,7 +787,7 @@
           "id": "nusquadronpilot",
           "upgrades": {
             "torpedo": ["protontorpedoes"],
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "configuration": ["os1arsenalloadout"],
             "modification": ["advancedslam"]
           }
@@ -815,7 +815,7 @@
           "id": "rhosquadronpilot",
           "upgrades": {
             "missile": ["homingmissiles"],
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "cannon": ["ioncannon"],
             "configuration": ["xg1assaultconfiguration"],
             "modification": ["advancedslam"]
@@ -830,7 +830,7 @@
           "id": "deathrain",
           "upgrades": {
             "missile": ["homingmissiles"],
-            "system": ["trajectorysimulator"],
+            "sensor": ["trajectorysimulator"],
             "configuration": ["bombletgenerator"],
             "modification": ["ablativeplating"]
           }
@@ -844,7 +844,7 @@
           "id": "cutlasssquadronpilot",
           "upgrades": {
             "missile": ["ionmissiles"],
-            "system": ["trajectorysimulator"],
+            "sensor": ["trajectorysimulator"],
             "gunner": ["skilledbombardier"],
             "device": ["protonbombs"]
           }
@@ -870,7 +870,7 @@
           "id": "cutlasssquadronpilot",
           "upgrades": {
             "missile": ["protonrockets"],
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "device": ["connernets"]
           }
         }

--- a/data/quick-builds/rebel-alliance.json
+++ b/data/quick-builds/rebel-alliance.json
@@ -204,7 +204,7 @@
         {
           "id": "esegetuketu",
           "upgrades": {
-            "system": ["trajectorysimulator"],
+            "sensor": ["trajectorysimulator"],
             "missile": ["ionmissiles"],
             "device": ["protonbombs", "connernets"],
             "modification": ["advancedslam"],
@@ -380,7 +380,7 @@
           "upgrades": {
             "talent": ["outmaneuver"],
             "torpedo": ["protontorpedoes"],
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "modification": ["afterburners"],
             "astromech": ["r2astromech"]
           }
@@ -395,7 +395,7 @@
           "upgrades": {
             "talent": ["predator"],
             "torpedo": ["protontorpedoes"],
-            "system": ["collisiondetector"],
+            "sensor": ["collisiondetector"],
             "astromech": ["r3astromech"]
           }
         }
@@ -409,7 +409,7 @@
           "upgrades": {
             "talent": ["crackshot"],
             "torpedo": ["iontorpedoes"],
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "astromech": ["r4astromech"]
           }
         }
@@ -612,7 +612,7 @@
         {
           "id": "cassianandor",
           "upgrades": {
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "crew": ["jynerso", "bazemalbus"],
             "configuration": ["pivotwing"]
           }
@@ -637,7 +637,7 @@
         {
           "id": "hefftobber",
           "upgrades": {
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "crew": ["perceptivecopilot"],
             "gunner": ["bistan"],
             "turret": ["ioncannonturret"],
@@ -652,7 +652,7 @@
         {
           "id": "bluesquadronscout",
           "upgrades": {
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "crew": ["tacticalofficer"],
             "configuration": ["pivotwing"]
           }
@@ -794,7 +794,7 @@
         {
           "id": "dashrendar",
           "upgrades": {
-            "talent": ["experthandling","trickshot"],
+            "talent": ["experthandling", "trickshot"],
             "illicit": ["riggedcargochute"],
             "crew": ["perceptivecopilot"],
             "title": ["outrider"]
@@ -834,7 +834,7 @@
           "id": "magvayarro",
           "upgrades": {
             "talent": ["elusive"],
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "crew": ["sawgerrera"],
             "modification": ["shieldupgrade"],
             "configuration": ["pivotwing"]
@@ -860,7 +860,7 @@
         {
           "id": "benthictwotubes",
           "upgrades": {
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "configuration": ["pivotwing"]
           }
         }
@@ -872,7 +872,7 @@
         {
           "id": "partisanrenegade",
           "upgrades": {
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "illicit": ["deadmansswitch"],
             "configuration": ["pivotwing"]
           }
@@ -942,7 +942,7 @@
         {
           "id": "kananjarrus",
           "upgrades": {
-            "crew": ["chopper-crew","herasyndulla"],
+            "crew": ["chopper-crew", "herasyndulla"],
             "gunner": ["ezrabridger"],
             "turret": ["ioncannonturret"],
             "title": ["ghost"]

--- a/data/quick-builds/resistance.json
+++ b/data/quick-builds/resistance.json
@@ -239,7 +239,7 @@
         {
           "id": "cobaltsquadronbomber",
           "upgrades": {
-            "system": ["trajectorysimulator"],
+            "sensor": ["trajectorysimulator"],
             "modification": ["ablativeplating"],
             "device": ["protonbombs"]
           }

--- a/data/quick-builds/scum-and-villainy.json
+++ b/data/quick-builds/scum-and-villainy.json
@@ -341,7 +341,7 @@
         {
           "id": "asajjventress",
           "upgrades": {
-            "force": ["sense"],
+            "force-power": ["sense"],
             "gunner": ["veteranturretgunner"],
             "illicit": ["inertialdampeners", "deadmansswitch"]
           }
@@ -627,7 +627,7 @@
           "id": "princexizor",
           "upgrades": {
             "talent": ["predator"],
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "modification": ["shieldupgrade"],
             "title": ["virago"]
           }
@@ -640,7 +640,7 @@
         {
           "id": "blacksunenforcer",
           "upgrades": {
-            "system": ["collisiondetector"]
+            "sensor": ["collisiondetector"]
           }
         }
       ]
@@ -652,7 +652,7 @@
           "id": "guri",
           "upgrades": {
             "talent": ["daredevil"],
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "torpedo": ["advprotontorpedoes"]
           }
         }
@@ -665,7 +665,7 @@
           "id": "dalanoberos-starviperclassattackplatform",
           "upgrades": {
             "talent": ["outmaneuver"],
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "illicit": ["contrabandcybernetics"],
             "torpedo": ["protontorpedoes"]
           }
@@ -918,7 +918,7 @@
           "id": "4lom",
           "upgrades": {
             "talent": ["elusive"],
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "crew": ["000", "zuckuss"],
             "gunner": ["bt1"],
             "title": ["misthunter"]
@@ -946,7 +946,7 @@
         {
           "id": "gandfindsman",
           "upgrades": {
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "crew": ["freelanceslicer"],
             "illicit": ["deadmansswitch"],
             "modification": ["electronicbaffle"]
@@ -1003,7 +1003,7 @@
           "id": "captainnym",
           "upgrades": {
             "talent": ["squadleader"],
-            "system": ["trajectorysimulator"],
+            "sensor": ["trajectorysimulator"],
             "astromech": ["r4astromech"],
             "device": ["bombletgenerator"],
             "title": ["havoc"]
@@ -1042,14 +1042,14 @@
         {
           "id": "ig88a",
           "upgrades": {
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "title": ["ig2000"]
           }
         },
         {
           "id": "ig88d",
           "upgrades": {
-            "system": ["advancedsensors"],
+            "sensor": ["advancedsensors"],
             "title": ["ig2000"]
           }
         }
@@ -1061,7 +1061,7 @@
         {
           "id": "ig88b",
           "upgrades": {
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "cannon": ["ioncannon"],
             "title": ["ig2000"]
           }
@@ -1069,7 +1069,7 @@
         {
           "id": "ig88c",
           "upgrades": {
-            "system": ["firecontrolsystem"],
+            "sensor": ["firecontrolsystem"],
             "cannon": ["ioncannon"],
             "title": ["ig2000"]
           }

--- a/tests/quick-builds-schema.test.js
+++ b/tests/quick-builds-schema.test.js
@@ -1,0 +1,28 @@
+const path = require("path");
+const { matchers } = require("jest-json-schema");
+expect.extend(matchers);
+
+const { "quick-builds": quickBuildFiles } = require("../data/manifest.json");
+
+const quickBuildsSchema = require("./schemas/quick-build.schema.json");
+
+describe("Quick Builds", () => {
+  quickBuildFiles.forEach(file => {
+    const contents = require(`../${file}`);
+    const filename = path.basename(file, path.extname(file));
+    expect(contents).toHaveProperty("quick-builds");
+    const { "quick-builds": quickBuilds } = contents;
+    describe(`${filename}`, () => {
+      quickBuilds.forEach((qb, i) => {
+        const testName = [
+          `#${i}`,
+          `threat ${qb.threat}`,
+          qb.pilots.map(d => d.id).join(", ")
+        ].join(" - ");
+        test(testName, () => {
+          expect(qb).toMatchSchema(quickBuildsSchema);
+        });
+      });
+    });
+  });
+});

--- a/tests/schemas/quick-build.schema.json
+++ b/tests/schemas/quick-build.schema.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "required": ["threat", "pilots"],
+  "additionalProperties": false,
+  "properties": {
+    "threat": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 6
+    },
+    "pilots": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+          "upgrades": {
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+              "^(astromech|cannon|configuration|crew|device|force-power|gunner|illicit|missile|modification|sensor|tacticalrelay|talent|tech|title|torpedo|turret)$": {
+                "type": "array",
+                "minLength": 1,
+                "items": { "type": "string", "pattern": "^[a-z0-9-]+$" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds JSON schema for Quick Builds data files to verify their data structure and upgrade slot names. It does not verify any XWS ids. 

Example error (where invalid slot `foo` is used):
```
 FAIL  tests/quick-builds-schema.test.js (7.223s)
  ● Quick Builds › resistance › #19 - threat 3 - cobaltsquadronbomber

    expect(received).toMatchSchema(schema)

    received
      should NOT have additional properties, but found 'foo'
```