### PR TITLE
Wave 4 ship icons

### DIFF
--- a/data/pilots/galactic-republic/naboo-royal-n-1-starfighter.json
+++ b/data/pilots/galactic-republic/naboo-royal-n-1-starfighter.json
@@ -35,6 +35,7 @@
     { "difficulty": "White", "type": "Barrel Roll" },
     { "difficulty": "White", "type": "Boost" }
   ],
+  "icon": "https://sb-cdn.fantasyflightgames.com/ship_types/I_Royal_Naboo_N-1_Starfighter.png",
   "pilots": [
     {
       "name": "Anakin Skywalker",

--- a/data/pilots/resistance/resistance-transport-pod.json
+++ b/data/pilots/resistance/resistance-transport-pod.json
@@ -33,6 +33,7 @@
     { "difficulty": "Red", "type": "Barrel Roll" },
     { "difficulty": "Red", "type": "Jam" }
   ],
+  "icon": "https://sb-cdn.fantasyflightgames.com/ship_types/I_Resistance_Transport_Cockpit_Pod.png",
   "pilots": [
     {
       "name": "BB-8",

--- a/data/pilots/resistance/resistance-transport.json
+++ b/data/pilots/resistance/resistance-transport.json
@@ -35,6 +35,7 @@
     { "difficulty": "Red", "type": "Coordinate" },
     { "difficulty": "Red", "type": "Jam" }
   ],
+  "icon": "https://sb-cdn.fantasyflightgames.com/ship_types/I_Resistance_Transport.png",
   "pilots": [
     {
       "name": "Cova Nell",

--- a/data/pilots/separatist-alliance/hyena-class-droid-bomber.json
+++ b/data/pilots/separatist-alliance/hyena-class-droid-bomber.json
@@ -39,6 +39,7 @@
     },
     { "difficulty": "Red", "type": "Reload" }
   ],
+  "icon": "https://sb-cdn.fantasyflightgames.com/ship_types/I_Hyena.png",
   "pilots": [
     {
       "name": "Techno Union Bomber",


### PR DESCRIPTION
Added the URLs for the icons for new ships in wave 4. The URLs are taken from the official squad builder.