### PR TITLE
Fixed two typos observed by r2-d7 users

### DIFF
--- a/data/conditions/conditions.json
+++ b/data/conditions/conditions.json
@@ -53,7 +53,7 @@
   },
   {
     "name": "You'd Better Mean Business",
-    "ability": "This condition is assigned facedown. Reveal it after you defend. After you defend, you may spend 2 [Charge] from Zam Wesell. If you do, perform a bonus attack against the defender. At the end of the Engagement Phase, if this card is facedown and you are in an enemy ship's firing arc, you may reveal this card. If you do, Zam Wesell recovers 2 [Charge]. At the start of the System Phase, remove this condition.",
+    "ability": "This condition is assigned facedown. Reveal it after you defend. After you defend, you may spend 2 [Charge] from Zam Wesell. If you do, perform a bonus attack against the attacker. At the end of the Engagement Phase, if this card is facedown and you are in an enemy ship's firing arc, you may reveal this card. If you do, Zam Wesell recovers 2 [Charge]. At the start of the System Phase, remove this condition.",
     "xws": "youdbettermeanbusiness"
   },
   {

--- a/data/pilots/resistance/t-70-x-wing.json
+++ b/data/pilots/resistance/t-70-x-wing.json
@@ -142,7 +142,7 @@
       },
       "image": "https://sb-cdn.fantasyflightgames.com/card_images/en/d2b6a5166b3fd985df5d1941408b58e1.png",
       "artwork": "https://squadbuilder.fantasyflightgames.com/card_art/e75228d8174f7879c51157fdd9b26e61.jpg",
-      "cost": 47,
+      "cost": 46,
       "slots": [
         "Talent",
         "Astromech",


### PR DESCRIPTION
Typo fixes
- incorrect text on zam wesell condition
- points value for resistance black squadron ace changed to match pdf (app points value is 47, pdf is 46). PDF 👑