### PR TITLE
fix rogue class starfighter faction

### DIFF
--- a/data/pilots/separatist-alliance/rogue-class-starfighter.json
+++ b/data/pilots/separatist-alliance/rogue-class-starfighter.json
@@ -24,7 +24,7 @@
     "5KR"
   ],
   "dialCodes": [],
-  "faction": "Scum and Villainy",
+  "faction": "Separatist Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 2 },
     { "type": "agility", "value": 2 },


### PR DESCRIPTION
Fixed issue where Separatist Rogue-class Starfighter listed Scum and Villainy as its faction.