### PR TITLE
Init, cost and loadout corrections

### DIFF
--- a/data/pilots/galactic-republic/delta-7b-aethersprite.json
+++ b/data/pilots/galactic-republic/delta-7b-aethersprite.json
@@ -180,7 +180,7 @@
       "standard": true,
       "epic": true,
       "cost": 7,
-      "loadout": 20,
+      "loadout": 15,
       "slots": [
         "Force Power",
         "Force Power",

--- a/data/pilots/galactic-republic/v-19-torrent-starfighter.json
+++ b/data/pilots/galactic-republic/v-19-torrent-starfighter.json
@@ -198,7 +198,7 @@
         "name": "Born for This",
         "text": "While another friendly ship at range 0-2 defends, if you are not strained, it may spend your focus and evade tokens as if that ship has them. If it does, you gain 1 strain token."
       },
-      "cost": 3,
+      "cost": 4,
       "xws": "axe-siegeofcoruscant",
       "ability": "After you perform an attack, you may choose another friendly ship with the Born for This ability at range 0-2 in your [Left Arc] or [Right Arc]. The chosen ship gains a lock on the defender.",
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/axe-siegeofcoruscant.png",

--- a/data/pilots/resistance/rz-2-a-wing.json
+++ b/data/pilots/resistance/rz-2-a-wing.json
@@ -64,7 +64,7 @@
     {
       "name": "Tallissan Lintra",
       "caption": "Deadly Approach",
-      "initiative": 4,
+      "initiative": 5,
       "limited": 1,
       "cost": 4,
       "loadout": 12,

--- a/data/pilots/scum-and-villainy/kihraxz-fighter.json
+++ b/data/pilots/scum-and-villainy/kihraxz-fighter.json
@@ -41,7 +41,7 @@
       "initiative": 3,
       "limited": 0,
       "cost": 4,
-      "loadout": 0,
+      "loadout": 3,
       "xws": "blacksunace",
       "text": "The Kihraxz assault fighter was developed specifically for the Black Sun crime syndicate, whose highly paid ace pilots demanded a nimble, powerful ship to match their skills.",
       "image": "https://squadbuilder.fantasyflightgames.com/card_images/Card_Pilot_195.png",


### PR DESCRIPTION
According to the last ship points document (Effective Date: 11/25/2022) :

rz-2-a-wing tallissanlintra : init 5 (not 4)
delta-7b-aethersprite anakinskywalker-delta7baethersprite : loadout 15 (not 20)
kihraxz-fighter blacksunace : loadout 3 (not 0)
v-19-torrent-starfighter axe-siegeofcoruscant : cost 4 (not 3)