### PR TITLE
Update t-70-x-wing.json

### DIFF
--- a/data/pilots/resistance/t-70-x-wing.json
+++ b/data/pilots/resistance/t-70-x-wing.json
@@ -337,7 +337,7 @@
       "initiative": 4,
       "limited": 1,
       "xws": "temminwexley-swz68",
-      "ability": "At the start of the Engagement Phase, each friendly T-70 X-Wing at range 0-3 may gain 1 strain token to flip its equipped [Configuration] upgrade. If it does, that ship gains 1 calculate token.",
+      "ability": "At the start of the Engagement Phase, each friendly T-70 X-wing at range 0-3 may gain 1 strain token to flip its equipped [Configuration] upgrade. If it does, that ship gains 1 calculate token.",
       "shipAbility": {
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."


### PR DESCRIPTION
capitalization fix - for the [LETTER]-wing ships, 'wing' is always lowercase.  Personally, I would have capitalized it too, but they didnt! :)