### PR TITLE
Wrong Ship Icon

### DIFF
--- a/data/pilots/scum-and-villainy/st-70-assault-ship.json
+++ b/data/pilots/scum-and-villainy/st-70-assault-ship.json
@@ -39,7 +39,7 @@
     { "difficulty": "White", "type": "Lock" },
     { "difficulty": "Red", "type": "Barrel Roll" }
   ],
-  "icon": "https://squadbuilder.fantasyflightgames.com/ship_types/I_TIEInterceptor.png",
+  "icon": "???",
   "pilots": [
     {
       "name": "The Mandalorian",


### PR DESCRIPTION
ST70 currently points to the wrong icon. Changing it to match the three ??? used in TIE/se, TIE/wi, and BTA-NR2 files. Though I suppose they could also all just be removed since "icon" is missing from the Gauntlet and does not appear to be a requirement per the schema.