### PR TITLE
Even more fixes

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -58,7 +58,7 @@
         "data/pilots/galactic-empire/lambda-class-t-4a-shuttle.json",
         "data/pilots/galactic-empire/tie-advanced-v1.json",
         "data/pilots/galactic-empire/tie-advanced-x1.json",
-        "data/pilots/galactic-empire/tie-interceptor.json",
+        "data/pilots/galactic-empire/tie-in-interceptor.json",
         "data/pilots/galactic-empire/tie-reaper.json",
         "data/pilots/galactic-empire/tie-d-defender.json",
         "data/pilots/galactic-empire/tie-ag-aggressor.json",

--- a/data/pilots/galactic-empire/tie-advanced-v1.json
+++ b/data/pilots/galactic-empire/tie-advanced-v1.json
@@ -112,7 +112,7 @@
       "limited": 1,
       "caption": "Ruthless Brute",
       "hyperspace": false,
-      "force": { "value": 2, "recovers": 1 },
+      "force": { "value": 2, "recovers": 1, "side": ["dark"] },
       "slots": ["Force Power", "Sensor", "Missile"],
       "ability": "While you perform an attack, after the Neutralize Results step, if the attack hit, you may spend 2 [Force] to add 1 [Critical Hit] result.",
       "cost": 42,

--- a/data/pilots/galactic-empire/tie-in-interceptor.json
+++ b/data/pilots/galactic-empire/tie-in-interceptor.json
@@ -1,5 +1,5 @@
 {
-  "name": "TIE Interceptor",
+  "name": "TIE/in Interceptor",
   "xws": "tieininterceptor",
   "ffg": 41,
   "size": "Small",

--- a/data/pilots/galactic-empire/vt-49-decimator.json
+++ b/data/pilots/galactic-empire/vt-49-decimator.json
@@ -125,6 +125,7 @@
         "Modification",
         "Title"
       ],
+      "charges": { "value": 3, "recovers": 0 },
       "ability": "During the End Phase, you may spend 1 [Charge] to flip 1 of your reinforce tokens to your other full arc instead of removing it.",
       "cost": 75,
       "ffg": 634,

--- a/data/pilots/rebel-alliance/modified-yt-1300-light-freighter.json
+++ b/data/pilots/rebel-alliance/modified-yt-1300-light-freighter.json
@@ -135,7 +135,7 @@
       "limited": 1,
       "caption": "There Is Another",
       "hyperspace": true,
-      "force": { "value": 1, "recovers": 1 },
+      "force": { "value": 1, "recovers": 1, "side": ["light"] },
       "slots": [
         "Force Power",
         "Missile",

--- a/data/pilots/resistance/fireball.json
+++ b/data/pilots/resistance/fireball.json
@@ -137,7 +137,13 @@
       "cost": 29,
       "ffg": 622,
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/686597246669987fe1b938f1419e598d.jpg",
-      "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/c5cfd1d89a204722ff95e9a4b134e7f1.png"
+      "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/c5cfd1d89a204722ff95e9a4b134e7f1.png",
+      "shipActions": [
+        { "difficulty": "White", "type": "Calculate" },
+        { "difficulty": "White", "type": "Evade" },
+        { "difficulty": "White", "type": "Barrel Roll" },
+        { "difficulty": "White", "type": "SLAM" }
+      ]
     }
   ]
 }

--- a/data/pilots/resistance/mg-100-starfortress-sf-17.json
+++ b/data/pilots/resistance/mg-100-starfortress-sf-17.json
@@ -180,6 +180,7 @@
       "limited": 1,
       "caption": "Hero",
       "hyperspace": false,
+      "charges": { "value": 1, "recovers": 1 },
       "slots": [
         "Talent",
         "Sensor",

--- a/data/pilots/resistance/rz-2-a-wing.json
+++ b/data/pilots/resistance/rz-2-a-wing.json
@@ -160,6 +160,7 @@
       "ability": "After you defend or perform an attack, you may spend 1 [Charge] to gain 1 focus or evade token.",
       "cost": 40,
       "ffg": 638,
+      "charges": { "value": 1, "recovers": 1 },
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/7d5b4f0691b55e9c755b1e71bd16a422.jpg",
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/17b2411d61b671ebca568ca2bb55e2da.png"
     },

--- a/data/pilots/scum-and-villainy/m3-a-interceptor.json
+++ b/data/pilots/scum-and-villainy/m3-a-interceptor.json
@@ -194,7 +194,13 @@
       "cost": 28,
       "ffg": 636,
       "artwork": "https://sb-cdn.fantasyflightgames.com/card_art/f1d43e799b5f829b40c091a2274e570f.jpg",
-      "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/22cf051c016aacea162995df8e9129a2.png"
+      "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/22cf051c016aacea162995df8e9129a2.png",
+      "shipActions": [
+        { "difficulty": "White", "type": "Calculate" },
+        { "difficulty": "White", "type": "Evade" },
+        { "difficulty": "White", "type": "Lock" },
+        { "difficulty": "White", "type": "Barrel Roll" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
- Fix: Morna Kee (Decimator) should have 3 Charges (a441cc2)
- Fix: Fifth Brother (TIE Advanced v1) uses Dark side of the Force (1ca96ba)
- Fix: Zizi Tlo (RZ-2 A-Wing) should have 1 Charge (300b8e1)
- Fix: R1-J5 (Fireball) should have Calculate instead of Focus (4f47779)
- Fix: Page Tico (Starfortress) should have 1 Charge (617bf1e)
- Fix: Leia uses Light side of the Force (f818f01)
- Fix: TIE Interceptor is now officially called TIE/in Interceptor (9884408)
- Fix: G4R-G0R V/M has Calculate instead of Focus (e3a3f6e)

Thanks to @sirjorj's http://xhud.sirjorj.com/xdv.html