### PR TITLE
Fix: Hyperspace script incorrect for dual-sided cards

### DIFF
--- a/scripts/hyperspace.js
+++ b/scripts/hyperspace.js
@@ -62,7 +62,7 @@ const run = async () => {
         log(`Updating ${path}`);
         return result.map(upgrade =>
           Object.assign({}, upgrade, {
-            hyperspace: upgrade.sides.every(
+            hyperspace: upgrade.sides.some(
               side => hyperspaceUpgradeIds.indexOf(side.ffg) > -1
             )
           })


### PR DESCRIPTION
If FFG only lists one side of the upgrade card in the Hyperspace game format the script would make the entire card illegal.