### PR TITLE
Add the dial code(s) that are on the back of the dial

### DIFF
--- a/data/pilots/first-order/tie-ba-interceptor.json
+++ b/data/pilots/first-order/tie-ba-interceptor.json
@@ -24,6 +24,9 @@
     "5FW",
     "5KR"
   ],
+  "dialCodes": [
+    "VT"
+  ],
   "faction": "First Order",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/first-order/tie-fo-fighter.json
+++ b/data/pilots/first-order/tie-fo-fighter.json
@@ -22,6 +22,9 @@
     "4KR",
     "5FW"
   ],
+  "dialCodes": [
+    "Tfo"
+  ],
   "faction": "First Order",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/first-order/tie-sf-fighter.json
+++ b/data/pilots/first-order/tie-sf-fighter.json
@@ -24,6 +24,9 @@
     "4FW",
     "5FW"
   ],
+  "dialCodes": [
+    "Tsf"
+  ],
   "faction": "First Order",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/first-order/tie-vn-silencer.json
+++ b/data/pilots/first-order/tie-vn-silencer.json
@@ -22,6 +22,9 @@
     "4KR",
     "5FB"
   ],
+  "dialCodes": [
+    "Tvn"
+  ],
   "faction": "First Order",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/first-order/upsilon-class-command-shuttle.json
+++ b/data/pilots/first-order/upsilon-class-command-shuttle.json
@@ -21,6 +21,9 @@
     "3NW",
     "3YR"
   ],
+  "dialCodes": [
+    "Ups"
+  ],
   "faction": "First Order",
   "stats": [
     { "type": "attack", "value": 4, "arc": "Front Arc" },

--- a/data/pilots/galactic-empire/alpha-class-star-wing.json
+++ b/data/pilots/galactic-empire/alpha-class-star-wing.json
@@ -19,6 +19,9 @@
     "3YW",
     "4FR"
   ],
+  "dialCodes": [
+    "SW"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/galactic-empire/lambda-class-t-4a-shuttle.json
+++ b/data/pilots/galactic-empire/lambda-class-t-4a-shuttle.json
@@ -17,6 +17,9 @@
     "3FW",
     "3NR"
   ],
+  "dialCodes": [
+    "LS"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/galactic-empire/tie-advanced-v1.json
+++ b/data/pilots/galactic-empire/tie-advanced-v1.json
@@ -24,6 +24,9 @@
     "4KR",
     "5FW"
   ],
+  "dialCodes": [
+    "TAv"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/galactic-empire/tie-advanced-x1.json
+++ b/data/pilots/galactic-empire/tie-advanced-x1.json
@@ -23,6 +23,9 @@
     "4KR",
     "5FW"
   ],
+  "dialCodes": [
+    "TAx"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/galactic-empire/tie-ag-aggressor.json
+++ b/data/pilots/galactic-empire/tie-ag-aggressor.json
@@ -20,6 +20,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "TAg"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/galactic-empire/tie-ca-punisher.json
+++ b/data/pilots/galactic-empire/tie-ca-punisher.json
@@ -20,6 +20,9 @@
     "3YR",
     "4KR"
   ],
+  "dialCodes": [
+    "TPu"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/galactic-empire/tie-d-defender.json
+++ b/data/pilots/galactic-empire/tie-d-defender.json
@@ -23,6 +23,9 @@
     "4KW",
     "5FB"
   ],
+  "dialCodes": [
+    "TD"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/galactic-empire/tie-in-interceptor.json
+++ b/data/pilots/galactic-empire/tie-in-interceptor.json
@@ -22,6 +22,9 @@
     "4KR",
     "5FW"
   ],
+  "dialCodes": [
+    "TI"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/galactic-empire/tie-ln-fighter.json
+++ b/data/pilots/galactic-empire/tie-ln-fighter.json
@@ -21,6 +21,9 @@
     "4KR",
     "5FW"
   ],
+  "dialCodes": [
+    "TF"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/galactic-empire/tie-ph-phantom.json
+++ b/data/pilots/galactic-empire/tie-ph-phantom.json
@@ -22,6 +22,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "TPh"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/galactic-empire/tie-reaper.json
+++ b/data/pilots/galactic-empire/tie-reaper.json
@@ -21,6 +21,9 @@
     "3FB",
     "3NW"
   ],
+  "dialCodes": [
+    "TR"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/galactic-empire/tie-sa-bomber.json
+++ b/data/pilots/galactic-empire/tie-sa-bomber.json
@@ -21,6 +21,9 @@
     "4FW",
     "5KR"
   ],
+  "dialCodes": [
+    "TB"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/galactic-empire/tie-sk-striker.json
+++ b/data/pilots/galactic-empire/tie-sk-striker.json
@@ -21,6 +21,9 @@
     "3FB",
     "3NW"
   ],
+  "dialCodes": [
+    "TS"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/galactic-empire/vt-49-decimator.json
+++ b/data/pilots/galactic-empire/vt-49-decimator.json
@@ -21,6 +21,9 @@
     "3YW",
     "4FW"
   ],
+  "dialCodes": [
+    "Dec"
+  ],
   "faction": "Galactic Empire",
   "stats": [
     { "arc": "Double Turret Arc", "type": "attack", "value": 3 },

--- a/data/pilots/galactic-republic/arc-170-starfighter.json
+++ b/data/pilots/galactic-republic/arc-170-starfighter.json
@@ -20,6 +20,9 @@
     "4FR",
     "4KR"
   ],
+  "dialCodes": [
+    "AR"
+  ],
   "faction": "Galactic Republic",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/galactic-republic/btl-b-y-wing.json
+++ b/data/pilots/galactic-republic/btl-b-y-wing.json
@@ -20,6 +20,9 @@
     "4FR",
     "4KR"
   ],
+  "dialCodes": [
+    "YwB"
+  ],
   "faction": "Galactic Republic",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/galactic-republic/delta-7-aethersprite.json
+++ b/data/pilots/galactic-republic/delta-7-aethersprite.json
@@ -22,6 +22,9 @@
     "5FW",
     "5KR"
   ],
+  "dialCodes": [
+    "D7A"
+  ],
   "faction": "Galactic Republic",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/galactic-republic/naboo-royal-n-1-starfighter.json
+++ b/data/pilots/galactic-republic/naboo-royal-n-1-starfighter.json
@@ -22,6 +22,9 @@
     "4FW",
     "5FW"
   ],
+  "dialCodes": [
+    "N1"
+  ],
   "faction": "Galactic Republic",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/galactic-republic/v-19-torrent-starfighter.json
+++ b/data/pilots/galactic-republic/v-19-torrent-starfighter.json
@@ -21,6 +21,9 @@
     "3KR",
     "4FW"
   ],
+  "dialCodes": [
+    "V19*"
+  ],
   "faction": "Galactic Republic",
   "stats": [
     { "type": "attack", "arc": "Front Arc", "value": 2 },

--- a/data/pilots/rebel-alliance/a-sf-01-b-wing.json
+++ b/data/pilots/rebel-alliance/a-sf-01-b-wing.json
@@ -22,6 +22,9 @@
     "3NR",
     "4FR"
   ],
+  "dialCodes": [
+    "BW"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/rebel-alliance/arc-170-starfighter.json
+++ b/data/pilots/rebel-alliance/arc-170-starfighter.json
@@ -20,6 +20,9 @@
     "4FR",
     "4KR"
   ],
+  "dialCodes": [
+    "AR"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/rebel-alliance/attack-shuttle.json
+++ b/data/pilots/rebel-alliance/attack-shuttle.json
@@ -22,6 +22,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "AS"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/rebel-alliance/auzituck-gunship.json
+++ b/data/pilots/rebel-alliance/auzituck-gunship.json
@@ -20,6 +20,9 @@
     "3YW",
     "4FW"
   ],
+  "dialCodes": [
+    "Auz"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Full Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/rebel-alliance/btl-a4-y-wing.json
+++ b/data/pilots/rebel-alliance/btl-a4-y-wing.json
@@ -20,6 +20,9 @@
     "4FR",
     "4KR"
   ],
+  "dialCodes": [
+    "YW"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/rebel-alliance/btl-s8-k-wing.json
+++ b/data/pilots/rebel-alliance/btl-s8-k-wing.json
@@ -16,6 +16,9 @@
     "3FW",
     "3NW"
   ],
+  "dialCodes": [
+    "KW"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Double Turret Arc", "type": "attack", "value": 2 },

--- a/data/pilots/rebel-alliance/e-wing.json
+++ b/data/pilots/rebel-alliance/e-wing.json
@@ -25,6 +25,9 @@
     "4KR",
     "5FW"
   ],
+  "dialCodes": [
+    "EW"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/rebel-alliance/hwk-290-light-freighter.json
+++ b/data/pilots/rebel-alliance/hwk-290-light-freighter.json
@@ -20,6 +20,9 @@
     "3YR",
     "4FW"
   ],
+  "dialCodes": [
+    "HK"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Single Turret Arc", "type": "attack", "value": 2 },

--- a/data/pilots/rebel-alliance/modified-yt-1300-light-freighter.json
+++ b/data/pilots/rebel-alliance/modified-yt-1300-light-freighter.json
@@ -22,6 +22,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "YT13"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Double Turret Arc", "type": "attack", "value": 3 },

--- a/data/pilots/rebel-alliance/rz-1-a-wing.json
+++ b/data/pilots/rebel-alliance/rz-1-a-wing.json
@@ -22,6 +22,9 @@
     "5FB",
     "5KR"
   ],
+  "dialCodes": [
+    "AW"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/rebel-alliance/sheathipede-class-shuttle.json
+++ b/data/pilots/rebel-alliance/sheathipede-class-shuttle.json
@@ -21,6 +21,9 @@
     "3KR",
     "4FR"
   ],
+  "dialCodes": [
+    "ShS"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/rebel-alliance/t-65-x-wing.json
+++ b/data/pilots/rebel-alliance/t-65-x-wing.json
@@ -22,6 +22,10 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "XW",
+	"T65"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/rebel-alliance/tie-ln-fighter.json
+++ b/data/pilots/rebel-alliance/tie-ln-fighter.json
@@ -21,6 +21,9 @@
     "4KR",
     "5FW"
   ],
+  "dialCodes": [
+    "TF"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/rebel-alliance/ut-60d-u-wing.json
+++ b/data/pilots/rebel-alliance/ut-60d-u-wing.json
@@ -18,6 +18,9 @@
     "3NW",
     "4FW"
   ],
+  "dialCodes": [
+    "UW"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/rebel-alliance/vcx-100-light-freighter.json
+++ b/data/pilots/rebel-alliance/vcx-100-light-freighter.json
@@ -22,6 +22,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "VCX"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 4 },

--- a/data/pilots/rebel-alliance/yt-2400-light-freighter.json
+++ b/data/pilots/rebel-alliance/yt-2400-light-freighter.json
@@ -22,6 +22,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "YT24"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Double Turret Arc", "type": "attack", "value": 4 },

--- a/data/pilots/rebel-alliance/z-95-af4-headhunter.json
+++ b/data/pilots/rebel-alliance/z-95-af4-headhunter.json
@@ -21,6 +21,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "Z95"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/resistance/fireball.json
+++ b/data/pilots/resistance/fireball.json
@@ -23,6 +23,9 @@
     "3RR",
     "4FR"
   ],
+  "dialCodes": [
+    "FB"
+  ],
   "faction": "Resistance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/resistance/mg-100-starfortress-sf-17.json
+++ b/data/pilots/resistance/mg-100-starfortress-sf-17.json
@@ -19,6 +19,9 @@
     "3FW",
     "3NR"
   ],
+  "dialCodes": [
+    "MG1"
+  ],
   "faction": "Resistance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/resistance/resistance-transport-pod.json
+++ b/data/pilots/resistance/resistance-transport-pod.json
@@ -20,6 +20,9 @@
     "3KR",
     "4FR"
   ],
+  "dialCodes": [
+    "RTP"
+  ],
   "faction": "Resistance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/resistance/resistance-transport.json
+++ b/data/pilots/resistance/resistance-transport.json
@@ -22,6 +22,9 @@
     "3NR",
     "4FR"
   ],
+  "dialCodes": [
+    "RT"
+  ],
   "faction": "Resistance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/resistance/rz-2-a-wing.json
+++ b/data/pilots/resistance/rz-2-a-wing.json
@@ -22,6 +22,9 @@
     "5FB",
     "5KR"
   ],
+  "dialCodes": [
+    "RZ2"
+  ],
   "faction": "Resistance",
   "stats": [
     { "arc": "Single Turret Arc", "type": "attack", "value": 2 },

--- a/data/pilots/resistance/scavenged-yt-1300.json
+++ b/data/pilots/resistance/scavenged-yt-1300.json
@@ -21,6 +21,9 @@
     "3PR",
     "4FR"
   ],
+  "dialCodes": [
+    "sYT"
+  ],
   "faction": "Resistance",
   "stats": [
     { "arc": "Double Turret Arc", "type": "attack", "value": 3 },

--- a/data/pilots/resistance/t-70-x-wing.json
+++ b/data/pilots/resistance/t-70-x-wing.json
@@ -22,6 +22,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "T70"
+  ],
   "faction": "Resistance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/scum-and-villainy/aggressor-assault-fighter.json
+++ b/data/pilots/scum-and-villainy/aggressor-assault-fighter.json
@@ -22,6 +22,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "AgF"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/scum-and-villainy/btl-a4-y-wing.json
+++ b/data/pilots/scum-and-villainy/btl-a4-y-wing.json
@@ -20,6 +20,9 @@
     "4FR",
     "4KR"
   ],
+  "dialCodes": [
+    "YW"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/scum-and-villainy/customized-yt-1300-light-freighter.json
+++ b/data/pilots/scum-and-villainy/customized-yt-1300-light-freighter.json
@@ -22,6 +22,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "CY"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Double Turret Arc", "type": "attack", "value": 2 },

--- a/data/pilots/scum-and-villainy/escape-craft.json
+++ b/data/pilots/scum-and-villainy/escape-craft.json
@@ -18,6 +18,9 @@
     "3NW",
     "3KR"
   ],
+  "dialCodes": [
+    "ES"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/scum-and-villainy/fang-fighter.json
+++ b/data/pilots/scum-and-villainy/fang-fighter.json
@@ -22,6 +22,9 @@
     "4KR",
     "5FW"
   ],
+  "dialCodes": [
+    "Fng"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/scum-and-villainy/firespray-class-patrol-craft.json
+++ b/data/pilots/scum-and-villainy/firespray-class-patrol-craft.json
@@ -22,6 +22,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "FPC"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/scum-and-villainy/g-1a-starfighter.json
+++ b/data/pilots/scum-and-villainy/g-1a-starfighter.json
@@ -22,6 +22,9 @@
     "4FR",
     "4KR"
   ],
+  "dialCodes": [
+    "G1A"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/scum-and-villainy/hwk-290-light-freighter.json
+++ b/data/pilots/scum-and-villainy/hwk-290-light-freighter.json
@@ -20,6 +20,9 @@
     "3YR",
     "4FW"
   ],
+  "dialCodes": [
+    "HK"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Single Turret Arc", "type": "attack", "value": 2 },

--- a/data/pilots/scum-and-villainy/jumpmaster-5000.json
+++ b/data/pilots/scum-and-villainy/jumpmaster-5000.json
@@ -21,6 +21,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "JM5"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Single Turret Arc", "type": "attack", "value": 2 },

--- a/data/pilots/scum-and-villainy/kihraxz-fighter.json
+++ b/data/pilots/scum-and-villainy/kihraxz-fighter.json
@@ -21,6 +21,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "KXZ"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/scum-and-villainy/lancer-class-pursuit-craft.json
+++ b/data/pilots/scum-and-villainy/lancer-class-pursuit-craft.json
@@ -21,6 +21,9 @@
     "5FW",
     "5KR"
   ],
+  "dialCodes": [
+    "LPC"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/scum-and-villainy/m12-l-kimogila-fighter.json
+++ b/data/pilots/scum-and-villainy/m12-l-kimogila-fighter.json
@@ -21,6 +21,9 @@
     "3YW",
     "4KR"
   ],
+  "dialCodes": [
+    "M12"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/scum-and-villainy/m3-a-interceptor.json
+++ b/data/pilots/scum-and-villainy/m3-a-interceptor.json
@@ -21,6 +21,9 @@
     "5FW",
     "5KR"
   ],
+  "dialCodes": [
+    "M3A"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/scum-and-villainy/modified-tie-ln-fighter.json
+++ b/data/pilots/scum-and-villainy/modified-tie-ln-fighter.json
@@ -20,6 +20,9 @@
     "4FW",
     "5FR"
   ],
+  "dialCodes": [
+    "Tmg"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/scum-and-villainy/quadrijet-transfer-spacetug.json
+++ b/data/pilots/scum-and-villainy/quadrijet-transfer-spacetug.json
@@ -23,6 +23,9 @@
     "3FB",
     "3NW"
   ],
+  "dialCodes": [
+    "QUA"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/scum-and-villainy/scurrg-h-6-bomber.json
+++ b/data/pilots/scum-and-villainy/scurrg-h-6-bomber.json
@@ -21,6 +21,9 @@
     "3RR",
     "4FR"
   ],
+  "dialCodes": [
+    "SRG"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/scum-and-villainy/starviper-class-attack-platform.json
+++ b/data/pilots/scum-and-villainy/starviper-class-attack-platform.json
@@ -21,6 +21,9 @@
     "3PR",
     "4FW"
   ],
+  "dialCodes": [
+    "SV"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/scum-and-villainy/yv-666-light-freighter.json
+++ b/data/pilots/scum-and-villainy/yv-666-light-freighter.json
@@ -20,6 +20,9 @@
     "3YW",
     "4FW"
   ],
+  "dialCodes": [
+    "YV6"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Full Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/scum-and-villainy/z-95-af4-headhunter.json
+++ b/data/pilots/scum-and-villainy/z-95-af4-headhunter.json
@@ -21,6 +21,9 @@
     "4FW",
     "4KR"
   ],
+  "dialCodes": [
+    "Z95"
+  ],
   "faction": "Scum and Villainy",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/separatist-alliance/belbullab-22-starfighter.json
+++ b/data/pilots/separatist-alliance/belbullab-22-starfighter.json
@@ -22,6 +22,9 @@
     "4FW",
     "5FW"
   ],
+  "dialCodes": [
+    "B22"
+  ],
   "faction": "Separatist Alliance",
   "stats": [
     { "type": "attack", "value": 3, "arc": "Front Arc" },

--- a/data/pilots/separatist-alliance/hyena-class-droid-bomber.json
+++ b/data/pilots/separatist-alliance/hyena-class-droid-bomber.json
@@ -23,6 +23,9 @@
     "4FW",
     "5FR"
   ],
+  "dialCodes": [
+    "HDB"
+  ],
   "faction": "Separatist Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/data/pilots/separatist-alliance/nantex-class-starfighter.json
+++ b/data/pilots/separatist-alliance/nantex-class-starfighter.json
@@ -24,6 +24,9 @@
     "5FW",
     "5KR"
   ],
+  "dialCodes": [
+    "NTX"
+  ],
   "faction": "Separatist Alliance",
   "stats": [
     { "arc": "Bullseye Arc", "type": "attack", "value": 3 },

--- a/data/pilots/separatist-alliance/sith-infiltrator.json
+++ b/data/pilots/separatist-alliance/sith-infiltrator.json
@@ -23,6 +23,9 @@
     "4FW",
     "5KR"
   ],
+  "dialCodes": [
+    "SIn"
+  ],
   "faction": "Separatist Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },

--- a/data/pilots/separatist-alliance/vulture-class-droid-fighter.json
+++ b/data/pilots/separatist-alliance/vulture-class-droid-fighter.json
@@ -21,6 +21,9 @@
     "4FB",
     "5FW"
   ],
+  "dialCodes": [
+    "VDF"
+  ],
   "faction": "Separatist Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },

--- a/tests/schemas/ship.schema.json
+++ b/tests/schemas/ship.schema.json
@@ -30,6 +30,13 @@
         "pattern": "^[0-5][ABDEFKLNOPRSTY][RWB]$"
       }
     },
+	"dialCodes": {
+	  "type": "array",
+	  "items": {
+	    "type": "string",
+	    "minLength": 2
+	  }
+	},
     "pilots": {
       "type": "array"
     },


### PR DESCRIPTION
Looking to add the dial codes that are on the back of the dials to xwing-data2. I'd like to have this information to help generate some storage labeling components. Looking to get it pushed upstream because it may be useful for a squad builder to also indicate what the dial code is for a ship.

dialCodes are a list because the T-65 X-Wing has both codes XW and T65. I did not see any other dials with multiple codes but just in case FFG changes the backs on any re-print the JSON file will be able to handle it.