### PR TITLE
fix a couple typos in quickbuilds

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -135,6 +135,9 @@
     "data/quick-builds/rebel-alliance.json",
     "data/quick-builds/scum-and-villainy.json",
     "data/quick-builds/galactic-empire.json",
-    "data/quick-builds/resistance.json"
+    "data/quick-builds/resistance.json",
+    "data/quick-builds/first-order.json",
+    "data/quick-builds/galactic-republic.json",
+    "data/quick-builds/separatist-alliance.json"
   ]
 }

--- a/data/quick-builds/galactic-republic.json
+++ b/data/quick-builds/galactic-republic.json
@@ -73,7 +73,7 @@
       "threat": 2,
       "pilots": [
         {
-          "id": "104thbatallionpilot",
+          "id": "104thbattalionpilot",
           "upgrades": {
             "talent": ["dedicated"],
             "astromech": ["r4pastromech"]
@@ -150,7 +150,7 @@
           "upgrades": {
             "force-power": ["predictiveshot"],
             "astromech": ["r4p17"],
-            "modification": ["sparepartscannisters", "calibratedlasertargeting"]
+            "modification": ["sparepartscanisters","calibratedlasertargeting"]
           }
         }
       ]


### PR DESCRIPTION
Fixed a couple typos in the galactic republic quick build json file.
Added the first order, galactic republic and separatist-alliance quick build json files to manifest.json. 