### PR TITLE
Fix icon for TIE Advanced x1

### DIFF
--- a/data/pilots/galactic-empire/tie-advanced-x1.json
+++ b/data/pilots/galactic-empire/tie-advanced-x1.json
@@ -39,7 +39,7 @@
     { "difficulty": "White", "type": "Lock" },
     { "difficulty": "White", "type": "Barrel Roll" }
   ],
-  "icon": "https://sb-cdn.fantasyflightgames.com/ship_types/I_TIEAdvancedPrototype.png",
+  "icon": "https://sb-cdn.fantasyflightgames.com/ship_types/I_TIEAdvanced.png",
   "pilots": [
     {
       "name": "Darth Vader",


### PR DESCRIPTION
The TIE Advanced x1 was using the same icon as the TIE Advanced prototype, so I've updated the URL to the correct icon.