### PR TITLE
Force all arrays to be multiline

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    plugins: [
+        // relative paths are usually required so Prettier can find the plugin
+        './node_modules/prettier-plugin-multiline-arrays', // plugin added here
+    ],
+    printWidth: 80,
+    tabWidth: 2,
+};

--- a/data/pilots/first-order/tie-ba-interceptor.json
+++ b/data/pilots/first-order/tie-ba-interceptor.json
@@ -81,7 +81,13 @@
         "name": "Fine-Tuned Thrusters",
         "text": "After you fully execute a maneuver, if you are not depleted or strained, you may gain 1 deplete or strain token to perform a [Lock] or [Barrel Roll] action."
       },
-      "slots": ["Talent", "Tech", "Missile", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Tech",
+        "Missile",
+        "Modification",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/holo.png",
@@ -102,7 +108,13 @@
         "name": "Fine-Tuned Thrusters",
         "text": "After you fully execute a maneuver, if you are not depleted or strained, you may gain 1 deplete or strain token to perform a [Lock] or [Barrel Roll] action."
       },
-      "slots": ["Talent", "Talent", "Tech", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Tech",
+        "Missile",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ember.png",
@@ -122,7 +134,11 @@
         "name": "Fine-Tuned Thrusters",
         "text": "After you fully execute a maneuver, if you are not depleted or strained, you may gain 1 deplete or strain token to perform a [Lock] or [Barrel Roll] action."
       },
-      "slots": ["Talent", "Tech", "Modification"],
+      "slots": [
+        "Talent",
+        "Tech",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/firstorderprovocateur.png",

--- a/data/pilots/first-order/tie-fo-fighter.json
+++ b/data/pilots/first-order/tie-fo-fighter.json
@@ -71,7 +71,13 @@
       "ability": "At the start of the Engagement Phase, you may spend 1 [Charge] and gain 1 stress token. If you do, until the end of the round, while you defend or perform an attack, you may change all of your [Focus] results to [Evade] or [Hit] results.",
       "image": "https://infinitearenas.com/xw2/images/pilots/commandermalarus.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/commandermalarus.png",
-      "slots": ["Talent", "Talent", "Missile", "Modification", "Tech"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Missile",
+        "Modification",
+        "Tech"
+      ],
       "charges": { "value": 2, "recovers": 0 },
       "standard": true,
       "extended": true,
@@ -89,7 +95,12 @@
       "ability": "While you perform a primary attack, if you are not stressed, you may gain 1 stress token to roll 1 additional attack die.",
       "image": "https://infinitearenas.com/xw2/images/pilots/scorch.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/scorch.png",
-      "slots": ["Talent", "Talent", "Modification", "Tech"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Modification",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -106,7 +117,13 @@
       "ability": "While you perform a primary attack, you may spend your lock on the defender and a focus token to change all of your results to [Critical Hit] results.",
       "image": "https://infinitearenas.com/xw2/images/pilots/static.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/static.png",
-      "slots": ["Talent", "Talent", "Cannon", "Modification", "Tech"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Cannon",
+        "Modification",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -123,7 +140,12 @@
       "ability": "While you perform a primary attack at attack range 3, roll 1 additional attack die.",
       "image": "https://infinitearenas.com/xw2/images/pilots/longshot.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/longshot.png",
-      "slots": ["Talent", "Modification", "Tech", "Tech"],
+      "slots": [
+        "Talent",
+        "Modification",
+        "Tech",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -139,7 +161,12 @@
       "text": "Only pilots who have demonstrated both exceptional skill and unwavering dedication are rewarded with coveted positions in the First Order squadrons operating secretly against the New Republic during the Cold War.",
       "image": "https://infinitearenas.com/xw2/images/pilots/omegasquadronace.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/omegasquadronace.png",
-      "slots": ["Talent", "Modification", "Modification", "Tech"],
+      "slots": [
+        "Talent",
+        "Modification",
+        "Modification",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -156,7 +183,10 @@
       "ability": "At the start of the Engagement Phase, you may choose a friendly ship at range 0-1. If you do, that ship removes 1 stress token.",
       "image": "https://infinitearenas.com/xw2/images/pilots/muse.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/muse.png",
-      "slots": ["Modification", "Tech"],
+      "slots": [
+        "Modification",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -173,7 +203,10 @@
       "ability": "While another friendly ship performs an attack, if you are at range 0-1 of the defender, you may suffer 1 [Critical Hit] damage to change 1 of the attacker's results to a [Critical Hit] result.",
       "image": "https://infinitearenas.com/xw2/images/pilots/tn3465.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/tn3465.png",
-      "slots": ["Modification", "Tech"],
+      "slots": [
+        "Modification",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -189,7 +222,10 @@
       "text": "Unhampered by a cumbersome galactic bureaucracy, technologies originally researched by the Empire's TIE Advanced program are now mass-produced on First Order starfighters. As a result, TIE/fo pilots enjoy higher survival rates than their predecessors in the Galactic Empire.",
       "image": "https://infinitearenas.com/xw2/images/pilots/zetasquadronpilot.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/zetasquadronpilot.png",
-      "slots": ["Modification", "Tech"],
+      "slots": [
+        "Modification",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -222,7 +258,11 @@
       "image": "https://infinitearenas.com/xw2/images/pilots/lieutenantrivas.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lieutenantrivas.png",
       "ability": "After a ship at range 1-2 gains a red or orange token, if you do not have that ship locked, you may acquire a lock on that ship.",
-      "slots": ["Talent", "Tech", "Modification"],
+      "slots": [
+        "Talent",
+        "Tech",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -239,7 +279,12 @@
       "ability": "While you are not damaged, treat your initiative value as 7.",
       "image": "https://infinitearenas.com/xw2/images/pilots/null.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/null.png",
-      "slots": ["Talent", "Talent", "Tech", "Tech"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Tech",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -256,7 +301,13 @@
       "ability": "After another friendly ship at range 0-2 is destroyed, you may perform a [Coordinate] action, even while stressed. While you coordinate, the ship you choose can perform an action only if that action is also on your action bar.",
       "image": "https://infinitearenas.com/xw2/images/pilots/lieutenantgalek.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lieutenantgalek.png",
-      "slots": ["Talent", "Tech", "Tech", "Cannon", "Modification"],
+      "slots": [
+        "Talent",
+        "Tech",
+        "Tech",
+        "Cannon",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -273,7 +324,12 @@
       "ability": "While you perform a primary attack, if you are not strained, you may gain 1 strain token to roll 1 additional die.",
       "image": "https://infinitearenas.com/xw2/images/pilots/dt798.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dt798.png",
-      "slots": ["Talent", "Tech", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Tech",
+        "Modification",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -291,7 +347,12 @@
       "conditions": ["primedforspeed"],
       "image": "https://infinitearenas.com/xw2/images/pilots/lingaava.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lingaava.png",
-      "slots": ["Talent", "Talent", "Tech", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Tech",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],

--- a/data/pilots/first-order/tie-se-bomber.json
+++ b/data/pilots/first-order/tie-se-bomber.json
@@ -206,7 +206,14 @@
       "extended": true,
       "cost": 4,
       "loadout": 8,
-      "slots": ["Tech", "Tech", "Missile", "Device", "Device", "Modification"],
+      "slots": [
+        "Tech",
+        "Tech",
+        "Missile",
+        "Device",
+        "Device",
+        "Modification"
+      ],
       "text": "Equipped with four laser cannons and advanced systems, the TIE/se bomber is a remarkably maneuverable craft that brings devastating ordnance to bear against any who dare to stand against the First Order.",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/sienarjaemustestpilot.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/sienarjaemustestpilot.png",

--- a/data/pilots/first-order/tie-sf-fighter.json
+++ b/data/pilots/first-order/tie-sf-fighter.json
@@ -69,7 +69,14 @@
         "name": "Heavy Weapon Turret",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. You must treat the [Front Arc] requirement of your equipped [Missile] upgrades as [Single Turret Arc]."
       },
-      "slots": ["Talent", "Talent", "Sensor", "Modification", "Gunner", "Tech"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Sensor",
+        "Modification",
+        "Gunner",
+        "Tech"
+      ],
       "charges": { "value": 1, "recovers": 1 },
       "image": "https://infinitearenas.com/xw2/images/pilots/quickdraw.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/quickdraw.png",
@@ -118,7 +125,13 @@
         "name": "Heavy Weapon Turret",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. You must treat the [Front Arc] requirement of your equipped [Missile] upgrades as [Single Turret Arc]."
       },
-      "slots": ["Sensor", "Missile", "Modification", "Gunner", "Tech"],
+      "slots": [
+        "Sensor",
+        "Missile",
+        "Modification",
+        "Gunner",
+        "Tech"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/omegasquadronexpert.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/omegasquadronexpert.png",
       "standard": true,
@@ -138,7 +151,12 @@
         "name": "Heavy Weapon Turret",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. You must treat the [Front Arc] requirement of your equipped [Missile] upgrades as [Single Turret Arc]."
       },
-      "slots": ["Sensor", "Talent", "Gunner", "Tech"],
+      "slots": [
+        "Sensor",
+        "Talent",
+        "Gunner",
+        "Tech"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/zetasquadronsurvivor.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/zetasquadronsurvivor.png",
       "standard": true,

--- a/data/pilots/first-order/tie-vn-silencer.json
+++ b/data/pilots/first-order/tie-vn-silencer.json
@@ -80,12 +80,22 @@
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
       "conditions": ["illshowyouthedarkside"],
-      "slots": ["Torpedo", "Missile", "Force Power", "Talent", "Tech", "Configuration"],
+      "slots": [
+        "Torpedo",
+        "Missile",
+        "Force Power",
+        "Talent",
+        "Tech",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/kyloren.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/kyloren.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Dark Side", "TIE"],
+      "keywords": [
+        "Dark Side",
+        "TIE"
+      ],
       "epic": true
     },
     {
@@ -100,7 +110,13 @@
         "name": "Autothrusters",
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
-      "slots": ["Talent", "Torpedo", "Missile", "Tech", "Configuration"],
+      "slots": [
+        "Talent",
+        "Torpedo",
+        "Missile",
+        "Tech",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/firstordertestpilot.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/firstordertestpilot.png",
       "standard": true,
@@ -121,7 +137,13 @@
         "name": "Autothrusters",
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
-      "slots": ["Talent", "Torpedo", "Missile", "Tech", "Configuration"],
+      "slots": [
+        "Talent",
+        "Torpedo",
+        "Missile",
+        "Tech",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/recoil.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/recoil.png",
       "standard": true,
@@ -142,7 +164,13 @@
         "name": "Autothrusters",
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
-      "slots": ["Talent", "Torpedo", "Missile", "Tech", "Configuration"],
+      "slots": [
+        "Talent",
+        "Torpedo",
+        "Missile",
+        "Tech",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/avenger.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/avenger.png",
       "standard": true,
@@ -162,7 +190,13 @@
         "name": "Autothrusters",
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
-      "slots": ["Tech", "Torpedo", "Missile", "Modification", "Configuration"],
+      "slots": [
+        "Tech",
+        "Torpedo",
+        "Missile",
+        "Modification",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/sienarjaemusengineer.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/sienarjaemusengineer.png",
       "standard": true,
@@ -182,7 +216,13 @@
       "caption": "Adrenaline Junkie",
       "standard": true,
       "extended": true,
-      "slots": ["Tech", "Talent", "Talent", "Missile", "Configuration"],
+      "slots": [
+        "Tech",
+        "Talent",
+        "Talent",
+        "Missile",
+        "Configuration"
+      ],
       "ability": "While you are damaged, treat your initiative as 6.",
       "cost": 5,
       "loadout": 11,

--- a/data/pilots/first-order/tie-wi-whisper-modified-interceptor.json
+++ b/data/pilots/first-order/tie-wi-whisper-modified-interceptor.json
@@ -78,8 +78,15 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/kyloren-tiewiwhispermodifiedinterceptor.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/kyloren-tiewiwhispermodifiedinterceptor.png",
       "caption": "Supreme Leader of the First Order",
-      "keywords": ["Dark Side", "Light Side", "TIE"],
-      "force": { "value": 3, "recovers": 1, "side": ["dark", "light"] },
+      "keywords": [
+        "Dark Side",
+        "Light Side",
+        "TIE"
+      ],
+      "force": { "value": 3, "recovers": 1, "side": [
+          "dark",
+          "light"
+        ] },
       "epic": true
     },
     {
@@ -95,7 +102,14 @@
       "extended": true,
       "cost": 5,
       "loadout": 15,
-      "slots": ["Talent", "Talent", "Cannon", "Tech", "Tech", "Configuration"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Cannon",
+        "Tech",
+        "Tech",
+        "Configuration"
+      ],
       "ability": "After you perform a [Bullseye Arc] attack, if you have 1 or more non-lock red or orange tokens, you may perform a bonus attack against a different target.",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/wrath.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/wrath.png",
@@ -116,7 +130,13 @@
       "extended": true,
       "cost": 4,
       "loadout": 10,
-      "slots": ["Talent", "Missile", "Tech", "Tech", "Configuration"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Tech",
+        "Tech",
+        "Configuration"
+      ],
       "ability": "After you fully execute a maneuver or perform a [Boost] action, each ship you moved through gains 2 jam tokens.",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/nightfall.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/nightfall.png",
@@ -137,7 +157,14 @@
       "extended": true,
       "cost": 4,
       "loadout": 12,
-      "slots": ["Talent", "Talent", "Missile", "Tech", "Tech", "Configuration"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Missile",
+        "Tech",
+        "Tech",
+        "Configuration"
+      ],
       "ability": "Before you engage, you may remove any number of jam tokens, then you may gain 1 focus token for each enemy ship that has you in its [Front Arc].",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/whirlwind.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/whirlwind.png",
@@ -159,7 +186,13 @@
       "extended": true,
       "cost": 4,
       "loadout": 10,
-      "slots": ["Talent", "Missile", "Tech", "Tech", "Configuration"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Tech",
+        "Tech",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/709thlegionace.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/709thlegionace.png",
       "keywords": ["TIE"],
@@ -179,7 +212,12 @@
       "extended": true,
       "cost": 4,
       "loadout": 3,
-      "slots": ["Talent", "Tech", "Tech", "Configuration"],
+      "slots": [
+        "Talent",
+        "Tech",
+        "Tech",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/redfuryzealot.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/redfuryzealot.png",
       "keywords": ["TIE"],

--- a/data/pilots/first-order/xi-class-light-shuttle.json
+++ b/data/pilots/first-order/xi-class-light-shuttle.json
@@ -89,7 +89,12 @@
       "initiative": 2,
       "cost": 4,
       "loadout": 10,
-      "slots": ["Crew", "Modification", "Tech", "Tech"],
+      "slots": [
+        "Crew",
+        "Modification",
+        "Tech",
+        "Tech"
+      ],
       "limited": 0,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/firstordercourier.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/firstordercourier.png",

--- a/data/pilots/galactic-empire/alpha-class-star-wing.json
+++ b/data/pilots/galactic-empire/alpha-class-star-wing.json
@@ -43,7 +43,13 @@
       "loadout": 14,
       "xws": "lieutenantkarsabi",
       "ability": "After you gain a disarm token, if you are not stressed, you may gain 1 stress token to remove 1 disarm token.",
-      "slots": ["Talent", "Sensor", "Missile", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Missile",
+        "Modification",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/lieutenantkarsabi.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lieutenantkarsabi.png",
       "standard": false,
@@ -59,7 +65,13 @@
       "loadout": 16,
       "xws": "majorvynder",
       "ability": "While you defend, if you are disarmed, roll 1 additional defense die.",
-      "slots": ["Talent", "Sensor", "Torpedo", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Torpedo",
+        "Modification",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/majorvynder.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/majorvynder.png",
       "standard": false,
@@ -75,7 +87,12 @@
       "xws": "nusquadronpilot",
       "text": "With a design inspired by other Cygnus Spaceworks vessels, the Alpha-class star wing is a versatile craft assigned to Imperial Navy specialist units that need a starfighter they can outfit for multiple roles.",
       "image": "https://infinitearenas.com/xw2/images/pilots/nusquadronpilot.png",
-      "slots": ["Sensor", "Cannon", "Modification", "Configuration"],
+      "slots": [
+        "Sensor",
+        "Cannon",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/nusquadronpilot.png",
       "standard": false,
       "extended": true,
@@ -89,7 +106,12 @@
       "loadout": 9,
       "xws": "rhosquadronpilot",
       "text": "The elite pilots of Rho Squadron instill terror in the Rebellion, using both the Xg-1 assault configuration and Os-1 arsenal loadout of the Alpha-class star wing to devastating effect.",
-      "slots": ["Talent", "Sensor", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Modification",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/rhosquadronpilot.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/rhosquadronpilot.png",
       "standard": false,

--- a/data/pilots/galactic-empire/lambda-class-t-4a-shuttle.json
+++ b/data/pilots/galactic-empire/lambda-class-t-4a-shuttle.json
@@ -43,7 +43,14 @@
       "xws": "captainkagi",
       "ability": "At the start of the Engagement Phase, you may choose 1 or more friendly ships at range 0-3. If you do, transfer all enemy lock tokens from the chosen ships to you.",
       "image": "https://infinitearenas.com/xw2/images/pilots/captainkagi.png",
-      "slots": ["Sensor", "Cannon", "Crew", "Crew", "Modification", "Title"],
+      "slots": [
+        "Sensor",
+        "Cannon",
+        "Crew",
+        "Crew",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/captainkagi.png",
       "standard": false,
       "extended": true,
@@ -60,7 +67,14 @@
       "ability": "At the start of the Activation Phase, you may spend 1 [Charge]. If you do, while friendly ships acquire locks this round, they must acquire locks beyond range 3 instead of at range 0-3.",
       "image": "https://infinitearenas.com/xw2/images/pilots/coloneljendon.png",
       "charges": { "value": 2, "recovers": 0 },
-      "slots": ["Sensor", "Cannon", "Cannon", "Crew", "Modification", "Title"],
+      "slots": [
+        "Sensor",
+        "Cannon",
+        "Cannon",
+        "Crew",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/coloneljendon.png",
       "standard": false,
       "extended": true,
@@ -76,7 +90,14 @@
       "xws": "lieutenantsai",
       "ability": "After you a perform a [Coordinate] action, if the ship you chose performed an action on your action bar, you may perform that action.",
       "image": "https://infinitearenas.com/xw2/images/pilots/lieutenantsai.png",
-      "slots": ["Sensor", "Cannon", "Crew", "Crew", "Modification", "Title"],
+      "slots": [
+        "Sensor",
+        "Cannon",
+        "Crew",
+        "Crew",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lieutenantsai.png",
       "standard": false,
       "extended": true,
@@ -91,7 +112,11 @@
       "xws": "omicrongrouppilot",
       "text": "Noted for its tri-wing design and advanced sensor suite, the Lambda-class shuttle serves a critical role as a light utility craft in the Imperial Navy.",
       "image": "https://infinitearenas.com/xw2/images/pilots/omicrongrouppilot.png",
-      "slots": ["Sensor", "Cannon", "Modification"],
+      "slots": [
+        "Sensor",
+        "Cannon",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/omicrongrouppilot.png",
       "standard": false,
       "extended": true,

--- a/data/pilots/galactic-empire/tie-advanced-v1.json
+++ b/data/pilots/galactic-empire/tie-advanced-v1.json
@@ -57,7 +57,11 @@
       "xws": "baronoftheempire",
       "text": "Sienar Fleet System's TIE Advanced v1 is a groundbreaking starfighter design, featuring upgraded engines, a missile launcher, and folding s-foils.",
       "image": "https://infinitearenas.com/xw2/images/pilots/baronoftheempire.png",
-      "slots": ["Talent", "Sensor", "Missile"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Missile"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/baronoftheempire.png",
       "standard": true,
       "extended": true,
@@ -75,11 +79,20 @@
       "ability": "While you defend at attack range 1, you may spend 1 [Force] to prevent the range 1 bonus. While you perform an attack against a defender at attack range 2-3, you may spend 1 [Force] to apply the range 1 bonus.",
       "image": "https://infinitearenas.com/xw2/images/pilots/grandinquisitor.png",
       "force": { "value": 2, "recovers": 1, "side": ["dark"] },
-      "slots": ["Sensor", "Missile", "Force Power", "Force Power", "Talent"],
+      "slots": [
+        "Sensor",
+        "Missile",
+        "Force Power",
+        "Force Power",
+        "Talent"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/grandinquisitor.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Dark Side", "TIE"],
+      "keywords": [
+        "Dark Side",
+        "TIE"
+      ],
       "epic": true
     },
     {
@@ -92,11 +105,17 @@
       "text": "The fearsome Inquisitors are given a great deal of autonomy and access to the Empire's latest technology, like the prototype TIE Advanced v1.",
       "image": "https://infinitearenas.com/xw2/images/pilots/inquisitor.png",
       "force": { "value": 1, "recovers": 1, "side": ["dark"] },
-      "slots": ["Sensor", "Force Power"],
+      "slots": [
+        "Sensor",
+        "Force Power"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/inquisitor.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Dark Side", "TIE"],
+      "keywords": [
+        "Dark Side",
+        "TIE"
+      ],
       "epic": true
     },
     {
@@ -110,11 +129,19 @@
       "ability": "While you perform a primary attack, before the Neutralize Results step, you may spend 2 [Force] to cancel 1 [Evade] result.",
       "image": "https://infinitearenas.com/xw2/images/pilots/seventhsister.png",
       "force": { "value": 2, "recovers": 1, "side": ["dark"] },
-      "slots": ["Sensor", "Missile", "Force Power", "Talent"],
+      "slots": [
+        "Sensor",
+        "Missile",
+        "Force Power",
+        "Talent"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/seventhsister.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Dark Side", "TIE"],
+      "keywords": [
+        "Dark Side",
+        "TIE"
+      ],
       "epic": true
     },
     {
@@ -126,13 +153,21 @@
       "standard": true,
       "extended": true,
       "force": { "value": 2, "recovers": 1, "side": ["dark"] },
-      "slots": ["Force Power", "Sensor", "Talent", "Missile"],
+      "slots": [
+        "Force Power",
+        "Sensor",
+        "Talent",
+        "Missile"
+      ],
       "ability": "While you perform an attack, after the Neutralize Results step, if the attack hit, you may spend 2 [Force] to add 1 [Critical Hit] result.",
       "cost": 4,
       "loadout": 7,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/fifthbrother.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/fifthbrother.png",
-      "keywords": ["Dark Side", "TIE"],
+      "keywords": [
+        "Dark Side",
+        "TIE"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/galactic-empire/tie-advanced-x1.json
+++ b/data/pilots/galactic-empire/tie-advanced-x1.json
@@ -69,7 +69,11 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/darthvader.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Dark Side", "Sith", "TIE"],
+      "keywords": [
+        "Dark Side",
+        "Sith",
+        "TIE"
+      ],
       "epic": true
     },
     {
@@ -86,7 +90,13 @@
         "name": "Advanced Targeting Computer",
         "text": "While you perform a primary attack against a defender you have locked, roll 1 additional attack die and change 1 [Hit] result to a [Critical Hit] result."
       },
-      "slots": ["Talent", "Talent", "Sensor", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Sensor",
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/maarekstele.png",
       "standard": true,
       "extended": true,
@@ -106,7 +116,11 @@
         "name": "Advanced Targeting Computer",
         "text": "While you perform a primary attack against a defender you have locked, roll 1 additional attack die and change 1 [Hit] result to a [Critical Hit] result."
       },
-      "slots": ["Sensor", "Talent", "Modification"],
+      "slots": [
+        "Sensor",
+        "Talent",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/stormsquadronace.png",
       "standard": true,
       "extended": true,
@@ -125,7 +139,10 @@
         "name": "Advanced Targeting Computer",
         "text": "While you perform a primary attack against a defender you have locked, roll 1 additional attack die and change 1 [Hit] result to a [Critical Hit] result."
       },
-      "slots": ["Sensor", "Modification"],
+      "slots": [
+        "Sensor",
+        "Modification"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/tempestsquadronpilot.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/tempestsquadronpilot.png",
       "standard": true,
@@ -147,7 +164,12 @@
         "name": "Advanced Targeting Computer",
         "text": "While you perform a primary attack against a defender you have locked, roll 1 additional attack die and change 1 [Hit] result to a [Critical Hit] result."
       },
-      "slots": ["Talent", "Sensor", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/vedfoslo.png",
       "standard": false,
       "extended": true,
@@ -168,7 +190,11 @@
         "name": "Advanced Targeting Computer",
         "text": "While you perform a primary attack against a defender you have locked, roll 1 additional attack die and change 1 [Hit] result to a [Critical Hit] result."
       },
-      "slots": ["Sensor", "Missile", "Modification"],
+      "slots": [
+        "Sensor",
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/zertikstrom.png",
       "standard": true,
       "extended": true,
@@ -195,11 +221,19 @@
         { "type": "hull", "value": 3 },
         { "type": "shields", "value": 3 }
       ],
-      "standardLoadout": ["marksmanship", "hate", "afterburners"],
+      "standardLoadout": [
+        "marksmanship",
+        "hate",
+        "afterburners"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/darthvader.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Dark Side", "Sith", "TIE"],
+      "keywords": [
+        "Dark Side",
+        "Sith",
+        "TIE"
+      ],
       "epic": true
     },
     {
@@ -217,7 +251,13 @@
         "name": "Advanced Targeting Computer",
         "text": "While you perform a primary attack against a defender you have locked, roll 1 additional attack die and change 1 [Hit] result to a [Critical Hit] result."
       },
-      "slots": ["Talent", "Tech", "Sensor", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Tech",
+        "Sensor",
+        "Missile",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -243,11 +283,19 @@
         { "type": "hull", "value": 3 },
         { "type": "shields", "value": 3 }
       ],
-      "standardLoadout": ["hate", "ionmissiles", "afterburners"],
+      "standardLoadout": [
+        "hate",
+        "ionmissiles",
+        "afterburners"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/darthvader.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Dark Side", "Sith", "TIE"],
+      "keywords": [
+        "Dark Side",
+        "Sith",
+        "TIE"
+      ],
       "epic": true
     },
     {
@@ -256,7 +304,11 @@
       "initiative": 5,
       "limited": 1,
       "cost": 5,
-      "standardLoadout": ["elusive", "outmaneuver", "afterburners"],
+      "standardLoadout": [
+        "elusive",
+        "outmaneuver",
+        "afterburners"
+      ],
       "xws": "maarekstele-swz105",
       "ability": "While you perform an attack, if the defender would be dealt a faceup damage card, instead draw 3 damage cards, choose 1, and discard the rest.",
       "image": "",

--- a/data/pilots/galactic-empire/tie-ag-aggressor.json
+++ b/data/pilots/galactic-empire/tie-ag-aggressor.json
@@ -96,7 +96,12 @@
       "xws": "onyxsquadronscout",
       "text": "Designed for extended engagements, the TIE/ag is flown primarily by elite pilots trained to leverage both its unique weapons loadout and its maneuverability to full effect.",
       "image": "https://infinitearenas.com/xw2/images/pilots/onyxsquadronscout.png",
-      "slots": ["Talent", "Turret", "Missile", "Gunner"],
+      "slots": [
+        "Talent",
+        "Turret",
+        "Missile",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/onyxsquadronscout.png",
       "standard": false,
       "extended": true,
@@ -112,7 +117,12 @@
       "xws": "sienarspecialist",
       "text": "During the development of the TIE aggressor, Sienar Fleet Systems valued performance and versatility over raw cost efficiency.",
       "image": "https://infinitearenas.com/xw2/images/pilots/sienarspecialist.png",
-      "slots": ["Turret", "Missile", "Modification", "Gunner"],
+      "slots": [
+        "Turret",
+        "Missile",
+        "Modification",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/sienarspecialist.png",
       "standard": false,
       "extended": true,

--- a/data/pilots/galactic-empire/tie-d-defender.json
+++ b/data/pilots/galactic-empire/tie-d-defender.json
@@ -53,7 +53,13 @@
         "name": "Full Throttle",
         "text": "After you fully execute a speed 3-5 maneuver, you may perform an [Evade] action."
       },
-      "slots": ["Talent", "Sensor", "Cannon", "Missile", "Configuration"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Cannon",
+        "Missile",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/colonelvessery.png",
       "standard": true,
       "extended": true,
@@ -101,7 +107,11 @@
         "name": "Full Throttle",
         "text": "After you fully execute a speed 3-5 maneuver, you may perform an [Evade] action."
       },
-      "slots": ["Sensor", "Cannon", "Configuration"],
+      "slots": [
+        "Sensor",
+        "Cannon",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/deltasquadronpilot.png",
       "standard": true,
       "extended": true,
@@ -121,7 +131,13 @@
         "name": "Full Throttle",
         "text": "After you fully execute a speed 3-5 maneuver, you may perform an [Evade] action."
       },
-      "slots": ["Talent", "Sensor", "Cannon", "Missile", "Configuration"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Cannon",
+        "Missile",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/onyxsquadronace.png",
       "standard": true,
       "extended": true,
@@ -200,9 +216,19 @@
       "force": { "value": 3, "recovers": 1 },
       "cost": 9,
       "loadout": 10,
-      "slots": ["Force Power", "Tech", "Cannon", "Missile", "Configuration"],
+      "slots": [
+        "Force Power",
+        "Tech",
+        "Cannon",
+        "Missile",
+        "Configuration"
+      ],
       "ability": "You cannot spend [Force] except while attacking. While you perform an attack, you may spend 1 [Force] to change 1 blank result to a [Hit] result.",
-      "keywords": ["Dark Side", "Sith", "TIE"],
+      "keywords": [
+        "Dark Side",
+        "Sith",
+        "TIE"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/darthvader-tieddefender.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/darthvader-tieddefender.png",
       "epic": true
@@ -221,7 +247,13 @@
       "extended": true,
       "cost": 7,
       "loadout": 15,
-      "slots": ["Talent", "Sensor", "Cannon", "Missile", "Configuration"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Cannon",
+        "Missile",
+        "Configuration"
+      ],
       "ability": "While another friendly ship at range 0-1 defends, before the Neutralize Results step, if you are in the attack arc and are not ionized, you may gain 1 ion token to cancel 1 [Hit] result.",
       "keywords": ["TIE"],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/captaindobbs.png",

--- a/data/pilots/galactic-empire/tie-in-interceptor.json
+++ b/data/pilots/galactic-empire/tie-in-interceptor.json
@@ -49,7 +49,10 @@
         "name": "Autothrusters",
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
-      "slots": ["Talent", "Configuration"],
+      "slots": [
+        "Talent",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/alphasquadronpilot.png",
       "standard": true,
       "extended": true,
@@ -69,7 +72,10 @@
         "name": "Autothrusters",
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
-      "slots": ["Talent", "Configuration"],
+      "slots": [
+        "Talent",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/sabersquadronace.png",
       "standard": true,
       "extended": true,
@@ -90,7 +96,12 @@
         "name": "Autothrusters",
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
-      "slots": ["Talent", "Talent", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/soontirfel.png",
       "standard": true,
       "extended": true,
@@ -111,7 +122,12 @@
         "name": "Autothrusters",
         "text": "After you perform an action, you may perform a red [Barrel Roll] or red [Boost] action."
       },
-      "slots": ["Talent", "Talent", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/turrphennir.png",
       "standard": true,
       "extended": true,
@@ -132,7 +148,12 @@
       "keywords": ["TIE"],
       "cost": 5,
       "loadout": 14,
-      "slots": ["Talent", "Talent", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Modification",
+        "Configuration"
+      ],
       "ability": "After you perform an attack, if the defender was destroyed, gain 1 stress token. After a friendly ship at range 0-3 is destroyed, remove 1 stress token.",
       "caption": "Look Through My Eyes",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/cienaree.png",
@@ -153,7 +174,13 @@
       "keywords": ["TIE"],
       "cost": 4,
       "loadout": 7,
-      "slots": ["Talent", "Talent", "Missile", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Missile",
+        "Modification",
+        "Configuration"
+      ],
       "ability": "While you perform an attack against a damaged defender, roll 1 additional attack die.",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/cienaree.png",
       "epic": true
@@ -172,7 +199,11 @@
       "extended": true,
       "cost": 4,
       "loadout": 9,
-      "slots": ["Talent", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Modification",
+        "Configuration"
+      ],
       "ability": "Action: Gain 1 strain token to recover 1 [Charge]. Before you engage, you may spend 1 [Charge] to perform an action.",
       "charges": { "value": 1, "recovers": -1 },
       "keywords": ["TIE"],
@@ -194,7 +225,11 @@
       "extended": true,
       "cost": 4,
       "loadout": 8,
-      "slots": ["Talent", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Modification",
+        "Configuration"
+      ],
       "ability": "After a friendly ship at range 0-3 with a lower initiative than yours partially executes a maneuver, it may perform a red [Focus] action.",
       "keywords": ["TIE"],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/commandantgoran.png",
@@ -215,7 +250,11 @@
       "extended": true,
       "cost": 3,
       "loadout": 6,
-      "slots": ["Talent", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Modification",
+        "Configuration"
+      ],
       "ability": "While you barrel roll, you must use the [[Bank Left] or [Bank Right]] template instead of the [[Straight]] template.",
       "keywords": ["TIE"],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lieutenantlorrir.png",
@@ -237,7 +276,11 @@
       "cost": 4,
       "loadout": 6,
       "charges": { "value": 1, "recovers": 1 },
-      "slots": ["Missile", "Modification", "Configuration"],
+      "slots": [
+        "Missile",
+        "Modification",
+        "Configuration"
+      ],
       "ability": "During the Engagement Phase, after a friendly small ship at range 0-3 is destroyed, if that ship has not engaged this phase, you may spend 1 [Charge]. If you do, that ship engages at the current initiative.",
       "keywords": ["TIE"],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/nashwindrider.png",
@@ -264,7 +307,10 @@
         { "type": "hull", "value": 3 },
         { "type": "shields", "value": 1 }
       ],
-      "standardLoadout": ["predator", "fanatic-battleofyavin"],
+      "standardLoadout": [
+        "predator",
+        "fanatic-battleofyavin"
+      ],
       "ability": "Before a friendly TIE at range 0-1 would suffer damage, you may spend 2 [Charge]. If you do, prevent 1 damage.",
       "keywords": ["TIE"],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/idenversio-battleofyavin.png",
@@ -290,7 +336,10 @@
         { "type": "agility", "value": 3 },
         { "type": "hull", "value": 4 }
       ],
-      "standardLoadout": ["disciplined", "primedthrusters"],
+      "standardLoadout": [
+        "disciplined",
+        "primedthrusters"
+      ],
       "ability": "After you perform a [Barrel Roll] action, you may spend 1 [Charge] to perform a [Boost] action.",
       "keywords": ["TIE"],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/sigma4-battleofyavin.png",
@@ -316,7 +365,10 @@
         { "type": "agility", "value": 3 },
         { "type": "hull", "value": 4 }
       ],
-      "standardLoadout": ["sensorjammer-battleofyavin", "elusive"],
+      "standardLoadout": [
+        "sensorjammer-battleofyavin",
+        "elusive"
+      ],
       "ability": "After you perform an attack that hits, you may spend 1 [Charge] to perform an [Evade] action.",
       "keywords": ["TIE"],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/sigma5-battleofyavin.png",
@@ -342,7 +394,10 @@
         { "type": "agility", "value": 3 },
         { "type": "hull", "value": 4 }
       ],
-      "standardLoadout": ["daredevil", "afterburners"],
+      "standardLoadout": [
+        "daredevil",
+        "afterburners"
+      ],
       "ability": "After you fully execute a speed 3-5 maneuver, you may spend 1 [Charge] to perform a [SLAM] action.",
       "keywords": ["TIE"],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/sigma6-battleofyavin.png",
@@ -375,7 +430,10 @@
         { "difficulty": "White", "type": "Boost" },
         { "difficulty": "White", "type": "Lock" }
       ],
-      "standardLoadout": ["marksmanship", "firecontrolsystem"],
+      "standardLoadout": [
+        "marksmanship",
+        "firecontrolsystem"
+      ],
       "ability": "During the System Phase, you may spend 1 [Charge] to acquire a lock on an enemy ship at range 0-1.",
       "keywords": ["TIE"],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/sigma7-battleofyavin.png",
@@ -405,7 +463,10 @@
       ],
       "ability": "While you perform an attack, after the Neutralize Results step, if the attack hit, you may spend 2 [Force]. If you do, change all of your [Hit] results to [Critical Hit] results.",
       "force": { "value": 2, "recovers": 1 },
-      "keywords": ["Dark Side", "TIE"],
+      "keywords": [
+        "Dark Side",
+        "TIE"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/secondsister.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/secondsister.png",
       "epic": true

--- a/data/pilots/galactic-empire/tie-ln-fighter.json
+++ b/data/pilots/galactic-empire/tie-ln-fighter.json
@@ -65,7 +65,10 @@
       "xws": "maulermithel",
       "ability": "While you perform an attack at attack range 1, roll 1 additional attack die.",
       "image": "https://infinitearenas.com/xw2/images/pilots/maulermithel.png",
-      "slots": ["Talent", "Cannon"],
+      "slots": [
+        "Talent",
+        "Cannon"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/maulermithel.png",
       "standard": true,
       "extended": true,
@@ -82,7 +85,10 @@
       "xws": "nightbeast",
       "ability": "After you fully execute a blue maneuver, you may perform a [Focus] action.",
       "image": "https://infinitearenas.com/xw2/images/pilots/nightbeast.png",
-      "slots": ["Talent", "Talent"],
+      "slots": [
+        "Talent",
+        "Talent"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/nightbeast.png",
       "standard": true,
       "extended": true,
@@ -117,7 +123,10 @@
       "ability": "While you perform an attack, you may spend 1 [Charge] to roll 1 additional attack die. After defending, lose 1 [Charge].",
       "image": "https://infinitearenas.com/xw2/images/pilots/wampa.png",
       "charges": { "value": 1, "recovers": 1 },
-      "slots": ["Talent", "Modification"],
+      "slots": [
+        "Talent",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/wampa.png",
       "standard": true,
       "extended": true,
@@ -166,7 +175,11 @@
       "xws": "delmeeko",
       "ability": "While a friendly ship at range 0-2 defends against a damaged attacker, the defender may reroll 1 defense die.",
       "image": "https://infinitearenas.com/xw2/images/pilots/delmeeko.png",
-      "slots": ["Cannon", "Talent", "Modification"],
+      "slots": [
+        "Cannon",
+        "Talent",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/delmeeko.png",
       "standard": true,
       "extended": true,
@@ -183,7 +196,12 @@
       "xws": "gideonhask",
       "ability": "While you perform an attack against a damaged defender, roll 1 additional attack die.",
       "image": "https://infinitearenas.com/xw2/images/pilots/gideonhask.png",
-      "slots": ["Talent", "Talent", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/gideonhask.png",
       "standard": true,
       "extended": true,
@@ -240,7 +258,11 @@
       "xws": "seynmarana",
       "ability": "While you perform an attack, you may spend 1 [Critical Hit] result. If you do, deal 1 facedown damage card to the defender, then cancel your remaining results.",
       "image": "https://infinitearenas.com/xw2/images/pilots/seynmarana.png",
-      "slots": ["Talent", "Cannon", "Modification"],
+      "slots": [
+        "Talent",
+        "Cannon",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/seynmarana.png",
       "standard": true,
       "extended": true,
@@ -257,7 +279,10 @@
       "xws": "valenrudor",
       "ability": "After a friendly ship at range 0-1 defends (after damage is resolved, if any), you may perform an action.",
       "image": "https://infinitearenas.com/xw2/images/pilots/valenrudor.png",
-      "slots": ["Talent", "Talent"],
+      "slots": [
+        "Talent",
+        "Talent"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/valenrudor.png",
       "standard": true,
       "extended": true,
@@ -274,7 +299,10 @@
       "xws": "isbjingoist",
       "ability": "Before you engage, you may choose 1 enemy ship in your [Front Arc] at range 0-1. If you do, that ship gains 1 deplete or strain token of your choice unless it chooses to remove 1 green token.",
       "image": "https://infinitearenas.com/xw2/images/pilots/isbjingoist.png",
-      "slots": ["Talent", "Illicit"],
+      "slots": [
+        "Talent",
+        "Illicit"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/isbjingoist.png",
       "standard": true,
       "extended": true,
@@ -292,7 +320,13 @@
       "charges": { "value": 2, "recovers": 1 },
       "ability": "While an enemy ship at range 1-3 defends, before attack dice are rolled, you may spend 1 [Charge] and choose a friendly ship at range 0-1 of the defender. If you do, defense dice cannot be modified during this attack and the chosen friendly ship gains 1 strain token.",
       "image": "https://infinitearenas.com/xw2/images/pilots/moffgideon.png",
-      "slots": ["Talent", "Illicit", "Illicit", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Illicit",
+        "Illicit",
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/moffgideon.png",
       "standard": true,
       "extended": true,
@@ -314,7 +348,11 @@
         { "type": "agility", "value": 3 },
         { "type": "hull", "value": 4 }
       ],
-      "standardLoadout": ["crackshot", "disciplined", "afterburners"],
+      "standardLoadout": [
+        "crackshot",
+        "disciplined",
+        "afterburners"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -335,7 +373,10 @@
         { "type": "agility", "value": 3 },
         { "type": "hull", "value": 4 }
       ],
-      "standardLoadout": ["ruthless", "precisionionengines"],
+      "standardLoadout": [
+        "ruthless",
+        "precisionionengines"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -356,7 +397,10 @@
         { "type": "agility", "value": 3 },
         { "type": "hull", "value": 4 }
       ],
-      "standardLoadout": ["predator", "afterburners"],
+      "standardLoadout": [
+        "predator",
+        "afterburners"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -378,7 +422,10 @@
         { "type": "agility", "value": 3 },
         { "type": "hull", "value": 4 }
       ],
-      "standardLoadout": ["elusive", "vengeful-battleofyavin"],
+      "standardLoadout": [
+        "elusive",
+        "vengeful-battleofyavin"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -416,7 +463,11 @@
       "ability": "After you fully execute a maneuver, you may acquire a lock on an enemy ship in your [Bullseye Arc].",
       "image": "https://infinitearenas.com/xw2/images/pilots/yricaquell.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/yricaquell.png",
-      "slots": ["Talent", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -428,7 +479,10 @@
       "initiative": 4,
       "limited": 1,
       "cost": 4,
-      "standardLoadout": ["disciplined", "elusive"],
+      "standardLoadout": [
+        "disciplined",
+        "elusive"
+      ],
       "xws": "idenversio-swz105",
       "ability": "Before a friendly TIE/ln fighter at range 0-1 would suffer 1 or more damage, you may spend 1 [Charge]. If you do, prevent that damage.",
       "image": "",
@@ -448,7 +502,10 @@
       "xws": "nightbeast-swz105",
       "ability": "After you fully execute a blue maneuver, you may perform a [Focus] action.",
       "image": "",
-      "standardLoadout": ["disciplined", "predator"],
+      "standardLoadout": [
+        "disciplined",
+        "predator"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/nightbeast.png",
       "standard": true,
       "extended": true,
@@ -464,7 +521,10 @@
       "xws": "valenrudor-swz105",
       "ability": "After a friendly ship at range 0-1 defends (after damage is resolved, if any), you may perform an action.",
       "image": "",
-      "standardLoadout": ["disciplined", "precisionionengines"],
+      "standardLoadout": [
+        "disciplined",
+        "precisionionengines"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/valenrudor.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/galactic-empire/tie-ph-phantom.json
+++ b/data/pilots/galactic-empire/tie-ph-phantom.json
@@ -51,7 +51,13 @@
         "name": "Stygium Array",
         "text": "After you decloak, you may perform an [Evade] action. At the start of the End Phase, you may spend 1 evade token to gain 1 cloak token."
       },
-      "slots": ["Talent", "Talent", "Sensor", "Modification", "Gunner"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Sensor",
+        "Modification",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/echo.png",
       "standard": false,
       "extended": true,
@@ -72,7 +78,13 @@
         "name": "Stygium Array",
         "text": "After you decloak, you may perform an [Evade] action. At the start of the End Phase, you may spend 1 evade token to gain 1 cloak token."
       },
-      "slots": ["Talent", "Sensor", "Modification", "Modification", "Gunner"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Modification",
+        "Modification",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/whisper.png",
       "standard": false,
       "extended": true,
@@ -92,7 +104,11 @@
         "name": "Stygium Array",
         "text": "After you decloak, you may perform an [Evade] action. At the start of the End Phase, you may spend 1 evade token to gain 1 cloak token."
       },
-      "slots": ["Sensor", "Modification", "Gunner"],
+      "slots": [
+        "Sensor",
+        "Modification",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/imdaartestpilot.png",
       "standard": false,
       "extended": true,
@@ -112,7 +128,12 @@
         "name": "Stygium Array",
         "text": "After you decloak, you may perform an [Evade] action. At the start of the End Phase, you may spend 1 evade token to gain 1 cloak token."
       },
-      "slots": ["Talent", "Sensor", "Modification", "Gunner"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Modification",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/sigmasquadronace.png",
       "standard": false,
       "extended": true,

--- a/data/pilots/galactic-empire/tie-rb-heavy.json
+++ b/data/pilots/galactic-empire/tie-rb-heavy.json
@@ -46,7 +46,11 @@
       "cost": 5,
       "loadout": 8,
       "initiative": 1,
-      "slots": ["Cannon", "Cannon", "Configuration"],
+      "slots": [
+        "Cannon",
+        "Cannon",
+        "Configuration"
+      ],
       "xws": "caridaacademycadet",
       "shipAbility": {
         "name": "Rotating Cannons",
@@ -66,7 +70,12 @@
       "cost": 5,
       "loadout": 7,
       "initiative": 3,
-      "slots": ["Cannon", "Cannon", "Modification", "Configuration"],
+      "slots": [
+        "Cannon",
+        "Cannon",
+        "Modification",
+        "Configuration"
+      ],
       "xws": "onyxsquadronsentry",
       "shipAbility": {
         "name": "Rotating Cannons",

--- a/data/pilots/galactic-empire/tie-reaper.json
+++ b/data/pilots/galactic-empire/tie-reaper.json
@@ -50,7 +50,11 @@
         "name": "Controlled Ailerons",
         "text": "Before you reveal your dial, if you are not stressed, you may boost."
       },
-      "slots": ["Crew", "Crew", "Modification"],
+      "slots": [
+        "Crew",
+        "Crew",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/vizier.png",
       "standard": true,
       "extended": true,
@@ -71,7 +75,12 @@
         "name": "Controlled Ailerons",
         "text": "Before you reveal your dial, if you are not stressed, you may boost."
       },
-      "slots": ["Talent", "Crew", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Crew",
+        "Modification",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/captainferoph.png",
       "standard": true,
       "extended": true,
@@ -92,7 +101,12 @@
         "name": "Controlled Ailerons",
         "text": "Before you reveal your dial, if you are not stressed, you may boost."
       },
-      "slots": ["Talent", "Crew", "Crew", "Modification"],
+      "slots": [
+        "Talent",
+        "Crew",
+        "Crew",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/majorvermeil.png",
       "standard": true,
       "extended": true,
@@ -112,7 +126,10 @@
         "name": "Controlled Ailerons",
         "text": "Before you reveal your dial, if you are not stressed, you may boost."
       },
-      "slots": ["Crew", "Modification"],
+      "slots": [
+        "Crew",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/scarifbasepilot.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/galactic-empire/tie-sa-bomber.json
+++ b/data/pilots/galactic-empire/tie-sa-bomber.json
@@ -109,7 +109,13 @@
         "name": "Nimble Bomber",
         "text": "If you would drop a device using a [Straight] template, you may use a [Bank Left] or [Bank Right] template of the same speed instead."
       },
-      "slots": ["Torpedo", "Device", "Device", "Modification", "Gunner"],
+      "slots": [
+        "Torpedo",
+        "Device",
+        "Device",
+        "Modification",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/gammasquadronace.png",
       "standard": true,
       "extended": true,
@@ -157,7 +163,13 @@
         "name": "Nimble Bomber",
         "text": "If you would drop a device using a [Straight] template, you may use a [Bank Left] or [Bank Right] template of the same speed instead."
       },
-      "slots": ["Missile", "Device", "Device", "Modification", "Gunner"],
+      "slots": [
+        "Missile",
+        "Device",
+        "Device",
+        "Modification",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/scimitarsquadronpilot.png",
       "standard": true,
       "extended": true,
@@ -207,7 +219,11 @@
         "name": "Nimble Bomber",
         "text": "If you would drop a device using a [Straight] template, you may use a [Bank Left] or [Bank Right] template of the same speed instead."
       },
-      "standardLoadout": ["feedbackping", "plasmatorpedoes", "protonbombs"],
+      "standardLoadout": [
+        "feedbackping",
+        "plasmatorpedoes",
+        "protonbombs"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/captainjonus.png",
       "standard": true,
       "extended": true,
@@ -227,7 +243,11 @@
         "name": "Nimble Bomber",
         "text": "If you would drop a device using a [Straight] template, you may use a [Bank Left] or [Bank Right] template of the same speed instead."
       },
-      "standardLoadout": ["elusive", "barragerockets", "proximitymines"],
+      "standardLoadout": [
+        "elusive",
+        "barragerockets",
+        "proximitymines"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/tomaxbren.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/galactic-empire/tie-sk-striker.json
+++ b/data/pilots/galactic-empire/tie-sk-striker.json
@@ -48,7 +48,13 @@
         "name": "Adaptive Ailerons",
         "text": "Before you reveal your dial, if you are not stressed, you must boost."
       },
-      "slots": ["Talent", "Talent", "Device", "Modification", "Gunner"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Device",
+        "Modification",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/countdown.png",
       "standard": true,
       "extended": true,
@@ -69,7 +75,13 @@
         "name": "Adaptive Ailerons",
         "text": "Before you reveal your dial, if you are not stressed, you must boost."
       },
-      "slots": ["Talent", "Talent", "Device", "Modification", "Gunner"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Device",
+        "Modification",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/duchess.png",
       "standard": true,
       "extended": true,
@@ -90,7 +102,12 @@
         "name": "Adaptive Ailerons",
         "text": "Before you reveal your dial, if you are not stressed, you must boost."
       },
-      "slots": ["Talent", "Device", "Modification", "Gunner"],
+      "slots": [
+        "Talent",
+        "Device",
+        "Modification",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/puresabacc.png",
       "standard": true,
       "extended": true,
@@ -110,7 +127,11 @@
         "name": "Adaptive Ailerons",
         "text": "Before you reveal your dial, if you are not stressed, you must boost."
       },
-      "slots": ["Talent", "Device", "Gunner"],
+      "slots": [
+        "Talent",
+        "Device",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/blacksquadronscout.png",
       "standard": true,
       "extended": true,
@@ -130,7 +151,11 @@
         "name": "Adaptive Ailerons",
         "text": "Before you reveal your dial, if you are not stressed, you must boost."
       },
-      "slots": ["Device", "Modification", "Gunner"],
+      "slots": [
+        "Device",
+        "Modification",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/planetarysentinel.png",
       "standard": true,
       "extended": true,
@@ -149,7 +174,13 @@
       "caption": "Destitute Demolitionist",
       "standard": true,
       "extended": true,
-      "slots": ["Talent", "Gunner", "Device", "Device", "Modification"],
+      "slots": [
+        "Talent",
+        "Gunner",
+        "Device",
+        "Device",
+        "Modification"
+      ],
       "ability": "After you fully execute a maneuver using your Adaptive Ailerons, if you are not stressed, you may drop 1 device.",
       "cost": 4,
       "loadout": 12,

--- a/data/pilots/galactic-empire/vt-49-decimator.json
+++ b/data/pilots/galactic-empire/vt-49-decimator.json
@@ -72,7 +72,13 @@
       "xws": "patrolleader",
       "text": "To be granted command of a VT-49 Decimator is seen as a significant promotion for a middling officer of the Imperial Navy.",
       "image": "https://infinitearenas.com/xw2/images/pilots/patrolleader.png",
-      "slots": ["Torpedo", "Crew", "Device", "Modification", "Gunner"],
+      "slots": [
+        "Torpedo",
+        "Crew",
+        "Device",
+        "Modification",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/patrolleader.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/galactic-republic/arc-170-starfighter.json
+++ b/data/pilots/galactic-republic/arc-170-starfighter.json
@@ -141,7 +141,13 @@
       "xws": "104thbattalionpilot",
       "cost": 5,
       "loadout": 8,
-      "slots": ["Torpedo", "Astromech", "Modification", "Gunner", "Gunner"],
+      "slots": [
+        "Torpedo",
+        "Astromech",
+        "Modification",
+        "Gunner",
+        "Gunner"
+      ],
       "initiative": 2,
       "limited": 0,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/104thbattalionpilot.png",
@@ -157,7 +163,13 @@
       "xws": "squadsevenveteran",
       "cost": 5,
       "loadout": 10,
-      "slots": ["Talent", "Astromech", "Modification", "Gunner", "Gunner"],
+      "slots": [
+        "Talent",
+        "Astromech",
+        "Modification",
+        "Gunner",
+        "Gunner"
+      ],
       "initiative": 3,
       "limited": 0,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/squadsevenveteran.png",
@@ -182,7 +194,11 @@
       "ability": "After you fully execute a red maneuver or perform a red action, you camy choose a friendly ship at range 0-3 and an enemy at range 0-1. The chosen frendly ship gains a lock on the enemy ship.",
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/oddball-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/oddball-arc170starfighter.png",
-      "standardLoadout": ["selfless", "veterantailgunner", "r4pastromech"],
+      "standardLoadout": [
+        "selfless",
+        "veterantailgunner",
+        "r4pastromech"
+      ],
       "shipStats": [
         { "arc": "Front Arc", "type": "attack", "value": 3 },
         { "arc": "Rear Arc", "type": "attack", "value": 2 },
@@ -210,7 +226,11 @@
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/wolffe-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/wolffe.png",
       "charges": { "value": 1, "recovers": 0 },
-      "standardLoadout": ["wolfpack-siegeofcoruscant", "veterantailgunner", "q7astromech"],
+      "standardLoadout": [
+        "wolfpack-siegeofcoruscant",
+        "veterantailgunner",
+        "q7astromech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["Clone"],
@@ -230,7 +250,11 @@
       "ability": "After a friendly ship at range 0-2 in your [Left Arc] or [Right Arc} performs an attack, if you are not strained, you may acquire a lock on the defender.",
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/jag-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/jag.png",
-      "standardLoadout": ["veterantailgunner", "r4pastromech", "synchronizedconsole"],
+      "standardLoadout": [
+        "veterantailgunner",
+        "r4pastromech",
+        "synchronizedconsole"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["Clone"],

--- a/data/pilots/galactic-republic/btl-b-y-wing.json
+++ b/data/pilots/galactic-republic/btl-b-y-wing.json
@@ -58,7 +58,10 @@
         "Modification",
         "Gunner"
       ],
-      "keywords": ["Clone", "Y-wing"],
+      "keywords": [
+        "Clone",
+        "Y-wing"
+      ],
       "epic": true
     },
     {
@@ -88,7 +91,11 @@
         "Gunner",
         "Force Power"
       ],
-      "keywords": ["Jedi", "Light Side", "Y-wing"],
+      "keywords": [
+        "Jedi",
+        "Light Side",
+        "Y-wing"
+      ],
       "epic": true
     },
     {
@@ -123,7 +130,10 @@
         "Modification"
       ],
       "initiative": 2,
-      "keywords": ["Droid", "Y-wing"],
+      "keywords": [
+        "Droid",
+        "Y-wing"
+      ],
       "epic": true
     },
     {
@@ -152,7 +162,10 @@
         "Modification",
         "Gunner"
       ],
-      "keywords": ["Clone", "Y-wing"],
+      "keywords": [
+        "Clone",
+        "Y-wing"
+      ],
       "epic": true
     },
     {
@@ -179,7 +192,10 @@
         "Device",
         "Modification"
       ],
-      "keywords": ["Clone", "Y-wing"],
+      "keywords": [
+        "Clone",
+        "Y-wing"
+      ],
       "epic": true
     },
     {
@@ -206,7 +222,10 @@
         "Device",
         "Modification"
       ],
-      "keywords": ["Clone", "Y-wing"],
+      "keywords": [
+        "Clone",
+        "Y-wing"
+      ],
       "epic": true
     },
     {
@@ -236,7 +255,10 @@
         "Modification",
         "Gunner"
       ],
-      "keywords": ["Clone", "Y-wing"],
+      "keywords": [
+        "Clone",
+        "Y-wing"
+      ],
       "epic": true
     },
     {
@@ -255,8 +277,17 @@
       "image": "https://infinitearenas.com/xw2/images/pilots/redsquadronbomber.png",
       "cost": 4,
       "loadout": 6,
-      "slots": ["Turret", "Torpedo", "Astromech", "Device", "Gunner"],
-      "keywords": ["Clone", "Y-wing"],
+      "slots": [
+        "Turret",
+        "Torpedo",
+        "Astromech",
+        "Device",
+        "Gunner"
+      ],
+      "keywords": [
+        "Clone",
+        "Y-wing"
+      ],
       "epic": true
     }
   ],

--- a/data/pilots/galactic-republic/clone-z-95-headhunter.json
+++ b/data/pilots/galactic-republic/clone-z-95-headhunter.json
@@ -128,7 +128,11 @@
       },
       "image": "https://infinitearenas.com/xw2/images/pilots/stub.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/stub.png",
-      "slots": ["Talent", "Sensor", "Modification"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "epic": true,

--- a/data/pilots/galactic-republic/delta-7-aethersprite.json
+++ b/data/pilots/galactic-republic/delta-7-aethersprite.json
@@ -55,9 +55,17 @@
       "extended": true,
       "cost": 4,
       "loadout": 3,
-      "slots": ["Astromech", "Modification", "Force Power", "Configuration"],
+      "slots": [
+        "Astromech",
+        "Modification",
+        "Force Power",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/jediknight.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -87,7 +95,10 @@
         "Configuration"
       ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/obiwankenobi.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -115,7 +126,10 @@
         "Configuration"
       ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/plokoon.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -135,9 +149,17 @@
       "extended": true,
       "cost": 4,
       "loadout": 8,
-      "slots": ["Astromech", "Modification", "Force Power", "Configuration"],
+      "slots": [
+        "Astromech",
+        "Modification",
+        "Force Power",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/saeseetiin.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -164,7 +186,10 @@
         "Force Power"
       ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/macewindu.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -193,7 +218,10 @@
         "Configuration"
       ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/anakinskywalker.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -213,9 +241,17 @@
       "image": "https://infinitearenas.com/xw2/images/pilots/ahsokatano.png",
       "cost": 4,
       "loadout": 7,
-      "slots": ["Astromech", "Modification", "Force Power", "Configuration"],
+      "slots": [
+        "Astromech",
+        "Modification",
+        "Force Power",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ahsokatano.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -242,7 +278,10 @@
         "Configuration"
       ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/barrissoffee.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -262,9 +301,17 @@
       "image": "https://infinitearenas.com/xw2/images/pilots/luminaraunduli.png",
       "cost": 4,
       "loadout": 7,
-      "slots": ["Astromech", "Modification", "Force Power", "Configuration"],
+      "slots": [
+        "Astromech",
+        "Modification",
+        "Force Power",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/luminaraunduli.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -285,8 +332,17 @@
       "image": "https://infinitearenas.com/xw2/images/pilots/adigallia.png",
       "cost": 5,
       "loadout": 12,
-      "slots": ["Force Power", "Talent", "Astromech", "Configuration", "Modification"],
-      "keywords": ["Jedi", "Light Side"],
+      "slots": [
+        "Force Power",
+        "Talent",
+        "Astromech",
+        "Configuration",
+        "Modification"
+      ],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/galactic-republic/delta-7b-aethersprite.json
+++ b/data/pilots/galactic-republic/delta-7b-aethersprite.json
@@ -54,9 +54,16 @@
       "standard": true,
       "epic": true,
       "cost": 6,
-      "slots": ["Force Power", "Astromech", "Modification"],
+      "slots": [
+        "Force Power",
+        "Astromech",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/jediknight-delta7baethersprite.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "loadout": 3,
       "extended": true
     },
@@ -84,7 +91,10 @@
         "Modification"
       ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/obiwankenobi-delta7baethersprite.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "loadout": 15,
       "extended": true
     },
@@ -111,7 +121,10 @@
         "Modification"
       ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/plokoon-delta7baethersprite.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "loadout": 19,
       "extended": true
     },
@@ -131,9 +144,16 @@
       "standard": false,
       "epic": true,
       "cost": 6,
-      "slots": ["Force Power", "Astromech", "Modification"],
+      "slots": [
+        "Force Power",
+        "Astromech",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/saeseetiin-delta7baethersprite.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "loadout": 9,
       "extended": true
     },
@@ -153,9 +173,17 @@
       "standard": true,
       "epic": true,
       "cost": 5,
-      "slots": ["Force Power", "Force Power", "Astromech", "Modification"],
+      "slots": [
+        "Force Power",
+        "Force Power",
+        "Astromech",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/macewindu-delta7baethersprite.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "loadout": 7,
       "extended": true
     },
@@ -184,7 +212,10 @@
         "Modification"
       ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/anakinskywalker-delta7baethersprite.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "extended": true
     },
     {
@@ -203,9 +234,16 @@
       "standard": true,
       "epic": true,
       "cost": 6,
-      "slots": ["Force Power", "Astromech", "Modification"],
+      "slots": [
+        "Force Power",
+        "Astromech",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ahsokatano-delta7baethersprite.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "loadout": 10,
       "extended": true
     },
@@ -225,9 +263,16 @@
       "standard": true,
       "epic": true,
       "cost": 5,
-      "slots": ["Force Power", "Astromech", "Modification"],
+      "slots": [
+        "Force Power",
+        "Astromech",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/barrissoffee-delta7baethersprite.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "loadout": 10,
       "extended": true
     },
@@ -247,9 +292,16 @@
       "standard": true,
       "epic": true,
       "cost": 6,
-      "slots": ["Force Power", "Astromech", "Modification"],
+      "slots": [
+        "Force Power",
+        "Astromech",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/luminaraunduli-delta7baethersprite.png",
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "loadout": 7,
       "extended": true
     },
@@ -271,8 +323,16 @@
       "image": "https://infinitearenas.com/xw2/images/pilots/adigallia-delta7baethersprite.png",
       "cost": 7,
       "loadout": 18,
-      "slots": ["Force Power", "Talent", "Astromech", "Modification"],
-      "keywords": ["Jedi", "Light Side"],
+      "slots": [
+        "Force Power",
+        "Talent",
+        "Astromech",
+        "Modification"
+      ],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/galactic-republic/eta-2-actis.json
+++ b/data/pilots/galactic-republic/eta-2-actis.json
@@ -63,7 +63,11 @@
         "Astromech",
         "Modification"
       ],
-      "keywords": ["Dark Side", "Jedi", "Light Side"],
+      "keywords": [
+        "Dark Side",
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -84,8 +88,18 @@
       "loadout": 15,
       "image": "https://infinitearenas.com/xw2/images/pilots/obiwankenobi-eta2actis.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/obiwankenobi-eta2actis.png",
-      "slots": ["Talent", "Force Power", "Force Power", "Astromech", "Modification", "Cannon"],
-      "keywords": ["Jedi", "Light Side"],
+      "slots": [
+        "Talent",
+        "Force Power",
+        "Force Power",
+        "Astromech",
+        "Modification",
+        "Cannon"
+      ],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -106,8 +120,18 @@
       "loadout": 15,
       "image": "https://infinitearenas.com/xw2/images/pilots/aaylasecura.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/aaylasecura.png",
-      "slots": ["Talent", "Force Power", "Force Power", "Astromech", "Modification", "Cannon"],
-      "keywords": ["Jedi", "Light Side"],
+      "slots": [
+        "Talent",
+        "Force Power",
+        "Force Power",
+        "Astromech",
+        "Modification",
+        "Cannon"
+      ],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -128,8 +152,18 @@
       "loadout": 10,
       "image": "https://infinitearenas.com/xw2/images/pilots/shaakti.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/shaakti.png",
-      "slots": ["Talent", "Force Power", "Force Power", "Astromech", "Modification", "Cannon"],
-      "keywords": ["Jedi", "Light Side"],
+      "slots": [
+        "Talent",
+        "Force Power",
+        "Force Power",
+        "Astromech",
+        "Modification",
+        "Cannon"
+      ],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -149,8 +183,16 @@
       "loadout": 4,
       "image": "https://infinitearenas.com/xw2/images/pilots/jedigeneral.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/jedigeneral.png",
-      "slots": ["Force Power", "Astromech", "Modification", "Cannon"],
-      "keywords": ["Jedi", "Light Side"],
+      "slots": [
+        "Force Power",
+        "Astromech",
+        "Modification",
+        "Cannon"
+      ],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -178,7 +220,10 @@
         "Modification",
         "Cannon"
       ],
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -196,10 +241,18 @@
       "force": { "value": 3, "recovers": 1 },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/anakinskywalker-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/anakinskywalker-eta2actis.png",
-      "standardLoadout": ["malice", "ancillaryionweapons-siegeofcoruscant",  "r2d2-republic"],
+      "standardLoadout": [
+        "malice",
+        "ancillaryionweapons-siegeofcoruscant",
+        "r2d2-republic"
+      ],
       "standard": true,
       "extended": true,
-      "keywords": ["Dark Side", "Jedi", "Light Side"],
+      "keywords": [
+        "Dark Side",
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -217,10 +270,17 @@
       "force": { "value": 3, "recovers": 1 },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/obiwankenobi-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/obiwankenobi-eta2actis.png",
-      "standardLoadout": ["patience", "ancillaryionweapons-siegeofcoruscant",  "r4p17-siegeofcoruscant"],
+      "standardLoadout": [
+        "patience",
+        "ancillaryionweapons-siegeofcoruscant",
+        "r4p17-siegeofcoruscant"
+      ],
       "standard": true,
       "extended": true,
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -238,10 +298,18 @@
       "force": { "value": 2, "recovers": 1 },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/shaakti-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/shaakti.png",
-      "standardLoadout": ["marksmanship", "brilliantevasion", "ancillaryionweapons-siegeofcoruscant",  "r4pastromech"],
+      "standardLoadout": [
+        "marksmanship",
+        "brilliantevasion",
+        "ancillaryionweapons-siegeofcoruscant",
+        "r4pastromech"
+      ],
       "standard": true,
       "extended": true,
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -270,7 +338,10 @@
         "Modification",
         "Cannon"
       ],
-      "keywords": ["Jedi", "Light Side"],
+      "keywords": [
+        "Jedi",
+        "Light Side"
+      ],
       "epic": true
     }
   ],

--- a/data/pilots/galactic-republic/naboo-royal-n-1-starfighter.json
+++ b/data/pilots/galactic-republic/naboo-royal-n-1-starfighter.json
@@ -45,7 +45,12 @@
       "extended": true,
       "cost": 5,
       "loadout": 20,
-      "slots": ["Talent", "Sensor", "Torpedo", "Astromech"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Torpedo",
+        "Astromech"
+      ],
       "ability": "Before you reveal your maneuver, you may spend 1 [Force] to barrel roll (this is not an action).",
       "force": { "value": 1, "recovers": 1, "side": ["light"] },
       "shipAbility": {
@@ -72,7 +77,13 @@
       "extended": true,
       "cost": 4,
       "loadout": 12,
-      "slots": ["Talent", "Talent", "Sensor", "Torpedo", "Astromech"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Sensor",
+        "Torpedo",
+        "Astromech"
+      ],
       "ability": "While you defend or perform a primary attack, if the speed of your revealed maneuver is higher than the enemy ship's, roll 1 additional die.",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ricolie.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/ricolie.png",
@@ -92,7 +103,12 @@
       "extended": true,
       "cost": 4,
       "loadout": 18,
-      "slots": ["Talent", "Sensor", "Torpedo", "Astromech"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Torpedo",
+        "Astromech"
+      ],
       "ability": "While an enemy ship in your [Front Arc] defends or performs an attack, that ship can modify only 1 [Focus] result (other results can still be modified).",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/padmeamidala.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/padmeamidala.png",
@@ -112,7 +128,12 @@
       "extended": true,
       "cost": 4,
       "loadout": 14,
-      "slots": ["Talent", "Sensor", "Torpedo", "Astromech"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Torpedo",
+        "Astromech"
+      ],
       "ability": "While you defend or perform an attack, if the speed of your revealed maneuver is the same as the enemy ship's, that ship's dice cannot be modified.",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dineeellberger.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/dineeellberger.png",
@@ -132,7 +153,11 @@
       "extended": true,
       "cost": 4,
       "loadout": 8,
-      "slots": ["Sensor", "Torpedo", "Astromech"],
+      "slots": [
+        "Sensor",
+        "Torpedo",
+        "Astromech"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bravoflightofficer.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/bravoflightofficer.png",
       "epic": true
@@ -153,7 +178,11 @@
       "ability": "Setup: After placing forces, assign the Decoyed condition to 1 friendly ship other than Naboo Handmaiden.",
       "cost": 4,
       "loadout": 8,
-      "slots": ["Sensor", "Modification", "Astromech"],
+      "slots": [
+        "Sensor",
+        "Modification",
+        "Astromech"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/naboohandmaiden.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/naboohandmaiden.png",
       "epic": true
@@ -172,7 +201,13 @@
       "extended": true,
       "cost": 4,
       "loadout": 16,
-      "slots": ["Talent", "Sensor", "Torpedo", "Astromech", "Modification"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Torpedo",
+        "Astromech",
+        "Modification"
+      ],
       "ability": "While you defend or perform an attack, if the speed of your revealed maneuver is greater than the enemy ship's, you may reroll your blank results.",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/gavynsykes.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/gavynsykes.png",

--- a/data/pilots/galactic-republic/nimbus-class-v-wing.json
+++ b/data/pilots/galactic-republic/nimbus-class-v-wing.json
@@ -138,7 +138,12 @@
       "loadout": 8,
       "image": "https://infinitearenas.com/xw2/images/pilots/klick.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/klick.png",
-      "slots": ["Talent", "Astromech", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Astromech",
+        "Modification",
+        "Configuration"
+      ],
       "keywords": ["Clone"],
       "epic": true
     },
@@ -158,7 +163,10 @@
       "loadout": 3,
       "image": "https://infinitearenas.com/xw2/images/pilots/shadowsquadronescort.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/shadowsquadronescort.png",
-      "slots": ["Modification", "Configuration"],
+      "slots": [
+        "Modification",
+        "Configuration"
+      ],
       "keywords": ["Clone"],
       "epic": true
     },
@@ -178,7 +186,10 @@
       "loadout": 4,
       "image": "https://infinitearenas.com/xw2/images/pilots/loyalistvolunteer.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/loyalistvolunteer.png",
-      "slots": ["Modification", "Configuration"],
+      "slots": [
+        "Modification",
+        "Configuration"
+      ],
       "epic": true
     },
     {
@@ -196,7 +207,11 @@
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/klick-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/klick.png",
       "charges": { "value": 1, "recovers": 1 },
-      "standardLoadout": ["r3astromech", "precisionionengines", "alpha3eesk"],
+      "standardLoadout": [
+        "r3astromech",
+        "precisionionengines",
+        "alpha3eesk"
+      ],
       "shipStats": [
         { "arc": "Front Arc", "type": "attack", "value": 2 },
         { "type": "agility", "value": 3 },
@@ -222,7 +237,12 @@
       "ability": "While you defend or perform an attack, if the bearing of your revealed maneuver is the same as the enemy ship's, you may change 1 of the enemy ship's [Focus] results to a blank result.",
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/contrail-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/contrail.png",
-      "standardLoadout": ["ionlimiteroverride", "preciseastromech-battleofyavin", "ionbombs", "alpha3bbesh"],
+      "standardLoadout": [
+        "ionlimiteroverride",
+        "preciseastromech-battleofyavin",
+        "ionbombs",
+        "alpha3bbesh"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["Clone"],

--- a/data/pilots/galactic-republic/syliure-class-hyperspace-ring.json
+++ b/data/pilots/galactic-republic/syliure-class-hyperspace-ring.json
@@ -16,9 +16,7 @@
       "initiative": 0,
       "cost": 2,
       "loadout": 0,
-      "slots": [
-        "Hyperdrive"
-      ],
+      "slots": ["Hyperdrive"],
       "limited": 0,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/transgalmegcontrollink.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/transgalmegcontrollink.png",

--- a/data/pilots/galactic-republic/v-19-torrent-starfighter.json
+++ b/data/pilots/galactic-republic/v-19-torrent-starfighter.json
@@ -52,7 +52,11 @@
       "extended": true,
       "cost": 3,
       "loadout": 8,
-      "slots": ["Talent", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/kickback.png",
       "keywords": ["Clone"],
       "epic": true
@@ -69,7 +73,12 @@
       "extended": true,
       "cost": 4,
       "loadout": 16,
-      "slots": ["Talent", "Torpedo", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Torpedo",
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/oddball.png",
       "keywords": ["Clone"],
       "epic": true
@@ -86,7 +95,12 @@
       "extended": true,
       "cost": 4,
       "loadout": 13,
-      "slots": ["Talent", "Missile", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/swoop.png",
       "keywords": ["Clone"],
       "epic": true
@@ -103,7 +117,11 @@
       "extended": true,
       "cost": 3,
       "loadout": 8,
-      "slots": ["Talent", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/axe.png",
       "keywords": ["Clone"],
       "epic": true
@@ -120,7 +138,12 @@
       "extended": true,
       "cost": 4,
       "loadout": 13,
-      "slots": ["Talent", "Missile", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/tucker.png",
       "keywords": ["Clone"],
       "epic": true
@@ -136,7 +159,10 @@
       "extended": true,
       "cost": 4,
       "loadout": 4,
-      "slots": ["Talent", "Modification"],
+      "slots": [
+        "Talent",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bluesquadronprotector.png",
       "keywords": ["Clone"],
       "epic": true
@@ -152,7 +178,11 @@
       "extended": true,
       "cost": 4,
       "loadout": 6,
-      "slots": ["Missile", "Talent", "Modification"],
+      "slots": [
+        "Missile",
+        "Talent",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/goldsquadrontrooper.png",
       "keywords": ["Clone"],
       "epic": true
@@ -171,7 +201,10 @@
       "ability": "After you perform a [Barrel Roll] action, you may perform a red [Lock] action. If you do, before you perfrom the [Lock] action, you may gain 1 strain to treat it as white.",
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/kickback-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/kickback.png",
-      "standardLoadout": ["diamondboronmissiles", "munitionsfailsafe"],
+      "standardLoadout": [
+        "diamondboronmissiles",
+        "munitionsfailsafe"
+      ],
       "shipStats": [
         { "arc": "Front Arc", "type": "attack", "value": 2 },
         { "type": "agility", "value": 2 },
@@ -196,7 +229,10 @@
       "ability": "After you perform an attack, you may choose another friendly ship with the Born for This ability at range 0-2 in your [Left Arc] or [Right Arc]. The chosen ship gains a lock on the defender.",
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/axe-siegeofcoruscant.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/axe.png",
-      "standardLoadout": ["deadeyeshot", "barragerockets"],
+      "standardLoadout": [
+        "deadeyeshot",
+        "barragerockets"
+      ],
       "shipStats": [
         { "arc": "Front Arc", "type": "attack", "value": 2 },
         { "type": "agility", "value": 2 },
@@ -219,7 +255,12 @@
       "extended": true,
       "cost": 3,
       "loadout": 7,
-      "slots": ["Talent", "Missile", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/slammer.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/slammer.png",
       "keywords": ["Clone"],

--- a/data/pilots/rebel-alliance/a-sf-01-b-wing.json
+++ b/data/pilots/rebel-alliance/a-sf-01-b-wing.json
@@ -49,7 +49,13 @@
       "xws": "bladesquadronveteran",
       "text": "A unique gyrostabilization system surrounds the B-wing's cockpit, ensuring that the pilot always remains stationary during flight.",
       "image": "https://infinitearenas.com/xw2/images/pilots/bladesquadronveteran.png",
-      "slots": ["Sensor", "Cannon", "Cannon", "Torpedo", "Configuration"],
+      "slots": [
+        "Sensor",
+        "Cannon",
+        "Cannon",
+        "Torpedo",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bladesquadronveteran.png",
       "standard": true,
       "extended": true,
@@ -65,7 +71,13 @@
       "xws": "bluesquadronpilot",
       "text": "Due to its heavy weapons array and resilient shielding, the B-wing has solidified itself as the Rebel Alliance's most innovative assault fighter.",
       "image": "https://infinitearenas.com/xw2/images/pilots/bluesquadronpilot.png",
-      "slots": ["Sensor", "Cannon", "Cannon", "Device", "Configuration"],
+      "slots": [
+        "Sensor",
+        "Cannon",
+        "Cannon",
+        "Device",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bluesquadronpilot.png",
       "standard": true,
       "extended": true,
@@ -158,7 +170,10 @@
       "caption": "Phoenix Leader",
       "standard": true,
       "extended": true,
-      "keywords": ["B-wing", "Spectre"],
+      "keywords": [
+        "B-wing",
+        "Spectre"
+      ],
       "cost": 5,
       "loadout": 14,
       "slots": [

--- a/data/pilots/rebel-alliance/attack-shuttle.json
+++ b/data/pilots/rebel-alliance/attack-shuttle.json
@@ -54,7 +54,13 @@
         "name": "Locked and Loaded",
         "text": "While you are docked, after your carrier ship performs a primary [Front Arc] or [Turret] attack, it may perform a bonus primary [Rear Arc] attack."
       },
-      "slots": ["Talent", "Turret", "Crew", "Modification", "Title"],
+      "slots": [
+        "Talent",
+        "Turret",
+        "Crew",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/zeborrelios.png",
       "standard": false,
       "extended": true,
@@ -76,11 +82,20 @@
         "name": "Locked and Loaded",
         "text": "While you are docked, after your carrier ship performs a primary [Front Arc] or [Turret] attack, it may perform a bonus primary [Rear Arc] attack."
       },
-      "slots": ["Turret", "Crew", "Modification", "Title", "Force Power"],
+      "slots": [
+        "Turret",
+        "Crew",
+        "Modification",
+        "Title",
+        "Force Power"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ezrabridger.png",
       "standard": false,
       "extended": true,
-      "keywords": ["Light Side", "Spectre"],
+      "keywords": [
+        "Light Side",
+        "Spectre"
+      ],
       "epic": true
     },
     {
@@ -97,7 +112,13 @@
         "name": "Locked and Loaded",
         "text": "While you are docked, after your carrier ship performs a primary [Front Arc] or [Turret] attack, it may perform a bonus primary [Rear Arc] attack."
       },
-      "slots": ["Talent", "Turret", "Crew", "Modification", "Title"],
+      "slots": [
+        "Talent",
+        "Turret",
+        "Crew",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/herasyndulla.png",
       "standard": false,
       "extended": true,
@@ -118,11 +139,20 @@
         "name": "Locked and Loaded",
         "text": "While you are docked, after your carrier ship performs a primary [Front Arc] or [Turret] attack, it may perform a bonus primary [Rear Arc] attack."
       },
-      "slots": ["Talent", "Turret", "Crew", "Modification", "Title"],
+      "slots": [
+        "Talent",
+        "Turret",
+        "Crew",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/sabinewren.png",
       "standard": false,
       "extended": true,
-      "keywords": ["Mandalorian", "Spectre"],
+      "keywords": [
+        "Mandalorian",
+        "Spectre"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/rebel-alliance/auzituck-gunship.json
+++ b/data/pilots/rebel-alliance/auzituck-gunship.json
@@ -43,7 +43,10 @@
       "xws": "kashyyykdefender",
       "text": "Equipped with three wide-range Sureggi twin laser cannons, the Auzituck gunship acts as a powerful deterrent to slaver operations in the Kashyyyk system.",
       "image": "https://infinitearenas.com/xw2/images/pilots/kashyyykdefender.png",
-      "slots": ["Crew", "Modification"],
+      "slots": [
+        "Crew",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/kashyyykdefender.png",
       "standard": false,
       "extended": true,
@@ -59,7 +62,12 @@
       "xws": "lowhhrick",
       "ability": "After a friendly ship at range 0-1 becomes the defender, you may spend 1 reinforce token. If you do, that ship gains 1 evade token.",
       "image": "https://infinitearenas.com/xw2/images/pilots/lowhhrick.png",
-      "slots": ["Talent", "Crew", "Crew", "Modification"],
+      "slots": [
+        "Talent",
+        "Crew",
+        "Crew",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lowhhrick.png",
       "standard": false,
       "extended": true,
@@ -75,7 +83,12 @@
       "xws": "wullffwarro",
       "ability": "While you perform a primary attack, if you are damaged, you may roll 1 additional attack die.",
       "image": "https://infinitearenas.com/xw2/images/pilots/wullffwarro.png",
-      "slots": ["Talent", "Crew", "Crew", "Modification"],
+      "slots": [
+        "Talent",
+        "Crew",
+        "Crew",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/wullffwarro.png",
       "standard": false,
       "extended": true,

--- a/data/pilots/rebel-alliance/btl-a4-y-wing.json
+++ b/data/pilots/rebel-alliance/btl-a4-y-wing.json
@@ -95,7 +95,11 @@
       "xws": "goldsquadronveteran",
       "text": "Commanded by Jon “Dutch” Vander, Gold Squadron played an instrumental role in the Battles of Scarif and Yavin.",
       "image": "https://infinitearenas.com/xw2/images/pilots/goldsquadronveteran.png",
-      "slots": ["Turret", "Modification", "Missile"],
+      "slots": [
+        "Turret",
+        "Modification",
+        "Missile"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/goldsquadronveteran.png",
       "standard": true,
       "extended": true,
@@ -111,7 +115,11 @@
       "xws": "graysquadronbomber",
       "text": "Long after the Y-wing was phased out by the Galactic Empire, its durability, dependability, and heavy armament help it remain a staple in the Rebel fleet.",
       "image": "https://infinitearenas.com/xw2/images/pilots/graysquadronbomber.png",
-      "slots": ["Device", "Modification", "Missile"],
+      "slots": [
+        "Device",
+        "Modification",
+        "Missile"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/graysquadronbomber.png",
       "standard": true,
       "extended": true,
@@ -178,7 +186,11 @@
         "name": "Hope",
         "text": "After another friendly ship at range 0-3 is destroyed, you may perform a [Focus] or [Boost] action."
       },
-      "standardLoadout": ["dorsalturret", "advprotontorpedoes", "r4astromech"],
+      "standardLoadout": [
+        "dorsalturret",
+        "advprotontorpedoes",
+        "r4astromech"
+      ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/dextiree-battleofyavin.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dextiree-battleofyavin.png",
       "standard": true,
@@ -198,7 +210,11 @@
         "name": "Hope",
         "text": "After another friendly ship at range 0-3 is destroyed, you may perform a [Focus] or [Boost] action."
       },
-      "standardLoadout": ["ioncannonturret", "advprotontorpedoes", "targetingastromech"],
+      "standardLoadout": [
+        "ioncannonturret",
+        "advprotontorpedoes",
+        "targetingastromech"
+      ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/dutchvander-battleofyavin.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dutchvander.png",
       "standard": true,
@@ -218,7 +234,11 @@
         "name": "Hope",
         "text": "After another friendly ship at range 0-3 is destroyed, you may perform a [Focus] or [Boost] action."
       },
-      "standardLoadout": ["dorsalturret", "advprotontorpedoes", "preciseastromech"],
+      "standardLoadout": [
+        "dorsalturret",
+        "advprotontorpedoes",
+        "preciseastromech"
+      ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/holokand-battleofyavin.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/holokand-battleofyavin.png",
       "standard": true,
@@ -238,7 +258,11 @@
         "name": "Hope",
         "text": "After another friendly ship at range 0-3 is destroyed, you may perform a [Focus] or [Boost] action."
       },
-      "standardLoadout": ["ioncannonturret", "advprotontorpedoes", "r4astromech"],
+      "standardLoadout": [
+        "ioncannonturret",
+        "advprotontorpedoes",
+        "r4astromech"
+      ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/popskrail-battleofyavin.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/popskrail-battleofyavin.png",
       "standard": true,
@@ -279,7 +303,10 @@
       "cost": 4,
       "xws": "dutchvander-swz106",
       "ability": "After you perform the [Lock] action, you may choose 1 friendly ship at range 1-3. That ship may acquire a lock on the object you locked, ignoring range restrictions.",
-      "standardLoadout": ["ioncannonturret", "protonbombs"],
+      "standardLoadout": [
+        "ioncannonturret",
+        "protonbombs"
+      ],
       "image": "",
       "artwork": "",
       "standard": true,
@@ -295,7 +322,10 @@
       "cost": 4,
       "xws": "hortonsalm-swz106",
       "ability": "While you perform an attack, you may reroll 1 attack die for each other friendly ship at range 0-1 of the defender.",
-      "standardLoadout": ["ioncannonturret", "proximitymines"],
+      "standardLoadout": [
+        "ioncannonturret",
+        "proximitymines"
+      ],
       "image": "",
       "artwork": "",
       "standard": true,

--- a/data/pilots/rebel-alliance/btl-s8-k-wing.json
+++ b/data/pilots/rebel-alliance/btl-s8-k-wing.json
@@ -89,7 +89,13 @@
       "xws": "wardensquadronpilot",
       "text": "Koensayr Manufacturing's K-wing boasts an advanced SubLight Acceleration Motor and an unprecedented 18 hard points, granting it unrivaled speed and firepower.",
       "image": "https://infinitearenas.com/xw2/images/pilots/wardensquadronpilot.png",
-      "slots": ["Torpedo", "Missile", "Device", "Device", "Gunner"],
+      "slots": [
+        "Torpedo",
+        "Missile",
+        "Device",
+        "Device",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/wardensquadronpilot.png",
       "standard": false,
       "extended": true,

--- a/data/pilots/rebel-alliance/e-wing.json
+++ b/data/pilots/rebel-alliance/e-wing.json
@@ -117,7 +117,12 @@
         "name": "Experimental Scanners",
         "text": "You can acquire locks beyond range 3. You cannot acquire locks at range 1."
       },
-      "slots": ["Sensor", "Tech", "Astromech", "Modification"],
+      "slots": [
+        "Sensor",
+        "Tech",
+        "Astromech",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/knavesquadronescort.png",
       "standard": false,
       "extended": true,
@@ -136,7 +141,12 @@
         "name": "Experimental Scanners",
         "text": "You can acquire locks beyond range 3. You cannot acquire locks at range 1."
       },
-      "slots": ["Sensor", "Torpedo", "Astromech", "Modification"],
+      "slots": [
+        "Sensor",
+        "Torpedo",
+        "Astromech",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/roguesquadronescort.png",
       "standard": false,
       "extended": true,

--- a/data/pilots/rebel-alliance/fang-fighter.json
+++ b/data/pilots/rebel-alliance/fang-fighter.json
@@ -58,7 +58,13 @@
         "name": "Concordia Faceoff",
         "text": "While you defend, if the attack range is 1 and you are in the attacker's [Front Arc], change 1 result to an [Evade] result."
       },
-      "slots": ["Talent", "Talent", "Torpedo", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Torpedo",
+        "Modification",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/fennrau-rebel-fang.png",
       "standard": true,
       "extended": true,
@@ -79,7 +85,13 @@
         "name": "Concordia Faceoff",
         "text": "While you defend, if the attack range is 1 and you are in the attacker's [Front Arc], change 1 result to an [Evade] result."
       },
-      "slots": ["Talent", "Talent", "Torpedo", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Torpedo",
+        "Modification",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bodicavenj.png",
       "standard": true,
       "extended": true,
@@ -100,7 +112,11 @@
         "name": "Concordia Faceoff",
         "text": "While you defend, if the attack range is 1 and you are in the attacker's [Front Arc], change 1 result to an [Evade] result."
       },
-      "slots": ["Torpedo", "Modification", "Modification"],
+      "slots": [
+        "Torpedo",
+        "Modification",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dirkullodin.png",
       "standard": true,
       "extended": true,
@@ -121,7 +137,12 @@
         "name": "Concordia Faceoff",
         "text": "While you defend, if the attack range is 1 and you are in the attacker's [Front Arc], change 1 result to an [Evade] result."
       },
-      "slots": ["Talent", "Torpedo", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Torpedo",
+        "Modification",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/clanwrenvolunteer.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/rebel-alliance/gauntlet-fighter.json
+++ b/data/pilots/rebel-alliance/gauntlet-fighter.json
@@ -57,7 +57,10 @@
       ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/chopper-gauntletfighter.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/chopper-gauntletfighter.png",
-      "keywords": ["Droid", "Spectre"],
+      "keywords": [
+        "Droid",
+        "Spectre"
+      ],
       "caption": "Spectre-3"
     },
     {
@@ -86,7 +89,10 @@
       ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ezrabridger-gauntletfighter.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/ezrabridger-gauntletfighter.png",
-      "keywords": ["Light Side", "Spectre"],
+      "keywords": [
+        "Light Side",
+        "Spectre"
+      ],
       "caption": "Spectre-6"
     },
     {

--- a/data/pilots/rebel-alliance/hwk-290-light-freighter.json
+++ b/data/pilots/rebel-alliance/hwk-290-light-freighter.json
@@ -79,7 +79,14 @@
       "xws": "kylekatarn",
       "ability": "At the start of the Engagement Phase, you may transfer 1 of your focus tokens to a friendly ship in your firing arc.",
       "image": "https://infinitearenas.com/xw2/images/pilots/kylekatarn.png",
-      "slots": ["Talent", "Talent", "Crew", "Device", "Modification", "Title"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Crew",
+        "Device",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/kylekatarn.png",
       "standard": true,
       "extended": true,
@@ -95,7 +102,10 @@
       "xws": "rebelscout",
       "text": "Designed to look like a bird in flight by the Corellian Engineering Corporation, “hawk” series ships are exemplary transport craft. Swift and rugged, the HWK-290 is often employed by Rebel agents as a mobile base of operations.",
       "image": "https://infinitearenas.com/xw2/images/pilots/rebelscout.png",
-      "slots": ["Device", "Modification"],
+      "slots": [
+        "Device",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/rebelscout.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/rebel-alliance/modified-yt-1300-light-freighter.json
+++ b/data/pilots/rebel-alliance/modified-yt-1300-light-freighter.json
@@ -62,7 +62,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/chewbacca.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     },
     {
@@ -89,7 +92,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/hansolo-modifiedyt1300lightfreighter.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     },
     {
@@ -116,7 +122,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/landocalrissian-modifiedyt1300lightfreighter.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     },
     {
@@ -128,11 +137,17 @@
       "xws": "outerrimsmuggler",
       "text": "Known for its durability and modular design, the YT-1300 is one of the most popular, widely used, and extensively customized freighters in the galaxy.",
       "image": "https://infinitearenas.com/xw2/images/pilots/outerrimsmuggler.png",
-      "slots": ["Missile", "Gunner"],
+      "slots": [
+        "Missile",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/outerrimsmuggler.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     },
     {
@@ -159,7 +174,11 @@
       "loadout": 24,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/leiaorgana.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/leiaorgana.png",
-      "keywords": ["Freighter", "YT-1300", "Light Side"],
+      "keywords": [
+        "Freighter",
+        "YT-1300",
+        "Light Side"
+      ],
       "epic": true
     },
     {
@@ -174,12 +193,20 @@
         "name": "Solo",
         "text": "While you defend or perform an attack, if there are no other friendly ships at range 0-1, you may spend 1 [Charge] to reroll one of your dice."
       },
-      "standardLoadout": ["chewbacca-battleofyavin", "riggedcargochute", "millenniumfalcon", "l337sprogramming-battleofyavin"],
+      "standardLoadout": [
+        "chewbacca-battleofyavin",
+        "riggedcargochute",
+        "millenniumfalcon",
+        "l337sprogramming-battleofyavin"
+      ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/hansolo-battleofyavin.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/hansolo-battleofyavin.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/rebel-alliance/rz-1-a-wing.json
+++ b/data/pilots/rebel-alliance/rz-1-a-wing.json
@@ -52,7 +52,11 @@
         "name": "Vectored Thrusters",
         "text": "After you perform an action, you may perform a red [Boost] action."
       },
-      "slots": ["Talent", "Talent", "Configuration"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/arvelcrynyd.png",
       "standard": true,
       "extended": true,
@@ -72,7 +76,11 @@
         "name": "Vectored Thrusters",
         "text": "After you perform an action, you may perform a red [Boost] action."
       },
-      "slots": ["Talent", "Talent", "Configuration"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/greensquadronpilot.png",
       "standard": true,
       "extended": true,
@@ -93,7 +101,13 @@
         "name": "Vectored Thrusters",
         "text": "After you perform an action, you may perform a red [Boost] action."
       },
-      "slots": ["Talent", "Talent", "Missile", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Missile",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/jakefarrell.png",
       "standard": true,
       "extended": true,
@@ -113,7 +127,10 @@
         "name": "Vectored Thrusters",
         "text": "After you perform an action, you may perform a red [Boost] action."
       },
-      "slots": ["Talent", "Configuration"],
+      "slots": [
+        "Talent",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/phoenixsquadronpilot.png",
       "standard": true,
       "extended": true,
@@ -134,7 +151,12 @@
       "keywords": ["A-wing"],
       "cost": 3,
       "loadout": 7,
-      "slots": ["Talent", "Talent", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Modification",
+        "Configuration"
+      ],
       "ability": "While you perform a primary attack, if the defender is in your [Front Arc], the defender rolls 1 fewer defense die.",
       "caption": "Promising Pilot",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/wedgeantilles-rz1awing.png",
@@ -152,7 +174,10 @@
       },
       "standard": true,
       "extended": true,
-      "keywords": ["A-wing", "Mandalorian"],
+      "keywords": [
+        "A-wing",
+        "Mandalorian"
+      ],
       "cost": 3,
       "loadout": 7,
       "slots": [
@@ -190,7 +215,10 @@
         "Configuration"
       ],
       "ability": "While another friendly ship at range 1-2 defends or performs an attack, during a Modify Dice step, you may transfer 1 of your focus tokens, evade tokens, or locks to that ship.",
-      "keywords": ["A-wing", "Spectre"],
+      "keywords": [
+        "A-wing",
+        "Spectre"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/herasyndulla-rz1awing.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/herasyndulla-rz1awing.png",
       "epic": true
@@ -219,7 +247,10 @@
         "Configuration"
       ],
       "ability": "After you fully execute a maneuver, you may choose a friendly ship at range 1-2 and spend 2 [Force]. That ship may perform an action, even while stressed.",
-      "keywords": ["A-wing", "Light Side"],
+      "keywords": [
+        "A-wing",
+        "Light Side"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ahsokatano-rz1awing.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/ahsokatano-rz1awing.png",
       "epic": true
@@ -238,7 +269,11 @@
       "extended": true,
       "cost": 4,
       "loadout": 7,
-      "slots": ["Talent", "Missile", "Configuration"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Configuration"
+      ],
       "ability": "While you defend or perform a primary attack, you may spend 1 lock you have on the enemy ship to add 1 [Focus] result to your dice results.",
       "keywords": ["A-wing"],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/sharabey-rz1awing.png",
@@ -259,7 +294,11 @@
       "extended": true,
       "cost": 3,
       "loadout": 6,
-      "slots": ["Talent", "Missile", "Configuration"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Configuration"
+      ],
       "ability": "After you acquire or spend a lock, you may remove 1 red token from yourself.",
       "keywords": ["A-wing"],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/derekklivian.png",
@@ -332,7 +371,10 @@
         "name": "Vectored Thrusters",
         "text": "After you perform an action, you may perform a red [Boost] action."
       },
-      "standardLoadout": ["predator", "afterburners"],
+      "standardLoadout": [
+        "predator",
+        "afterburners"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/arvelcrynyd.png",
       "standard": true,
       "extended": true,
@@ -352,7 +394,11 @@
         "name": "Vectored Thrusters",
         "text": "After you perform an action, you may perform a red [Boost] action."
       },
-      "standardLoadout": ["elusive", "outmaneuver", "ionmissiles"],
+      "standardLoadout": [
+        "elusive",
+        "outmaneuver",
+        "ionmissiles"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/jakefarrell.png",
       "standard": true,
       "extended": true,
@@ -372,7 +418,10 @@
       "standard": true,
       "extended": true,
       "cost": 4,
-      "standardLoadout": ["hopeful", "concussionmissiles"],
+      "standardLoadout": [
+        "hopeful",
+        "concussionmissiles"
+      ],
       "ability": "While you defend or perform a primary attack, you may spend 1 lock you have on the enemy ship to add 1 [Focus] result to your dice results.",
       "keywords": ["A-wing"],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/sharabey-rz1awing.png",

--- a/data/pilots/rebel-alliance/sheathipede-class-shuttle.json
+++ b/data/pilots/rebel-alliance/sheathipede-class-shuttle.json
@@ -49,7 +49,13 @@
         "name": "Comms Shuttle",
         "text": "While you are docked, your carrier ship gains [Coordinate]. Before your carrier ship activates, it may perform a [Coordinate] action."
       },
-      "slots": ["Talent", "Crew", "Astromech", "Modification", "Title"],
+      "slots": [
+        "Talent",
+        "Crew",
+        "Astromech",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/zeborrelios-sheathipedeclassshuttle.png",
       "standard": true,
       "extended": true,
@@ -74,11 +80,19 @@
         "name": "Comms Shuttle",
         "text": "While you are docked, your carrier ship gains [Coordinate]. Before your carrier ship activates, it may perform a [Coordinate] action."
       },
-      "slots": ["Crew", "Astromech", "Modification", "Title"],
+      "slots": [
+        "Crew",
+        "Astromech",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ap5.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Droid", "Spectre"],
+      "keywords": [
+        "Droid",
+        "Spectre"
+      ],
       "epic": true
     },
     {
@@ -96,11 +110,20 @@
         "name": "Comms Shuttle",
         "text": "While you are docked, your carrier ship gains [Coordinate]. Before your carrier ship activates, it may perform a [Coordinate] action."
       },
-      "slots": ["Crew", "Astromech", "Modification", "Title", "Force Power"],
+      "slots": [
+        "Crew",
+        "Astromech",
+        "Modification",
+        "Title",
+        "Force Power"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ezrabridger-sheathipedeclassshuttle.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Light Side", "Spectre"],
+      "keywords": [
+        "Light Side",
+        "Spectre"
+      ],
       "epic": true
     },
     {
@@ -117,11 +140,20 @@
         "name": "Comms Shuttle",
         "text": "While you are docked, your carrier ship gains [Coordinate]. Before your carrier ship activates, it may perform a [Coordinate] action."
       },
-      "slots": ["Talent", "Crew", "Astromech", "Modification", "Title"],
+      "slots": [
+        "Talent",
+        "Crew",
+        "Astromech",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/fennrau-sheathipedeclassshuttle.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Mandalorian", "Spectre"],
+      "keywords": [
+        "Mandalorian",
+        "Spectre"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/rebel-alliance/t-65-x-wing.json
+++ b/data/pilots/rebel-alliance/t-65-x-wing.json
@@ -21,7 +21,10 @@
     "4FW",
     "4KR"
   ],
-  "dialCodes": ["XW", "T65"],
+  "dialCodes": [
+    "XW",
+    "T65"
+  ],
   "faction": "Rebel Alliance",
   "stats": [
     { "arc": "Front Arc", "type": "attack", "value": 3 },
@@ -45,7 +48,12 @@
       "loadout": 18,
       "xws": "biggsdarklighter",
       "ability": "While another friendly ship at range 0-1 defends, before the Neutralize Results step, if you are in the attack arc, you may suffer 1 [Hit] or [Critical Hit] damage to cancel 1 matching result.",
-      "slots": ["Torpedo", "Astromech", "Modification", "Configuration"],
+      "slots": [
+        "Torpedo",
+        "Astromech",
+        "Modification",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/biggsdarklighter.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/biggsdarklighter.png",
       "standard": true,
@@ -63,7 +71,10 @@
       "text": "Designed by Incom Corporation, the T-65 X-wing quickly proved to be one of the most effective and versatile military vehicles in the galaxy and a boon to the Rebellion.",
       "image": "https://infinitearenas.com/xw2/images/pilots/bluesquadronescort.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bluesquadronescort.png",
-      "slots": ["Astromech", "Configuration"],
+      "slots": [
+        "Astromech",
+        "Configuration"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["X-wing"],
@@ -77,12 +88,19 @@
       "loadout": 4,
       "xws": "cavernangelszealot",
       "text": "Unlike most Rebel cells, Saw Gerrera's partisans are willing to use extreme methods to undermine the Galactic Empire's objectives in brutal battles that raged from Geonosis to Jedha.",
-      "slots": ["Astromech", "Illicit", "Configuration"],
+      "slots": [
+        "Astromech",
+        "Illicit",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/cavernangelszealot.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/cavernangelszealot.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Partisan", "X-wing"],
+      "keywords": [
+        "Partisan",
+        "X-wing"
+      ],
       "epic": true
     },
     {
@@ -103,7 +121,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/edriotwotubes.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Partisan", "X-wing"],
+      "keywords": [
+        "Partisan",
+        "X-wing"
+      ],
       "epic": true
     },
     {
@@ -138,7 +159,12 @@
       "loadout": 15,
       "xws": "jekporkins",
       "ability": "After you receive a stress token, you may roll 1 attack die to remove it. On a [Hit] result, suffer 1 [Hit] damage.",
-      "slots": ["Torpedo", "Astromech", "Talent", "Configuration"],
+      "slots": [
+        "Torpedo",
+        "Astromech",
+        "Talent",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/jekporkins.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/jekporkins.png",
       "standard": true,
@@ -166,7 +192,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/kullbeesperado.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Partisan", "X-wing"],
+      "keywords": [
+        "Partisan",
+        "X-wing"
+      ],
       "epic": true
     },
     {
@@ -189,7 +218,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/leevantenza.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Partisan", "X-wing"],
+      "keywords": [
+        "Partisan",
+        "X-wing"
+      ],
       "epic": true
     },
     {
@@ -214,7 +246,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lukeskywalker.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Light Side", "X-wing"],
+      "keywords": [
+        "Light Side",
+        "X-wing"
+      ],
       "epic": true
     },
     {
@@ -225,7 +260,11 @@
       "loadout": 3,
       "xws": "redsquadronveteran",
       "text": "Created as an elite starfighter squad, Red Squadron includes some of the best pilots in the Rebel Alliance.",
-      "slots": ["Talent", "Astromech", "Configuration"],
+      "slots": [
+        "Talent",
+        "Astromech",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/redsquadronveteran.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/redsquadronveteran.png",
       "standard": true,
@@ -291,7 +330,12 @@
         "name": "Hope",
         "text": "After another friendly ship at range 0-3 is destroyed, you may perform a [Focus] or [Boost] action."
       },
-      "standardLoadout": ["attackspeed-battleofyavin", "selfless", "protontorpedoes", "r2f2-battleofyavin"],
+      "standardLoadout": [
+        "attackspeed-battleofyavin",
+        "selfless",
+        "protontorpedoes",
+        "r2f2-battleofyavin"
+      ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/biggsdarklighter-battleofyavin.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/biggsdarklighter.png",
       "standard": true,
@@ -311,7 +355,10 @@
         "name": "Hope",
         "text": "After another friendly ship at range 0-3 is destroyed, you may perform a [Focus] or [Boost] action."
       },
-      "standardLoadout": ["advprotontorpedoes", "r5k6-battleofyavin"],
+      "standardLoadout": [
+        "advprotontorpedoes",
+        "r5k6-battleofyavin"
+      ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/garvendreis-battleofyavin.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/garvendreis-t65xwing.png",
       "standard": true,
@@ -331,7 +378,11 @@
         "name": "Hope",
         "text": "After another friendly ship at range 0-3 is destroyed, you may perform a [Focus] or [Boost] action."
       },
-      "standardLoadout": ["advprotontorpedoes", "r5d8-battleofyavin", "unstablesublightengines-battleofyavin"],
+      "standardLoadout": [
+        "advprotontorpedoes",
+        "r5d8-battleofyavin",
+        "unstablesublightengines-battleofyavin"
+      ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/jekporkins-battleofyavin.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/jekporkins.png",
       "standard": true,
@@ -352,7 +403,12 @@
         "name": "Hope",
         "text": "After another friendly ship at range 0-3 is destroyed, you may perform a [Focus] or [Boost] action."
       },
-      "standardLoadout": ["attackspeed-battleofyavin", "instictiveaim", "protontorpedoes", "r2d2-battleofyavin"],
+      "standardLoadout": [
+        "attackspeed-battleofyavin",
+        "instictiveaim",
+        "protontorpedoes",
+        "r2d2-battleofyavin"
+      ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/lukeskywalker-battleofyavin.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lukeskywalker.png",
       "standard": true,
@@ -372,7 +428,12 @@
         "name": "Hope",
         "text": "After another friendly ship at range 0-3 is destroyed, you may perform a [Focus] or [Boost] action."
       },
-      "standardLoadout": ["attackspeed-battleofyavin", "marksmanship", "protontorpedoes", "r2a3-battleofyavin"],
+      "standardLoadout": [
+        "attackspeed-battleofyavin",
+        "marksmanship",
+        "protontorpedoes",
+        "r2a3-battleofyavin"
+      ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/wedgeantilles-battleofyavin.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/wedgeantilles.png",
       "standard": true,
@@ -435,7 +496,11 @@
       "xws": "lukeskywalker-swz106",
       "ability": "After you are declared as the defender during an attack, you may recover 1 [Force].",
       "force": { "value": 2, "recovers": 1, "side": ["light"] },
-      "standardLoadout": ["instictiveaim", "protontorpedoes", "r2d2"],
+      "standardLoadout": [
+        "instictiveaim",
+        "protontorpedoes",
+        "r2d2"
+      ],
       "image": "",
       "artwork": "",
       "standard": true,
@@ -451,7 +516,11 @@
       "cost": 5,
       "xws": "jekporkins-swz106",
       "ability": "After you receive a stress token, you may roll 1 attack die to remove it. On a [Hit] result, suffer 1 [Hit] damage.",
-      "standardLoadout": ["predate", "protontorpedoes", "r5d8-battleofyavin"],
+      "standardLoadout": [
+        "predate",
+        "protontorpedoes",
+        "r5d8-battleofyavin"
+      ],
       "image": "",
       "artwork": "",
       "standard": true,

--- a/data/pilots/rebel-alliance/tie-ln-fighter.json
+++ b/data/pilots/rebel-alliance/tie-ln-fighter.json
@@ -44,11 +44,17 @@
       "xws": "zeborrelios-tielnfighter",
       "ability": "While you defend, [Critical Hit] results are neutralized before [Hit] results.",
       "image": "https://infinitearenas.com/xw2/images/pilots/zeborrelios-tielnfighter.png",
-      "slots": ["Crew", "Modification"],
+      "slots": [
+        "Crew",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/zeborrelios-tielnfighter.png",
       "standard": true,
       "extended": true,
-      "keywords": ["TIE", "Spectre"],
+      "keywords": [
+        "TIE",
+        "Spectre"
+      ],
       "epic": true
     },
     {
@@ -62,11 +68,18 @@
       "ability": "After you perform an attack, assign the Suppressive Fire condition to the defender.",
       "image": "https://infinitearenas.com/xw2/images/pilots/captainrex.png",
       "conditions": ["suppressivefire"],
-      "slots": ["Talent", "Talent", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/captainrex.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Clone", "TIE"],
+      "keywords": [
+        "Clone",
+        "TIE"
+      ],
       "epic": true
     },
     {
@@ -80,11 +93,19 @@
       "ability": "While you defend or perform an attack, if you are stressed, you may spend 1 [Force] to change up to 2 of your [Focus] results to [Evade] or [Hit] results.",
       "image": "https://infinitearenas.com/xw2/images/pilots/ezrabridger-tielnfighter.png",
       "force": { "value": 1, "recovers": 1, "side": ["light"] },
-      "slots": ["Modification", "Crew", "Force Power"],
+      "slots": [
+        "Modification",
+        "Crew",
+        "Force Power"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ezrabridger-tielnfighter.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Light Side", "Spectre", "TIE"],
+      "keywords": [
+        "Light Side",
+        "Spectre",
+        "TIE"
+      ],
       "epic": true
     },
     {
@@ -97,11 +118,18 @@
       "xws": "sabinewren-tielnfighter",
       "ability": "Before you activate, you may perform a [Barrel Roll] or [Boost] action.",
       "image": "https://infinitearenas.com/xw2/images/pilots/sabinewren-tielnfighter.png",
-      "slots": ["Talent", "Modification"],
+      "slots": [
+        "Talent",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/sabinewren-tielnfighter.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Mandalorian", "TIE", "Spectre"],
+      "keywords": [
+        "Mandalorian",
+        "TIE",
+        "Spectre"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/rebel-alliance/ut-60d-u-wing.json
+++ b/data/pilots/rebel-alliance/ut-60d-u-wing.json
@@ -66,7 +66,10 @@
       "xws": "bluesquadronscout",
       "text": "Used for deploying troops under the cover of darkness or into the heat of battle, the UT-60D U-wing fulfills the Rebellion's need for a swift and hardy troop transport.",
       "image": "https://infinitearenas.com/xw2/images/pilots/bluesquadronscout.png",
-      "slots": ["Modification", "Configuration"],
+      "slots": [
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bluesquadronscout.png",
       "standard": true,
       "extended": true,
@@ -82,7 +85,13 @@
       "xws": "bodhirook",
       "ability": "Friendly ships can acquire locks onto objects at range 0-3 of any friendly ship.",
       "image": "https://infinitearenas.com/xw2/images/pilots/bodhirook.png",
-      "slots": ["Sensor", "Crew", "Crew", "Modification", "Configuration"],
+      "slots": [
+        "Sensor",
+        "Crew",
+        "Crew",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bodhirook.png",
       "standard": true,
       "extended": true,
@@ -98,7 +107,13 @@
       "xws": "cassianandor",
       "ability": "At the start of the Activation Phase, you may choose 1 friendly ship at range 1-3. If you do, that ship removes 1 stress token.",
       "image": "https://infinitearenas.com/xw2/images/pilots/cassianandor.png",
-      "slots": ["Talent", "Sensor", "Crew", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Crew",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/cassianandor.png",
       "standard": true,
       "extended": true,
@@ -160,7 +175,10 @@
       "loadout": 6,
       "xws": "partisanrenegade",
       "text": "Saw Gerrera's partisans were first established to oppose Separatist forces on Onderon during the Clone Wars and continued to wage war against galactic tyranny as the Empire rose to power.",
-      "slots": ["Illicit", "Configuration"],
+      "slots": [
+        "Illicit",
+        "Configuration"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/partisanrenegade.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/partisanrenegade.png",
       "standard": true,
@@ -200,7 +218,13 @@
       "limited": 1,
       "xws": "k2so",
       "ability": "After you gain a stress token, gain 1 calculate token.",
-      "slots": ["Sensor", "Crew", "Crew", "Modification", "Configuration"],
+      "slots": [
+        "Sensor",
+        "Crew",
+        "Crew",
+        "Modification",
+        "Configuration"
+      ],
       "shipActions": [
         { "difficulty": "White", "type": "Calculate" },
         { "difficulty": "White", "type": "Lock" },

--- a/data/pilots/rebel-alliance/vcx-100-light-freighter.json
+++ b/data/pilots/rebel-alliance/vcx-100-light-freighter.json
@@ -68,7 +68,11 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/chopper.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Droid", "Freighter", "Spectre"],
+      "keywords": [
+        "Droid",
+        "Freighter",
+        "Spectre"
+      ],
       "epic": true
     },
     {
@@ -99,7 +103,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/herasyndulla-vcx100lightfreighter.png",
       "standard": false,
       "extended": true,
-      "keywords": ["Freighter", "Spectre"],
+      "keywords": [
+        "Freighter",
+        "Spectre"
+      ],
       "epic": true
     },
     {
@@ -131,7 +138,12 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/kananjarrus.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "Jedi", "Light Side", "Spectre"],
+      "keywords": [
+        "Freighter",
+        "Jedi",
+        "Light Side",
+        "Spectre"
+      ],
       "epic": true
     },
     {
@@ -147,7 +159,11 @@
         "name": "Tail Gun",
         "text": "While you have a docked ship, you have a primary [Rear Arc] weapon with an attack value equal to your docked ship's primary [Front Arc] attack value."
       },
-      "slots": ["Turret", "Torpedo", "Gunner"],
+      "slots": [
+        "Turret",
+        "Torpedo",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lothalrebel.png",
       "standard": true,
       "extended": true,
@@ -182,7 +198,10 @@
       "loadout": 16,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/alexsandrkallus.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/alexsandrkallus.png",
-      "keywords": ["Freighter", "Spectre"],
+      "keywords": [
+        "Freighter",
+        "Spectre"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/rebel-alliance/yt-2400-light-freighter.json
+++ b/data/pilots/rebel-alliance/yt-2400-light-freighter.json
@@ -68,7 +68,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/leebo.png",
       "standard": false,
       "extended": true,
-      "keywords": ["Droid", "Freighter"],
+      "keywords": [
+        "Droid",
+        "Freighter"
+      ],
       "epic": true
     },
     {
@@ -113,7 +116,10 @@
         "name": "Sensor Blindspot",
         "text": "While you perform a primary attack at attack range 0-1, do not apply the range 0-1 bonus and roll 1 fewer attack die."
       },
-      "slots": ["Missile", "Illicit"],
+      "slots": [
+        "Missile",
+        "Illicit"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/wildspacefringer.png",
       "standard": false,
       "extended": true,

--- a/data/pilots/rebel-alliance/z-95-af4-headhunter.json
+++ b/data/pilots/rebel-alliance/z-95-af4-headhunter.json
@@ -45,7 +45,12 @@
       "xws": "airencracken",
       "ability": "After you perform an attack, you may choose 1 friendly ship at range 1. That ship may perform an action, treating it as red.",
       "image": "https://infinitearenas.com/xw2/images/pilots/airencracken.png",
-      "slots": ["Talent", "Torpedo", "Sensor", "Modification"],
+      "slots": [
+        "Talent",
+        "Torpedo",
+        "Sensor",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/airencracken.png",
       "standard": true,
       "extended": true,
@@ -60,7 +65,10 @@
       "xws": "banditsquadronpilot",
       "text": "The Z-95 Headhunter was the primary inspiration for Incom Corporation's exemplary T-65 X-wing starfighter. Though it is considered outdated by modern standards, it remains a versatile and potent snub fighter.",
       "image": "https://infinitearenas.com/xw2/images/pilots/banditsquadronpilot.png",
-      "slots": ["Missile", "Modification"],
+      "slots": [
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/banditsquadronpilot.png",
       "standard": true,
       "extended": true,
@@ -76,7 +84,11 @@
       "xws": "lieutenantblount",
       "ability": "While you perform a primary attack, if there is at least 1 other friendly ship at range 0-1 of the defender, you may roll 1 additional attack die.",
       "image": "https://infinitearenas.com/xw2/images/pilots/lieutenantblount.png",
-      "slots": ["Talent", "Talent", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lieutenantblount.png",
       "standard": true,
       "extended": true,
@@ -91,7 +103,10 @@
       "xws": "talasquadronpilot",
       "text": "The AF4 series is the latest in a long line of Headhunter designs. Cheap and relatively durable, it is a favorite among independent outfits like the Rebellion.",
       "image": "https://infinitearenas.com/xw2/images/pilots/talasquadronpilot.png",
-      "slots": ["Talent", "Modification"],
+      "slots": [
+        "Talent",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/talasquadronpilot.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/resistance/fireball.json
+++ b/data/pilots/resistance/fireball.json
@@ -47,7 +47,10 @@
         "name": "Explosion with Wings",
         "text": "Setup: You are dealt 1 facedown damage card. After you perform a [SLAM] action, you may expose 1 damage card to remove 1 disarm token."
       },
-      "slots": ["Missile", "Modification"],
+      "slots": [
+        "Missile",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "cost": 3,
@@ -126,7 +129,12 @@
       "caption": "Bucket",
       "standard": true,
       "extended": true,
-      "slots": ["Missile", "Crew", "Modification", "Title"],
+      "slots": [
+        "Missile",
+        "Crew",
+        "Modification",
+        "Title"
+      ],
       "ability": "Before you expose 1 of your damage cards, you may look at your facedown damage cards, choose 1, and expose that card instead.",
       "cost": 3,
       "loadout": 8,

--- a/data/pilots/resistance/resistance-transport-pod.json
+++ b/data/pilots/resistance/resistance-transport-pod.json
@@ -43,7 +43,12 @@
       "extended": true,
       "cost": 2,
       "loadout": 4,
-      "slots": ["Tech", "Tech", "Crew", "Modification"],
+      "slots": [
+        "Tech",
+        "Tech",
+        "Crew",
+        "Modification"
+      ],
       "ability": "During the System Phase, you may perform a red [Barrel Roll] or [Boost] action.",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bb8.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/bb8.png",
@@ -67,7 +72,13 @@
       "extended": true,
       "cost": 3,
       "loadout": 9,
-      "slots": ["Talent", "Tech", "Crew", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Tech",
+        "Crew",
+        "Modification",
+        "Modification"
+      ],
       "ability": "While you defend or perform an attack, you may reroll up to 1 of your results for each other friendly ship in the attack arc.",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/rosetico.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/rosetico.png",
@@ -83,7 +94,11 @@
       "extended": true,
       "cost": 3,
       "loadout": 6,
-      "slots": ["Tech", "Crew", "Modification"],
+      "slots": [
+        "Tech",
+        "Crew",
+        "Modification"
+      ],
       "ability": "Setup: After placing forces, assign the Compromising Intel condition to 1 enemy ship.",
       "conditions": ["compromisingintel"],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/vimoradi.png",
@@ -100,7 +115,13 @@
       "extended": true,
       "cost": 4,
       "loadout": 15,
-      "slots": ["Talent", "Talent", "Tech", "Crew", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Tech",
+        "Crew",
+        "Modification"
+      ],
       "ability": "While you defend or perform an attack, you may add 1 blank result, or you may gain 1 strain token to add 1 focus result instead.",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/finn.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/finn.png",

--- a/data/pilots/resistance/resistance-transport.json
+++ b/data/pilots/resistance/resistance-transport.json
@@ -123,7 +123,12 @@
       "extended": true,
       "cost": 4,
       "loadout": 6,
-      "slots": ["Cannon", "Crew", "Astromech", "Astromech"],
+      "slots": [
+        "Cannon",
+        "Crew",
+        "Astromech",
+        "Astromech"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/logisticsdivisionpilot.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/logisticsdivisionpilot.png",
       "epic": true
@@ -144,14 +149,14 @@
         "Tech",
         "Cannon",
         "Cannon",
-        "Torpedo", 
+        "Torpedo",
         "Astromech",
         "Illicit",
         "Modification"
-    ],
-    "image": "https://infinitearenas.com/xw2/images/pilots/takajamoreesa.png",
-    "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/takajamoreesa.png",
-    "epic": true
+      ],
+      "image": "https://infinitearenas.com/xw2/images/pilots/takajamoreesa.png",
+      "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/takajamoreesa.png",
+      "epic": true
     }
   ],
   "icon": "https://infinitearenas.com/xw2/images/shipicons/resistance/I_Resistance_Transport.png"

--- a/data/pilots/resistance/rz-2-a-wing.json
+++ b/data/pilots/resistance/rz-2-a-wing.json
@@ -51,7 +51,12 @@
         "name": "Refined Gyrostabilizers",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
-      "slots": ["Talent", "Talent", "Modification", "Tech"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Modification",
+        "Tech"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/lulolampar.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lulolampar.png",
       "standard": true,
@@ -132,7 +137,12 @@
       },
       "image": "https://infinitearenas.com/xw2/images/pilots/greersonnel.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/greersonnel.png",
-      "slots": ["Talent", "Modification", "Missile", "Tech"],
+      "slots": [
+        "Talent",
+        "Modification",
+        "Missile",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["A-wing"],
@@ -150,7 +160,11 @@
         "name": "Refined Gyrostabilizers",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
-      "slots": ["Talent", "Talent", "Tech"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Tech"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/greensquadronexpert.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/greensquadronexpert.png",
       "standard": true,
@@ -170,7 +184,10 @@
         "name": "Refined Gyrostabilizers",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
-      "slots": ["Talent", "Tech"],
+      "slots": [
+        "Talent",
+        "Tech"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/bluesquadronrecruit.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bluesquadronrecruit.png",
       "standard": true,
@@ -190,7 +207,13 @@
       "caption": "Committed to the Cause",
       "standard": true,
       "extended": true,
-      "slots": ["Talent", "Talent", "Tech", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Tech",
+        "Missile",
+        "Modification"
+      ],
       "ability": "After you defend or perform an attack, you may spend 1 [Charge] to gain 1 focus or evade token.",
       "cost": 5,
       "loadout": 10,
@@ -212,7 +235,12 @@
       "caption": "Reckless Rookie",
       "standard": true,
       "extended": true,
-      "slots": ["Talent", "Tech", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Tech",
+        "Missile",
+        "Modification"
+      ],
       "ability": "While you defend or perform an attack, if the enemy ship is in another friendly ship's [Single Turret Arc], you may spend 1 focus token from that friendly ship to change 1 of your [Focus] results to an [Evade] or [Hit] result.",
       "cost": 4,
       "loadout": 10,
@@ -234,7 +262,12 @@
         "name": "Refined Gyrostabilizers",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
-      "slots": ["Talent", "Missile", "Tech", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Tech",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "image": "https://infinitearenas.com/xw2/images/pilots/merlcobben.png",
@@ -255,7 +288,13 @@
         "name": "Refined Gyrostabilizers",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
-      "slots": ["Talent", "Talent", "Modification", "Cannon", "Tech"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Modification",
+        "Cannon",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "image": "https://infinitearenas.com/xw2/images/pilots/suralindajavos.png",
@@ -276,7 +315,12 @@
         "name": "Refined Gyrostabilizers",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
-      "slots": ["Talent", "Modification", "Missile", "Tech"],
+      "slots": [
+        "Talent",
+        "Modification",
+        "Missile",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "image": "https://infinitearenas.com/xw2/images/pilots/wrobietyce.png",
@@ -297,7 +341,13 @@
         "name": "Refined Gyrostabilizers",
         "text": "You can rotate your [Single Turret Arc] indicator only to your [Front Arc] or [Rear Arc]. After you perform an action, you may perform a red [Boost] or red [Rotate Arc] action."
       },
-      "slots": ["Talent", "Talent", "Missile", "Tech", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Missile",
+        "Tech",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "image": "https://infinitearenas.com/xw2/images/pilots/seftinvanik.png",

--- a/data/pilots/resistance/scavenged-yt-1300.json
+++ b/data/pilots/resistance/scavenged-yt-1300.json
@@ -46,10 +46,19 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/resistancesympathizer.png",
       "cost": 6,
       "loadout": 10,
-      "slots": ["Talent", "Missile", "Modification", "Modification", "Gunner"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Modification",
+        "Modification",
+        "Gunner"
+      ],
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     },
     {
@@ -77,7 +86,10 @@
       ],
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     },
     {
@@ -104,7 +116,10 @@
       ],
       "standard": false,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     },
     {
@@ -132,7 +147,11 @@
       ],
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "Light Side", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "Light Side",
+        "YT-1300"
+      ],
       "epic": true
     },
     {
@@ -159,7 +178,10 @@
       ],
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     },
     {
@@ -187,7 +209,10 @@
       ],
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/resistance/t-70-x-wing.json
+++ b/data/pilots/resistance/t-70-x-wing.json
@@ -111,7 +111,12 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bluesquadronrookie.png",
       "cost": 5,
       "loadout": 4,
-      "slots": ["Astromech", "Modification", "Configuration", "Tech"],
+      "slots": [
+        "Astromech",
+        "Modification",
+        "Configuration",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["X-wing"],
@@ -131,7 +136,13 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/redsquadronexpert.png",
       "cost": 5,
       "loadout": 2,
-      "slots": ["Talent", "Astromech", "Modification", "Configuration", "Tech"],
+      "slots": [
+        "Talent",
+        "Astromech",
+        "Modification",
+        "Configuration",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["X-wing"],
@@ -151,7 +162,13 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/blacksquadronace-t70xwing.png",
       "cost": 5,
       "loadout": 10,
-      "slots": ["Talent", "Astromech", "Modification", "Configuration", "Tech"],
+      "slots": [
+        "Talent",
+        "Astromech",
+        "Modification",
+        "Configuration",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["X-wing"],
@@ -198,7 +215,13 @@
       },
       "cost": 5,
       "loadout": 13,
-      "slots": ["Talent", "Astromech", "Modification", "Configuration", "Tech"],
+      "slots": [
+        "Talent",
+        "Astromech",
+        "Modification",
+        "Configuration",
+        "Tech"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/jophseastriker.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/jophseastriker.png",
       "standard": true,
@@ -249,7 +272,12 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lieutenantbastian.png",
       "cost": 5,
       "loadout": 14,
-      "slots": ["Astromech", "Modification", "Configuration", "Tech"],
+      "slots": [
+        "Astromech",
+        "Modification",
+        "Configuration",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["X-wing"],
@@ -298,7 +326,12 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/jaycristubbs.png",
       "cost": 4,
       "loadout": 8,
-      "slots": ["Astromech", "Modification", "Configuration", "Tech"],
+      "slots": [
+        "Astromech",
+        "Modification",
+        "Configuration",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["X-wing"],
@@ -320,7 +353,12 @@
       "cost": 4,
       "loadout": 7,
       "charges": { "value": 1, "recovers": 1 },
-      "slots": ["Astromech", "Modification", "Configuration", "Tech"],
+      "slots": [
+        "Astromech",
+        "Modification",
+        "Configuration",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["X-wing"],
@@ -395,7 +433,13 @@
       },
       "cost": 4,
       "loadout": 7,
-      "slots": ["Talent", "Astromech", "Modification", "Configuration", "Tech"],
+      "slots": [
+        "Talent",
+        "Astromech",
+        "Modification",
+        "Configuration",
+        "Tech"
+      ],
       "standard": true,
       "extended": true,
       "image": "https://infinitearenas.com/xw2/images/pilots/caithrenalli.png",
@@ -417,7 +461,12 @@
       "extended": true,
       "cost": 4,
       "loadout": 9,
-      "slots": ["Tech", "Astromech", "Modification", "Configuration"],
+      "slots": [
+        "Tech",
+        "Astromech",
+        "Modification",
+        "Configuration"
+      ],
       "ability": "While you perform an attack, if the defender's initiative is higher than yours, you may change 1 blank result to a [Focus] result.",
       "image": "https://infinitearenas.com/xw2/images/pilots/nimichireen.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/nimichireen.png",

--- a/data/pilots/scum-and-villainy/aggressor-assault-fighter.json
+++ b/data/pilots/scum-and-villainy/aggressor-assault-fighter.json
@@ -64,7 +64,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ig88a.png",
       "standard": false,
       "extended": true,
-      "keywords": ["Bounty Hunter", "Droid"],
+      "keywords": [
+        "Bounty Hunter",
+        "Droid"
+      ],
       "epic": true
     },
     {
@@ -94,7 +97,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ig88b.png",
       "standard": false,
       "extended": true,
-      "keywords": ["Bounty Hunter", "Droid"],
+      "keywords": [
+        "Bounty Hunter",
+        "Droid"
+      ],
       "epic": true
     },
     {
@@ -124,7 +130,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ig88c.png",
       "standard": false,
       "extended": true,
-      "keywords": ["Bounty Hunter", "Droid"],
+      "keywords": [
+        "Bounty Hunter",
+        "Droid"
+      ],
       "epic": true
     },
     {
@@ -154,7 +163,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ig88d.png",
       "standard": false,
       "extended": true,
-      "keywords": ["Bounty Hunter", "Droid"],
+      "keywords": [
+        "Bounty Hunter",
+        "Droid"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/scum-and-villainy/btl-a4-y-wing.json
+++ b/data/pilots/scum-and-villainy/btl-a4-y-wing.json
@@ -44,7 +44,12 @@
       "xws": "crymorahgoon",
       "text": "Though far from nimble, the Y-wing's heavy hull, substantial shielding, and turret-mounted cannons make it an excellent patrol craft.",
       "image": "https://infinitearenas.com/xw2/images/pilots/crymorahgoon.png",
-      "slots": ["Turret", "Device", "Illicit", "Missile"],
+      "slots": [
+        "Turret",
+        "Device",
+        "Illicit",
+        "Missile"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/crymorahgoon.png",
       "standard": true,
       "extended": true,
@@ -86,7 +91,13 @@
       "xws": "hiredgun",
       "text": "Just the mention of Imperial credits can bring a host of less-than-trustworthy individuals to your side.",
       "image": "https://infinitearenas.com/xw2/images/pilots/hiredgun.png",
-      "slots": ["Turret", "Torpedo", "Device", "Illicit", "Missile"],
+      "slots": [
+        "Turret",
+        "Torpedo",
+        "Device",
+        "Illicit",
+        "Missile"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/hiredgun.png",
       "standard": true,
       "extended": true,
@@ -179,7 +190,13 @@
       "extended": true,
       "cost": 4,
       "loadout": 6,
-      "slots": ["Turret", "Torpedo", "Missile", "Astromech", "Device"],
+      "slots": [
+        "Turret",
+        "Torpedo",
+        "Missile",
+        "Astromech",
+        "Device"
+      ],
       "keywords": ["Y-wing"],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/amaxinewarrior.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/amaxinewarrior.png",
@@ -221,7 +238,12 @@
       "extended": true,
       "cost": 4,
       "loadout": 5,
-      "slots": ["Turret", "Torpedo", "Missile", "Device"],
+      "slots": [
+        "Turret",
+        "Torpedo",
+        "Missile",
+        "Device"
+      ],
       "keywords": ["Y-wing"],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/jinatasecurityofficer.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/jinatasecurityofficer.png",

--- a/data/pilots/scum-and-villainy/customized-yt-1300-light-freighter.json
+++ b/data/pilots/scum-and-villainy/customized-yt-1300-light-freighter.json
@@ -45,12 +45,19 @@
       "loadout": 6,
       "xws": "freightercaptain",
       "text": "Many spacers make a living traveling the Outer Rim, where the difference between smuggler and legitimate merchant is often murky. On the outskirts of civilization, buyers are rarely so discerning to ask where merchandise came from, at least as long as the price is low enough.",
-      "slots": ["Missile", "Illicit", "Gunner"],
+      "slots": [
+        "Missile",
+        "Illicit",
+        "Gunner"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/freightercaptain.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/freightercaptain.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     },
     {
@@ -76,7 +83,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/hansolo.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     },
     {
@@ -107,7 +117,11 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/l337.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Droid", "Freighter", "YT-1300"],
+      "keywords": [
+        "Droid",
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     },
     {
@@ -133,7 +147,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/landocalrissian.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Freighter", "YT-1300"],
+      "keywords": [
+        "Freighter",
+        "YT-1300"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/scum-and-villainy/escape-craft.json
+++ b/data/pilots/scum-and-villainy/escape-craft.json
@@ -78,7 +78,11 @@
         "name": "Co-Pilot",
         "text": "While you are docked, your carrier ship has your pilot ability in addition to its own."
       },
-      "slots": ["Talent", "Crew", "Modification"],
+      "slots": [
+        "Talent",
+        "Crew",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/l337-escapecraft.png",
       "standard": true,
       "extended": true,
@@ -98,7 +102,11 @@
         "name": "Co-Pilot",
         "text": "While you are docked, your carrier ship has your pilot ability in addition to its own."
       },
-      "slots": ["Talent", "Crew", "Modification"],
+      "slots": [
+        "Talent",
+        "Crew",
+        "Modification"
+      ],
       "image": "https://infinitearenas.com/xw2/images/pilots/landocalrissian-escapecraft.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/landocalrissian-escapecraft.png",
       "standard": true,
@@ -119,7 +127,11 @@
         "name": "Co-Pilot",
         "text": "While you are docked, your carrier ship has your pilot ability in addition to its own."
       },
-      "slots": ["Talent", "Crew", "Modification"],
+      "slots": [
+        "Talent",
+        "Crew",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/outerrimpioneer.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/scum-and-villainy/fang-fighter.json
+++ b/data/pilots/scum-and-villainy/fang-fighter.json
@@ -58,7 +58,13 @@
         "name": "Concordia Faceoff",
         "text": "While you defend, if the attack range is 1 and you are in the attacker's [Front Arc], change 1 result to an [Evade] result."
       },
-      "slots": ["Talent", "Talent", "Modification", "Modification", "Torpedo"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Modification",
+        "Modification",
+        "Torpedo"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/fennrau.png",
       "standard": true,
       "extended": true,
@@ -79,7 +85,13 @@
         "name": "Concordia Faceoff",
         "text": "While you defend, if the attack range is 1 and you are in the attacker's [Front Arc], change 1 result to an [Evade] result."
       },
-      "slots": ["Talent", "Missile", "Torpedo", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Torpedo",
+        "Modification",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/joyrekkoff.png",
       "standard": true,
       "extended": true,
@@ -100,7 +112,12 @@
         "name": "Concordia Faceoff",
         "text": "While you defend, if the attack range is 1 and you are in the attacker's [Front Arc], change 1 result to an [Evade] result."
       },
-      "slots": ["Talent", "Missile", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Modification",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/kadsolus.png",
       "standard": true,
       "extended": true,
@@ -121,7 +138,13 @@
         "name": "Concordia Faceoff",
         "text": "While you defend, if the attack range is 1 and you are in the attacker's [Front Arc], change 1 result to an [Evade] result."
       },
-      "slots": ["Talent", "Talent", "Torpedo", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Torpedo",
+        "Modification",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/oldteroch.png",
       "standard": true,
       "extended": true,
@@ -141,7 +164,10 @@
         "name": "Concordia Faceoff",
         "text": "While you defend, if the attack range is 1 and you are in the attacker's [Front Arc], change 1 result to an [Evade] result."
       },
-      "slots": ["Torpedo", "Modification"],
+      "slots": [
+        "Torpedo",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/skullsquadronpilot.png",
       "standard": true,
       "extended": true,
@@ -161,7 +187,10 @@
         "name": "Concordia Faceoff",
         "text": "While you defend, if the attack range is 1 and you are in the attacker's [Front Arc], change 1 result to an [Evade] result."
       },
-      "slots": ["Modification", "Modification"],
+      "slots": [
+        "Modification",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/zealousrecruit.png",
       "standard": true,
       "extended": true,
@@ -181,7 +210,12 @@
         "name": "Concordia Faceoff",
         "text": "While you defend, if the attack range is 1 and you are in the attacker's [Front Arc], change 1 result to an [Evade] result."
       },
-      "slots": ["Talent", "Missile", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Modification",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/mandalorianroyalguard.png",
       "standard": true,
       "extended": true,
@@ -204,7 +238,12 @@
         "name": "Concordia Faceoff",
         "text": "While you defend, if the attack range is 1 and you are in the attacker's [Front Arc], change 1 result to an [Evade] result."
       },
-      "slots": ["Talent", "Missile", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Modification",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["Mandalorian"],

--- a/data/pilots/scum-and-villainy/firespray-class-patrol-craft.json
+++ b/data/pilots/scum-and-villainy/firespray-class-patrol-craft.json
@@ -74,7 +74,12 @@
       "xws": "bountyhunter",
       "text": "The Firespray-class patrol craft is infamous for its association with the deadly bounty hunters Jango Fett and Boba Fett, who packed their craft with countless deadly armaments.",
       "image": "https://infinitearenas.com/xw2/images/pilots/bountyhunter.png",
-      "slots": ["Cannon", "Missile", "Device", "Illicit"],
+      "slots": [
+        "Cannon",
+        "Missile",
+        "Device",
+        "Illicit"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bountyhunter.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/scum-and-villainy/g-1a-starfighter.json
+++ b/data/pilots/scum-and-villainy/g-1a-starfighter.json
@@ -46,7 +46,14 @@
       "xws": "4lom",
       "ability": "After you fully execute a red maneuver, gain 1 calculate token. At the start of the End Phase, you may choose 1 ship at range 0-1. If you do, transfer 1 of your stress tokens to that ship.",
       "image": "https://infinitearenas.com/xw2/images/pilots/4lom.png",
-      "slots": ["Talent", "Sensor", "Crew", "Illicit", "Modification", "Title"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Crew",
+        "Illicit",
+        "Modification",
+        "Title"
+      ],
       "shipActions": [
         { "difficulty": "White", "type": "Calculate" },
         { "difficulty": "White", "type": "Lock" },
@@ -55,7 +62,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/4lom.png",
       "standard": false,
       "extended": true,
-      "keywords": ["Bounty Hunter", "Droid"],
+      "keywords": [
+        "Bounty Hunter",
+        "Droid"
+      ],
       "epic": true
     },
     {
@@ -84,7 +94,14 @@
       "xws": "zuckuss",
       "ability": "While you perform a primary attack, you may roll 1 additional attack die. If you do, the defender rolls 1 additional defense die.",
       "image": "https://infinitearenas.com/xw2/images/pilots/zuckuss.png",
-      "slots": ["Talent", "Sensor", "Crew", "Illicit", "Modification", "Title"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Crew",
+        "Illicit",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/zuckuss.png",
       "standard": false,
       "extended": true,

--- a/data/pilots/scum-and-villainy/hwk-290-light-freighter.json
+++ b/data/pilots/scum-and-villainy/hwk-290-light-freighter.json
@@ -104,7 +104,10 @@
       "xws": "spicerunner",
       "text": "Though its cargo space is limited compared to other light freighters, the small, swift HWK-290 is a favorite choice of smugglers who specialize in discreetly transporting precious goods.",
       "image": "https://infinitearenas.com/xw2/images/pilots/spicerunner.png",
-      "slots": ["Device", "Illicit"],
+      "slots": [
+        "Device",
+        "Illicit"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/spicerunner.png",
       "standard": true,
       "extended": true,
@@ -121,7 +124,13 @@
       "xws": "torkilmux",
       "ability": "At the start of the Engagement Phase, you may choose 1 ship in your firing arc. If you do, that ship engages at initiative 0 instead of its normal initiative value this round.",
       "image": "https://infinitearenas.com/xw2/images/pilots/torkilmux.png",
-      "slots": ["Crew", "Device", "Illicit", "Modification", "Modification"],
+      "slots": [
+        "Crew",
+        "Device",
+        "Illicit",
+        "Modification",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/torkilmux.png",
       "standard": true,
       "extended": true,
@@ -161,7 +170,11 @@
       "caption": "Lost Padawan",
       "standard": true,
       "extended": true,
-      "keywords": ["Jedi", "Light Side", "Freighter"],
+      "keywords": [
+        "Jedi",
+        "Light Side",
+        "Freighter"
+      ],
       "force": { "value": 1, "recovers": 1 },
       "cost": 4,
       "loadout": 6,

--- a/data/pilots/scum-and-villainy/jumpmaster-5000.json
+++ b/data/pilots/scum-and-villainy/jumpmaster-5000.json
@@ -52,7 +52,11 @@
       "xws": "contractedscout",
       "text": "Built for long-distance reconnaissance and plotting new standard routes, the lightly armed JumpMaster 5000 is often extensively retrofitted with custom upgrades.",
       "image": "https://infinitearenas.com/xw2/images/pilots/contractedscout.png",
-      "slots": ["Cannon", "Torpedo", "Illicit"],
+      "slots": [
+        "Cannon",
+        "Torpedo",
+        "Illicit"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/contractedscout.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/scum-and-villainy/lancer-class-pursuit-craft.json
+++ b/data/pilots/scum-and-villainy/lancer-class-pursuit-craft.json
@@ -59,7 +59,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/asajjventress.png",
       "standard": false,
       "extended": true,
-      "keywords": ["Bounty Hunter", "Dark Side"],
+      "keywords": [
+        "Bounty Hunter",
+        "Dark Side"
+      ],
       "epic": true
     },
     {
@@ -83,7 +86,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ketsuonyo.png",
       "standard": false,
       "extended": true,
-      "keywords": ["Bounty Hunter", "Mandalorian"],
+      "keywords": [
+        "Bounty Hunter",
+        "Mandalorian"
+      ],
       "epic": true
     },
     {
@@ -107,7 +113,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/sabinewren-lancerclasspursuitcraft.png",
       "standard": false,
       "extended": true,
-      "keywords": ["Bounty Hunter", "Mandalorian"],
+      "keywords": [
+        "Bounty Hunter",
+        "Mandalorian"
+      ],
       "epic": true
     },
     {
@@ -119,7 +128,10 @@
       "xws": "shadowporthunter",
       "text": "Crime syndicates augment the lethal skills of their loyal contractors with the best technology available, like the fast and formidable Lancer-class pursuit craft.",
       "image": "https://infinitearenas.com/xw2/images/pilots/shadowporthunter.png",
-      "slots": ["Illicit", "Illicit"],
+      "slots": [
+        "Illicit",
+        "Illicit"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/shadowporthunter.png",
       "standard": false,
       "extended": true,

--- a/data/pilots/scum-and-villainy/m3-a-interceptor.json
+++ b/data/pilots/scum-and-villainy/m3-a-interceptor.json
@@ -69,7 +69,11 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "slots": ["Talent", "Illicit", "Modification"],
+      "slots": [
+        "Talent",
+        "Illicit",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/genesisred.png",
       "standard": true,
       "extended": true,
@@ -109,7 +113,10 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "slots": ["Talent", "Modification"],
+      "slots": [
+        "Talent",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/laetinashera.png",
       "standard": true,
       "extended": true,
@@ -129,7 +136,11 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "slots": ["Talent", "Cannon", "Modification"],
+      "slots": [
+        "Talent",
+        "Cannon",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/quinnjast.png",
       "standard": true,
       "extended": true,
@@ -150,7 +161,13 @@
         "name": "Weapon Hardpoint",
         "text": "You can equip 1 [Cannon], [Torpedo], or [Missile] upgrade."
       },
-      "slots": ["Talent", "Talent", "Cannon", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Cannon",
+        "Modification",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/serissu.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/scum-and-villainy/modified-tie-ln-fighter.json
+++ b/data/pilots/scum-and-villainy/modified-tie-ln-fighter.json
@@ -48,7 +48,12 @@
       },
       "image": "https://infinitearenas.com/xw2/images/pilots/ahhav.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/ahhav.png",
-      "slots": ["Talent", "Illicit", "Illicit", "Modification"],
+      "slots": [
+        "Talent",
+        "Illicit",
+        "Illicit",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -70,7 +75,11 @@
         "name": "Notched Stabilizers",
         "text": "While you move, you ignore asteroids."
       },
-      "slots": ["Talent", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -91,7 +100,11 @@
       },
       "image": "https://infinitearenas.com/xw2/images/pilots/foremanproach.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/foremanproach.png",
-      "slots": ["Talent", "Talent", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],
@@ -133,7 +146,10 @@
       "charges": { "value": 1, "recovers": 1 },
       "image": "https://infinitearenas.com/xw2/images/pilots/overseeryushyn.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/overseeryushyn.png",
-      "slots": ["Talent", "Modification"],
+      "slots": [
+        "Talent",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "keywords": ["TIE"],

--- a/data/pilots/scum-and-villainy/quadrijet-transfer-spacetug.json
+++ b/data/pilots/scum-and-villainy/quadrijet-transfer-spacetug.json
@@ -76,7 +76,10 @@
         "name": "Spacetug Tractor Array",
         "text": "Action: Choose a ship in your [Front Arc] at range 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in your [Bullseye Arc] at range 1."
       },
-      "slots": ["Device", "Illicit"],
+      "slots": [
+        "Device",
+        "Illicit"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/jakkugunrunner.png",
       "standard": false,
       "extended": true,
@@ -96,7 +99,14 @@
         "name": "Spacetug Tractor Array",
         "text": "Action: Choose a ship in your [Front Arc] at range 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in your [Bullseye Arc] at range 1."
       },
-      "slots": ["Crew", "Device", "Illicit", "Illicit", "Modification", "Tech"],
+      "slots": [
+        "Crew",
+        "Device",
+        "Illicit",
+        "Illicit",
+        "Modification",
+        "Tech"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/sarcoplank.png",
       "standard": false,
       "extended": true,
@@ -117,7 +127,13 @@
         "name": "Spacetug Tractor Array",
         "text": "Action: Choose a ship in your [Front Arc] at range 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in your [Bullseye Arc] at range 1."
       },
-      "slots": ["Crew", "Device", "Illicit", "Modification", "Tech"],
+      "slots": [
+        "Crew",
+        "Device",
+        "Illicit",
+        "Modification",
+        "Tech"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/unkarplutt.png",
       "standard": false,
       "extended": true,

--- a/data/pilots/scum-and-villainy/scurrg-h-6-bomber.json
+++ b/data/pilots/scum-and-villainy/scurrg-h-6-bomber.json
@@ -70,7 +70,12 @@
       "xws": "lokrevenant",
       "text": "The Nubian Design Collective crafted the Scurrg H-6 Bomber with combat versatility in mind, arming it with powerful shields and a bristling array of destructive weaponry.",
       "image": "https://infinitearenas.com/xw2/images/pilots/lokrevenant.png",
-      "slots": ["Turret", "Device", "Device", "Gunner"],
+      "slots": [
+        "Turret",
+        "Device",
+        "Device",
+        "Gunner"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lokrevenant.png",
       "standard": false,
       "extended": true,

--- a/data/pilots/scum-and-villainy/st-70-assault-ship.json
+++ b/data/pilots/scum-and-villainy/st-70-assault-ship.json
@@ -60,7 +60,10 @@
       "image": "https://infinitearenas.com/xw2/images/pilots/themandalorian.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/themandalorian.png",
       "loadout": 10,
-      "keywords": ["Mandalorian", "Bounty Hunter"],
+      "keywords": [
+        "Mandalorian",
+        "Bounty Hunter"
+      ],
       "standard": true,
       "extended": true,
       "epic": true
@@ -102,7 +105,14 @@
       "limited": 2,
       "cost": 6,
       "xws": "guildbountyhunter",
-      "slots": ["Talent", "Crew", "Gunner", "Illicit", "Illicit", "Modification"],
+      "slots": [
+        "Talent",
+        "Crew",
+        "Gunner",
+        "Illicit",
+        "Illicit",
+        "Modification"
+      ],
       "ability": "While you perform an attack at attack range 1-2, you may spend 1 non-recurring [Charge] from 1 of your equipped [Illicit] upgrades to change 1 [Focus] result to a [Critical Hit] result.",
       "image": "https://infinitearenas.com/xw2/images/pilots/guildbountyhunter.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/guildbountyhunter.png",
@@ -118,7 +128,13 @@
       "limited": 0,
       "cost": 6,
       "xws": "outerrimenforcer",
-      "slots": ["Crew", "Gunner", "Illicit", "Modification", "Modification"],
+      "slots": [
+        "Crew",
+        "Gunner",
+        "Illicit",
+        "Modification",
+        "Modification"
+      ],
       "text": "Designed as a military craft, the ST-70 assault ship is a durable and versatile vessel. For someone travelling in the Outer Rim, this ship can be a transport, combat craft, and home all in one.",
       "image": "https://infinitearenas.com/xw2/images/pilots/outerrimenforcer.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/outerrimenforcer.png",

--- a/data/pilots/scum-and-villainy/starviper-class-attack-platform.json
+++ b/data/pilots/scum-and-villainy/starviper-class-attack-platform.json
@@ -96,7 +96,12 @@
         "name": "Microthrusters",
         "text": "While you perform a barrel roll, you must use the [Bank Left] or [Bank Right] template instead of the [Straight] template."
       },
-      "slots": ["Talent", "Tech", "Torpedo", "Modification"],
+      "slots": [
+        "Talent",
+        "Tech",
+        "Torpedo",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dalanoberos-starviperclassattackplatform.png",
       "standard": false,
       "extended": true,
@@ -131,7 +136,13 @@
         "name": "Microthrusters",
         "text": "While you perform a barrel roll, you must use the [Bank Left] or [Bank Right] template instead of the [Straight] template."
       },
-      "slots": ["Talent", "Tech", "Torpedo", "Modification", "Title"],
+      "slots": [
+        "Talent",
+        "Tech",
+        "Torpedo",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/guri.png",
       "standard": false,
       "extended": true,
@@ -152,7 +163,13 @@
         "name": "Microthrusters",
         "text": "While you perform a barrel roll, you must use the [Bank Left] or [Bank Right] template instead of the [Straight] template."
       },
-      "slots": ["Talent", "Tech", "Torpedo", "Modification", "Title"],
+      "slots": [
+        "Talent",
+        "Tech",
+        "Torpedo",
+        "Modification",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/princexizor.png",
       "standard": false,
       "extended": true,

--- a/data/pilots/scum-and-villainy/yv-666-light-freighter.json
+++ b/data/pilots/scum-and-villainy/yv-666-light-freighter.json
@@ -58,7 +58,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bossk.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Bounty Hunter", "Freighter"],
+      "keywords": [
+        "Bounty Hunter",
+        "Freighter"
+      ],
       "epic": true
     },
     {
@@ -85,7 +88,10 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/lattsrazzi.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Bounty Hunter", "Freighter"],
+      "keywords": [
+        "Bounty Hunter",
+        "Freighter"
+      ],
       "epic": true
     },
     {
@@ -124,7 +130,11 @@
       "xws": "trandoshanslaver",
       "text": "The spacious triple-decker design of the YV-666 makes it popular among bounty hunters and slavers, who often retrofit an entire deck for prisoner transport.",
       "image": "https://infinitearenas.com/xw2/images/pilots/trandoshanslaver.png",
-      "slots": ["Cannon", "Missile", "Modification"],
+      "slots": [
+        "Cannon",
+        "Missile",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/trandoshanslaver.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/scum-and-villainy/z-95-af4-headhunter.json
+++ b/data/pilots/scum-and-villainy/z-95-af4-headhunter.json
@@ -59,7 +59,10 @@
       "xws": "blacksunsoldier",
       "text": "The vast and influential Black Sun crime syndicate can always find a use for talented pilots, provided they aren't particular about how they earn their credits.",
       "image": "https://infinitearenas.com/xw2/images/pilots/blacksunsoldier.png",
-      "slots": ["Illicit", "Modification"],
+      "slots": [
+        "Illicit",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/blacksunsoldier.png",
       "standard": true,
       "extended": true,
@@ -75,7 +78,12 @@
       "xws": "kaatoleeachos",
       "ability": "At the start of the Engagement Phase, you may choose 1 friendly ship at range 0-2. If you do, transfer 1 focus or evade token from that ship to yourself.",
       "image": "https://infinitearenas.com/xw2/images/pilots/kaatoleeachos.png",
-      "slots": ["Talent", "Missile", "Illicit", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Illicit",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/kaatoleeachos.png",
       "standard": true,
       "extended": true,
@@ -134,7 +142,13 @@
         "name": "Pursuit Craft",
         "text": "After you deploy, you may acquire a lock on a ship the friendly Hound's Tooth has locked."
       },
-      "slots": ["Talent", "Talent", "Missile", "Illicit", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Missile",
+        "Illicit",
+        "Modification"
+      ],
       "standard": true,
       "extended": true,
       "cost": 2,

--- a/data/pilots/separatist-alliance/belbullab-22-starfighter.json
+++ b/data/pilots/separatist-alliance/belbullab-22-starfighter.json
@@ -58,7 +58,13 @@
       "extended": true,
       "cost": 5,
       "loadout": 11,
-      "slots": ["Talent", "Modification", "Modification", "Missile", "Title"],
+      "slots": [
+        "Talent",
+        "Modification",
+        "Modification",
+        "Missile",
+        "Title"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/generalgrievous.png",
       "epic": true
     },
@@ -74,7 +80,12 @@
       "extended": true,
       "cost": 4,
       "loadout": 9,
-      "slots": ["Talent", "Modification", "Modification", "Tactical Relay"],
+      "slots": [
+        "Talent",
+        "Modification",
+        "Modification",
+        "Tactical Relay"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/wattambor.png",
       "epic": true
     },
@@ -103,7 +114,10 @@
       "extended": true,
       "cost": 4,
       "loadout": 5,
-      "slots": ["Modification", "Tactical Relay"],
+      "slots": [
+        "Modification",
+        "Tactical Relay"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/feethanottrawautopilot.png",
       "keywords": ["Droid"],
       "epic": true
@@ -120,7 +134,11 @@
       "extended": true,
       "cost": 5,
       "loadout": 17,
-      "slots": ["Modification", "Modification", "Tactical Relay"],
+      "slots": [
+        "Modification",
+        "Modification",
+        "Tactical Relay"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/captainsear.png",
       "epic": true
     },
@@ -129,7 +147,11 @@
       "xws": "skakoanace",
       "cost": 4,
       "loadout": 4,
-      "slots": ["Talent", "Modification", "Modification"],
+      "slots": [
+        "Talent",
+        "Modification",
+        "Modification"
+      ],
       "initiative": 3,
       "limited": 0,
       "image": "https://infinitearenas.com/xw2/images/pilots/skakoanace.png",

--- a/data/pilots/separatist-alliance/droid-tri-fighter.json
+++ b/data/pilots/separatist-alliance/droid-tri-fighter.json
@@ -90,7 +90,14 @@
       "loadout": 6,
       "image": "https://infinitearenas.com/xw2/images/pilots/phlacarphoccprototype.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/phlacarphoccprototype.png",
-      "slots": ["Talent", "Sensor", "Missile", "Modification", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Missile",
+        "Modification",
+        "Modification",
+        "Configuration"
+      ],
       "keywords": ["Droid"],
       "epic": true
     },
@@ -112,7 +119,14 @@
       "loadout": 3,
       "image": "https://infinitearenas.com/xw2/images/pilots/fearsomepredator.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/fearsomepredator.png",
-      "slots": ["Talent", "Sensor", "Missile", "Modification", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Missile",
+        "Modification",
+        "Modification",
+        "Configuration"
+      ],
       "keywords": ["Droid"],
       "epic": true
     },
@@ -133,7 +147,14 @@
       "loadout": 4,
       "image": "https://infinitearenas.com/xw2/images/pilots/dis347.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dis347.png",
-      "slots": ["Talent", "Sensor", "Missile", "Modification", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Sensor",
+        "Missile",
+        "Modification",
+        "Modification",
+        "Configuration"
+      ],
       "keywords": ["Droid"],
       "epic": true
     },
@@ -153,7 +174,12 @@
       "loadout": 3,
       "image": "https://infinitearenas.com/xw2/images/pilots/separatistinterceptor.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/separatistinterceptor.png",
-      "slots": ["Talent", "Missile", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Modification",
+        "Configuration"
+      ],
       "keywords": ["Droid"],
       "epic": true
     },
@@ -173,7 +199,11 @@
       "loadout": 4,
       "image": "https://infinitearenas.com/xw2/images/pilots/colicoidinterceptor.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/colicoidinterceptor.png",
-      "slots": ["Talent", "Modification", "Configuration"],
+      "slots": [
+        "Talent",
+        "Modification",
+        "Configuration"
+      ],
       "keywords": ["Droid"],
       "epic": true
     },
@@ -190,7 +220,11 @@
         "text": "While you defend or perform an attack, you may spend 1 calculate token from a friendly ship at range 0-1 to change 1 [Focus] result to an [Evade] or [Hit] result."
       },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/dis347-siegeofcoruscant.png",
-      "standardLoadout": ["marksmanship", "afterburners", "contingencyprotocol-siegeofcoruscant"],
+      "standardLoadout": [
+        "marksmanship",
+        "afterburners",
+        "contingencyprotocol-siegeofcoruscant"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dis347.png",
       "standard": true,
       "extended": true,
@@ -210,7 +244,11 @@
         "text": "While you defend or perform an attack, you may spend 1 calculate token from a friendly ship at range 0-1 to change 1 [Focus] result to an [Evade] or [Hit] result."
       },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/dist81-siegeofcoruscant.png",
-      "standardLoadout": ["outmaneuver", "afterburners", "contingencyprotocol-siegeofcoruscant"],
+      "standardLoadout": [
+        "outmaneuver",
+        "afterburners",
+        "contingencyprotocol-siegeofcoruscant"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dist81.png",
       "standard": true,
       "extended": true,
@@ -230,7 +268,11 @@
         "text": "While you defend or perform an attack, you may spend 1 calculate token from a friendly ship at range 0-1 to change 1 [Focus] result to an [Evade] or [Hit] result."
       },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/phlacarphoccprototype-siegeofcoruscant.png",
-      "standardLoadout": ["afterburners", "contingencyprotocol-siegeofcoruscant", "evasionsequence7-siegeofcoruscant"],
+      "standardLoadout": [
+        "afterburners",
+        "contingencyprotocol-siegeofcoruscant",
+        "evasionsequence7-siegeofcoruscant"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/phlacarphoccprototype.png",
       "standard": true,
       "extended": true,
@@ -269,7 +311,12 @@
       "loadout": 12,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/volandas.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/volandas.png",
-      "slots": ["Talent", "Missile", "Illicit", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Illicit",
+        "Modification"
+      ],
       "keywords": ["Bounty Hunter"],
       "epic": true
     }

--- a/data/pilots/separatist-alliance/firespray-class-patrol-craft.json
+++ b/data/pilots/separatist-alliance/firespray-class-patrol-craft.json
@@ -71,7 +71,10 @@
       "initiative": 5,
       "limited": 1,
       "caption": "Clawdite Changeling",
-      "conditions": ["youdbettermeanbusiness", "youshouldthankme"],
+      "conditions": [
+        "youdbettermeanbusiness",
+        "youshouldthankme"
+      ],
       "standard": true,
       "extended": true,
       "ability": "Setup: Lose 2 [Charge]. During the System Phase, you may assign 1 of your secret conditions to yourself facedown: “You Should Thank Me” or “You'd Better Mean Business”",
@@ -129,7 +132,11 @@
       "loadout": 10,
       "image": "https://infinitearenas.com/xw2/images/pilots/separatistracketeer.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/separatistracketeer.png",
-      "slots": ["Cannon", "Missile", "Device"],
+      "slots": [
+        "Cannon",
+        "Missile",
+        "Device"
+      ],
       "epic": true
     },
     {
@@ -155,7 +162,10 @@
         "Modification",
         "Title"
       ],
-      "keywords": ["Dark Side", "Bounty Hunter"],
+      "keywords": [
+        "Dark Side",
+        "Bounty Hunter"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/separatist-alliance/hmp-droid-gunship.json
+++ b/data/pilots/separatist-alliance/hmp-droid-gunship.json
@@ -74,7 +74,12 @@
       "initiative": 1,
       "cost": 4,
       "loadout": 8,
-      "slots": ["Missile", "Device", "Modification", "Configuration"],
+      "slots": [
+        "Missile",
+        "Device",
+        "Modification",
+        "Configuration"
+      ],
       "limited": 0,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/baktoiddrone.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/baktoiddrone.png",
@@ -153,7 +158,14 @@
       "initiative": 3,
       "cost": 4,
       "loadout": 15,
-      "slots": ["Missile", "Missile", "Crew", "Device", "Modification", "Configuration"],
+      "slots": [
+        "Missile",
+        "Missile",
+        "Crew",
+        "Device",
+        "Modification",
+        "Configuration"
+      ],
       "limited": 2,
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/onderonoppressor.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/onderonoppressor.png",

--- a/data/pilots/separatist-alliance/hyena-class-droid-bomber.json
+++ b/data/pilots/separatist-alliance/hyena-class-droid-bomber.json
@@ -53,7 +53,12 @@
       "extended": true,
       "cost": 3,
       "loadout": 6,
-      "slots": ["Torpedo", "Device", "Modification", "Configuration"],
+      "slots": [
+        "Torpedo",
+        "Device",
+        "Modification",
+        "Configuration"
+      ],
       "text": "Baktoid Armor Workshop developed the Hyena as a strike craft compatible with Trade Federation Vulture swarm tactics.",
       "image": "https://infinitearenas.com/xw2/images/pilots/technounionbomber.png",
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/technounionbomber.png",
@@ -76,7 +81,12 @@
       "extended": true,
       "cost": 3,
       "loadout": 8,
-      "slots": ["Device", "Device", "Modification", "Configuration"],
+      "slots": [
+        "Device",
+        "Device",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/bombardmentdrone.png",
       "keywords": ["Droid"],
       "epic": true
@@ -150,7 +160,12 @@
       "extended": true,
       "cost": 3,
       "loadout": 4,
-      "slots": ["Missile", "Device", "Modification", "Configuration"],
+      "slots": [
+        "Missile",
+        "Device",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/separatistbomber.png",
       "keywords": ["Droid"],
       "epic": true
@@ -181,7 +196,12 @@
       "extended": true,
       "cost": 4,
       "loadout": 16,
-      "slots": ["Sensor", "Tactical Relay", "Modification", "Configuration"],
+      "slots": [
+        "Sensor",
+        "Tactical Relay",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dbs32c.png",
       "keywords": ["Droid"],
       "epic": true
@@ -210,7 +230,11 @@
         { "difficulty": "Red", "type": "Jam" }
       ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/dbs32c-siegeofcoruscant.png",
-      "standardLoadout": ["plasmatorpedoes", "contingencyprotocol-siegeofcoruscant", "strutlockoverride-siegeofcoruscant"],
+      "standardLoadout": [
+        "plasmatorpedoes",
+        "contingencyprotocol-siegeofcoruscant",
+        "strutlockoverride-siegeofcoruscant"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dbs32c.png",
       "standard": true,
       "extended": true,
@@ -230,7 +254,11 @@
         "text": "While you defend or perform an attack, you may spend 1 calculate token from a friendly ship at range 0-1 to change 1 [Focus] result to an [Evade] or [Hit] result."
       },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/dbs404-siegeofcoruscant.png",
-      "standardLoadout": ["advprotontorpedoes", "contingencyprotocol-siegeofcoruscant", "strutlockoverride-siegeofcoruscant"],
+      "standardLoadout": [
+        "advprotontorpedoes",
+        "contingencyprotocol-siegeofcoruscant",
+        "strutlockoverride-siegeofcoruscant"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dbs404.png",
       "standard": true,
       "extended": true,
@@ -250,7 +278,11 @@
         "text": "While you defend or perform an attack, you may spend 1 calculate token from a friendly ship at range 0-1 to change 1 [Focus] result to an [Evade] or [Hit] result."
       },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/baktoidprototype-siegeofcoruscant.png",
-      "standardLoadout": ["homingmissiles", "contingencyprotocol-siegeofcoruscant", "strutlockoverride-siegeofcoruscant"],
+      "standardLoadout": [
+        "homingmissiles",
+        "contingencyprotocol-siegeofcoruscant",
+        "strutlockoverride-siegeofcoruscant"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/baktoidprototype.png",
       "standard": true,
       "extended": true,

--- a/data/pilots/separatist-alliance/nantex-class-starfighter.json
+++ b/data/pilots/separatist-alliance/nantex-class-starfighter.json
@@ -72,7 +72,12 @@
       "ability": "While you perform a primary attack, if the defender is tractored, roll 1 additional attack die.",
       "cost": 5,
       "loadout": 15,
-      "slots": ["Talent", "Talent", "Talent", "Modification"],
+      "slots": [
+        "Talent",
+        "Talent",
+        "Talent",
+        "Modification"
+      ],
       "epic": true
     },
     {
@@ -92,7 +97,10 @@
       "ability": "After you perform an attack that hits, each friendly ship with [Calculate] on its action bar and a lock on the defender may perform a red [Calculate] action.",
       "cost": 4,
       "loadout": 7,
-      "slots": ["Talent", "Talent"],
+      "slots": [
+        "Talent",
+        "Talent"
+      ],
       "epic": true
     },
     {
@@ -112,7 +120,10 @@
       "ability": "While you perform a primary attack, if the defender is tractored, you may reroll up to 2 attack dice.",
       "cost": 4,
       "loadout": 10,
-      "slots": ["Talent", "Talent"],
+      "slots": [
+        "Talent",
+        "Talent"
+      ],
       "epic": true
     },
     {
@@ -131,7 +142,10 @@
       "ability": "During the System Phase, you may gain 1 disarm token and choose a friendly ship at range 1-2. If you do, it gains 1 tractor token, then repairs 1 of its faceup Ship trait damage cards.",
       "standard": true,
       "extended": true,
-      "slots": ["Talent", "Modification"],
+      "slots": [
+        "Talent",
+        "Modification"
+      ],
       "xws": "gorgol",
       "epic": true
     },
@@ -150,7 +164,10 @@
       "standard": true,
       "extended": true,
       "limited": 0,
-      "slots": ["Talent", "Talent"],
+      "slots": [
+        "Talent",
+        "Talent"
+      ],
       "xws": "petranakiarenaace",
       "epic": true
     }

--- a/data/pilots/separatist-alliance/rogue-class-starfighter.json
+++ b/data/pilots/separatist-alliance/rogue-class-starfighter.json
@@ -91,7 +91,12 @@
       "cost": 4,
       "loadout": 11,
       "xws": "ig101",
-      "slots": ["Cannon", "Cannon", "Modification", "Modification"],
+      "slots": [
+        "Cannon",
+        "Cannon",
+        "Modification",
+        "Modification"
+      ],
       "ability": "At the start of the System Phase, you may repair 1 faceup damage card.",
       "shipAbility": {
         "name": "Networked Calculations",
@@ -130,7 +135,11 @@
       "cost": 4,
       "loadout": 6,
       "xws": "magnaguardexecutioner",
-      "slots": ["Cannon", "Cannon", "Modification"],
+      "slots": [
+        "Cannon",
+        "Cannon",
+        "Modification"
+      ],
       "text": "In addition to guarding Separatist leaders, MagneGuard droids are sometimes dispatched in swift Rogue-class Starfighters to eliminate their enemies.",
       "shipAbility": {
         "name": "Networked Calculations",
@@ -170,7 +179,12 @@
       "cost": 4,
       "loadout": 10,
       "xws": "magnaguardprotector",
-      "slots": ["Cannon", "Cannon", "Modification", "Missile"],
+      "slots": [
+        "Cannon",
+        "Cannon",
+        "Modification",
+        "Missile"
+      ],
       "ability": "After placing forces, assign the Guarded condition to 1 friendly ship other than MagnaGuard Protector.",
       "shipAbility": {
         "name": "Networked Calculations",
@@ -210,7 +224,12 @@
       "cost": 4,
       "loadout": 11,
       "xws": "ig102",
-      "slots": ["Cannon", "Cannon", "Modification", "Modification"],
+      "slots": [
+        "Cannon",
+        "Cannon",
+        "Modification",
+        "Modification"
+      ],
       "ability": "While you defend, if the attacker's initiative is equal to or greater than yours, you may change 1 blank result to a [Focus] result.",
       "shipAbility": {
         "name": "Networked Calculations",
@@ -250,7 +269,12 @@
       "cost": 4,
       "loadout": 12,
       "xws": "ig111",
-      "slots": ["Cannon", "Cannon", "Modification", "Modification"],
+      "slots": [
+        "Cannon",
+        "Cannon",
+        "Modification",
+        "Modification"
+      ],
       "ability": "After you perform an attack that missed, you may choose 1 enemy ship in your [Bullseye Arc] and gain 1 deplete token. If you do, that ship suffers 1 [Hit] damage.",
       "shipAbility": {
         "name": "Networked Calculations",

--- a/data/pilots/separatist-alliance/sith-infiltrator.json
+++ b/data/pilots/separatist-alliance/sith-infiltrator.json
@@ -64,7 +64,10 @@
         "Tactical Relay"
       ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/darthmaul.png",
-      "keywords": ["Dark Side", "Sith"],
+      "keywords": [
+        "Dark Side",
+        "Sith"
+      ],
       "epic": true
     },
     {
@@ -92,7 +95,10 @@
         "Tactical Relay"
       ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/countdooku.png",
-      "keywords": ["Dark Side", "Sith"],
+      "keywords": [
+        "Dark Side",
+        "Sith"
+      ],
       "epic": true
     },
     {
@@ -106,7 +112,12 @@
       "extended": true,
       "cost": 6,
       "loadout": 9,
-      "slots": ["Cannon", "Torpedo", "Device", "Modification"],
+      "slots": [
+        "Cannon",
+        "Torpedo",
+        "Device",
+        "Modification"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/darkcourier.png",
       "epic": true
     },
@@ -156,11 +167,18 @@
       ],
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/countdooku-siegeofcoruscant.png",
       "force": { "value": 3, "recovers": 1, "side": ["dark"] },
-      "standardLoadout": ["malice", "roilinganger-siegeofcoruscant", "scimitar"],
+      "standardLoadout": [
+        "malice",
+        "roilinganger-siegeofcoruscant",
+        "scimitar"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/countdooku.png",
       "standard": true,
       "extended": true,
-      "keywords": ["Dark Side", "Sith"],
+      "keywords": [
+        "Dark Side",
+        "Sith"
+      ],
       "epic": true
     }
   ]

--- a/data/pilots/separatist-alliance/vulture-class-droid-fighter.json
+++ b/data/pilots/separatist-alliance/vulture-class-droid-fighter.json
@@ -54,7 +54,10 @@
       "extended": true,
       "cost": 2,
       "loadout": 0,
-      "slots": ["Modification", "Configuration"],
+      "slots": [
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/tradefederationdrone.png",
       "keywords": ["Droid"],
       "epic": true
@@ -75,7 +78,11 @@
       "extended": true,
       "cost": 3,
       "loadout": 8,
-      "slots": ["Cannon", "Modification", "Configuration"],
+      "slots": [
+        "Cannon",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/precisehunter.png",
       "keywords": ["Droid"],
       "epic": true
@@ -96,7 +103,11 @@
       "extended": true,
       "cost": 2,
       "loadout": 4,
-      "slots": ["Missile", "Modification", "Configuration"],
+      "slots": [
+        "Missile",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/haorchallprototype.png",
       "keywords": ["Droid"],
       "epic": true
@@ -117,7 +128,11 @@
       "extended": true,
       "cost": 2,
       "loadout": 7,
-      "slots": ["Missile", "Modification", "Configuration"],
+      "slots": [
+        "Missile",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dfs081.png",
       "keywords": ["Droid"],
       "epic": true
@@ -137,7 +152,11 @@
       "extended": true,
       "cost": 2,
       "loadout": 3,
-      "slots": ["Missile", "Modification", "Configuration"],
+      "slots": [
+        "Missile",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/separatistdrone.png",
       "keywords": ["Droid"],
       "epic": true
@@ -158,7 +177,12 @@
       "extended": true,
       "cost": 3,
       "loadout": 10,
-      "slots": ["Missile", "Modification", "Modification", "Configuration"],
+      "slots": [
+        "Missile",
+        "Modification",
+        "Modification",
+        "Configuration"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dfs311.png",
       "keywords": ["Droid"],
       "epic": true
@@ -177,7 +201,11 @@
         "text": "While you defend or perform an attack, you may spend 1 calculate token from a friendly ship at range 0-1 to change 1 [Focus] result to an [Evade] or [Hit] result."
       },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/dfs081-siegeofcoruscant.png",
-      "standardLoadout": ["discordmissiles", "contingencyprotocol-siegeofcoruscant", "strutlockoverride-siegeofcoruscant"],
+      "standardLoadout": [
+        "discordmissiles",
+        "contingencyprotocol-siegeofcoruscant",
+        "strutlockoverride-siegeofcoruscant"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dfs081.png",
       "standard": true,
       "extended": true,
@@ -197,7 +225,11 @@
         "text": "While you defend or perform an attack, you may spend 1 calculate token from a friendly ship at range 0-1 to change 1 [Focus] result to an [Evade] or [Hit] result."
       },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/dfs311-siegeofcoruscant.png",
-      "standardLoadout": ["discordmissiles", "contingencyprotocol-siegeofcoruscant", "strutlockoverride-siegeofcoruscant"],
+      "standardLoadout": [
+        "discordmissiles",
+        "contingencyprotocol-siegeofcoruscant",
+        "strutlockoverride-siegeofcoruscant"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dfs311.png",
       "standard": true,
       "extended": true,
@@ -217,7 +249,11 @@
         "text": "While you defend or perform an attack, you may spend 1 calculate token from a friendly ship at range 0-1 to change 1 [Focus] result to an [Evade] or [Hit] result."
       },
       "image": "https://infinitearenas.com/xw2/images/quickbuilds/haorchallprototype-siegeofcoruscant.png",
-      "standardLoadout": ["ionmissiles", "contingencyprotocol-siegeofcoruscant", "strutlockoverride-siegeofcoruscant"],
+      "standardLoadout": [
+        "ionmissiles",
+        "contingencyprotocol-siegeofcoruscant",
+        "strutlockoverride-siegeofcoruscant"
+      ],
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/haorchallprototype.png",
       "standard": true,
       "extended": true,
@@ -242,7 +278,12 @@
       "cost": 2,
       "loadout": 5,
       "charges": { "value": 3, "recovers": 0 },
-      "slots": ["Missile", "Modification", "Modification", "Configuration"],
+      "slots": [
+        "Missile",
+        "Modification",
+        "Modification",
+        "Configuration"
+      ],
       "keywords": ["Droid"],
       "epic": true
     },
@@ -272,7 +313,11 @@
       "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/kelrodoaiholdout.png",
       "cost": 2,
       "loadout": 7,
-      "slots": ["Talent", "Missile", "Modification"],
+      "slots": [
+        "Talent",
+        "Missile",
+        "Modification"
+      ],
       "epic": true
     }
   ]

--- a/data/quick-builds/first-order.json
+++ b/data/quick-builds/first-order.json
@@ -51,7 +51,10 @@
         {
           "id": "longshot",
           "upgrades": {
-            "talent": ["elusive", "predator"]
+            "talent": [
+              "elusive",
+              "predator"
+            ]
           }
         }
       ]
@@ -62,7 +65,10 @@
         {
           "id": "omegasquadronace",
           "upgrades": {
-            "talent": ["elusive", "fanatical"],
+            "talent": [
+              "elusive",
+              "fanatical"
+            ],
             "modification": ["hullupgrade"]
           }
         }
@@ -131,7 +137,10 @@
           "id": "null",
           "upgrades": {
             "talent": ["swarmtactics"],
-            "modification": ["afterburners", "shieldupgrade"]
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -145,7 +154,10 @@
             "talent": ["juke"],
             "sensor": ["collisiondetector"],
             "gunner": ["hotshotgunner"],
-            "modification": ["afterburners", "shieldupgrade"]
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -209,7 +221,10 @@
         {
           "id": "kyloren",
           "upgrades": {
-            "force-power": ["hate", "predictiveshot"],
+            "force-power": [
+              "hate",
+              "predictiveshot"
+            ],
             "tech": ["primedthrusters"],
             "torpedo": ["advprotontorpedoes"]
           }
@@ -318,7 +333,10 @@
           "upgrades": {
             "sensor": ["advancedsensors"],
             "cannon": ["ioncannon"],
-            "crew": ["kyloren", "supremeleadersnoke"],
+            "crew": [
+              "kyloren",
+              "supremeleadersnoke"
+            ],
             "modification": ["shieldupgrade"]
           }
         }
@@ -330,7 +348,10 @@
         {
           "id": "lieutenantdormitz",
           "upgrades": {
-            "tech": ["biohexacryptcodes", "hyperspacetrackingdata"],
+            "tech": [
+              "biohexacryptcodes",
+              "hyperspacetrackingdata"
+            ],
             "cannon": ["tractorbeam"]
           }
         }
@@ -350,8 +371,14 @@
         {
           "id": "majorstridan",
           "upgrades": {
-            "tech": ["biohexacryptcodes", "patternanalyzer"],
-            "crew": ["captainphasma", "generalhux"],
+            "tech": [
+              "biohexacryptcodes",
+              "patternanalyzer"
+            ],
+            "crew": [
+              "captainphasma",
+              "generalhux"
+            ],
             "cannon": ["tractorbeam"]
           }
         }
@@ -439,7 +466,10 @@
         {
           "id": "ember",
           "upgrades": {
-            "talent": ["predator", "elusive"],
+            "talent": [
+              "predator",
+              "elusive"
+            ],
             "missile": ["concussionmissiles"],
             "modification": ["afterburners"]
           }
@@ -454,7 +484,10 @@
           "upgrades": {
             "talent": ["proudtradition"],
             "missile": ["magpulsewarheads"],
-            "modification": ["hullupgrade", "munitionsfailsafe"]
+            "modification": [
+              "hullupgrade",
+              "munitionsfailsafe"
+            ]
           }
         }
       ]
@@ -506,7 +539,7 @@
             "talent": ["elusive"],
             "torpedo": ["protontorpedoes"],
             "tech": ["advancedoptics"],
-			"modification": ["engineupgrade"]
+            "modification": ["engineupgrade"]
           }
         }
       ]
@@ -520,8 +553,8 @@
             "talent": ["feedbackping"],
             "device": ["concussionbombs"],
             "tech": ["primedthrusters"],
-			"modification": ["delayedfuses"],
-			"gunner": ["dt798"]
+            "modification": ["delayedfuses"],
+            "gunner": ["dt798"]
           }
         }
       ]
@@ -535,7 +568,7 @@
             "talent": ["outmaneuver"],
             "missile": ["protonrockets"],
             "torpedo": ["iontorpedoes"],
-			"modification": ["engineupgrade"]
+            "modification": ["engineupgrade"]
           }
         }
       ]
@@ -549,7 +582,7 @@
             "talent": ["predator"],
             "missile": ["electrochaffmissiles"],
             "gunner": ["suppressivegunner"],
-			"modification": ["shieldupgrade"]
+            "modification": ["shieldupgrade"]
           }
         }
       ]
@@ -600,7 +633,7 @@
             "talent": ["predator"],
             "force-power": ["malice"],
             "configuration": ["enhancedjammingsuite"],
-			"missile": ["clustermissiles"]
+            "missile": ["clustermissiles"]
           }
         }
       ]
@@ -611,10 +644,13 @@
         {
           "id": "whirlwind",
           "upgrades": {
-            "talent": ["elusive", "ionlimiteroverride"],
+            "talent": [
+              "elusive",
+              "ionlimiteroverride"
+            ],
             "tech": ["sensorscramblers"],
             "missile": ["protonrockets"],
-			"modification": ["hullupgrade"]
+            "modification": ["hullupgrade"]
           }
         }
       ]
@@ -639,7 +675,11 @@
           "id": "agentterex",
           "upgrades": {
             "crew": ["commandermalarus"],
-            "illicit": ["deadmansswitch", "contrabandcybernetics", "inertialdampeners"]
+            "illicit": [
+              "deadmansswitch",
+              "contrabandcybernetics",
+              "inertialdampeners"
+            ]
           }
         }
       ]
@@ -652,8 +692,8 @@
           "upgrades": {
             "talent": ["snapshot"],
             "crew": ["agentterex"],
-			"tech": ["sensorbuoysuite"],
-			"modification": ["hullupgrade"]
+            "tech": ["sensorbuoysuite"],
+            "modification": ["hullupgrade"]
           }
         }
       ]
@@ -666,8 +706,8 @@
           "upgrades": {
             "talent": ["deadeyeshot"],
             "tech": ["sensorbuoysuite"],
-			"crew": ["commanderpyre"],
-			"illicit": ["riggedcargochute"]
+            "crew": ["commanderpyre"],
+            "illicit": ["riggedcargochute"]
           }
         }
       ]
@@ -680,7 +720,7 @@
           "upgrades": {
             "crew": ["tacticalofficer"],
             "tech": ["automatedtargetpriority"],
-			"modification": ["shieldupgrade"]
+            "modification": ["shieldupgrade"]
           }
         }
       ]
@@ -693,8 +733,11 @@
           "upgrades": {
             "command": ["strategiccommander"],
             "hardpoint": ["pointdefensebattery"],
-			"team": ["damagecontrolteam", "gunneryspecialists"],
-			"cargo": ["adaptiveshields"]
+            "team": [
+              "damagecontrolteam",
+              "gunneryspecialists"
+            ],
+            "cargo": ["adaptiveshields"]
           }
         }
       ]
@@ -706,10 +749,16 @@
           "id": "firstordercollaborators",
           "upgrades": {
             "command": ["stalwartcaptain"],
-            "hardpoint": ["ioncannonbattery", "pointdefensebattery"],
-			"crew": ["novicetechnician"],
-			"team": ["bombardmentspecialists", "commsteam"],
-			"cargo": ["boostedscanners"]
+            "hardpoint": [
+              "ioncannonbattery",
+              "pointdefensebattery"
+            ],
+            "crew": ["novicetechnician"],
+            "team": [
+              "bombardmentspecialists",
+              "commsteam"
+            ],
+            "cargo": ["boostedscanners"]
           }
         }
       ]

--- a/data/quick-builds/galactic-empire.json
+++ b/data/quick-builds/galactic-empire.json
@@ -19,7 +19,10 @@
           "id": "blacksquadronace",
           "upgrades": {
             "talent": ["outmaneuver"],
-            "modification": ["afterburners", "shieldupgrade"]
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -52,7 +55,7 @@
           "upgrades": {
             "talent": ["lonewolf"],
             "torpedo": ["protontorpedoes"],
-			"modification": ["targetingcomputer"]
+            "modification": ["targetingcomputer"]
           }
         }
       ]
@@ -64,7 +67,10 @@
           "id": "nightbeast",
           "upgrades": {
             "talent": ["predator"],
-            "modification": ["hullupgrade", "shieldupgrade"]
+            "modification": [
+              "hullupgrade",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -96,7 +102,10 @@
           "id": "wampa",
           "upgrades": {
             "talent": ["crackshot"],
-            "modification": ["hullupgrade", "stealthdevice"]
+            "modification": [
+              "hullupgrade",
+              "stealthdevice"
+            ]
           }
         }
       ]
@@ -108,7 +117,10 @@
           "id": "blacksquadronace",
           "upgrades": {
             "talent": ["crackshot"],
-            "modification": ["afterburners", "shieldupgrade"]
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -219,7 +231,10 @@
             "force-power": ["supernaturalreflexes"],
             "missile": ["clustermissiles"],
             "sensor": ["firecontrolsystem"],
-            "modification": ["afterburners", "shieldupgrade"]
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -297,7 +312,10 @@
             "title": ["st321"],
             "cannon": ["ioncannon"],
             "sensor": ["collisiondetector"],
-            "crew": ["darthvader", "freelanceslicer"]
+            "crew": [
+              "darthvader",
+              "freelanceslicer"
+            ]
           }
         }
       ]
@@ -311,7 +329,10 @@
             "cannon": ["tractorbeam"],
             "sensor": ["collisiondetector"],
             "crew": ["emperorpalpatine"],
-            "modification": ["shieldupgrade", "staticdischargevanes"]
+            "modification": [
+              "shieldupgrade",
+              "staticdischargevanes"
+            ]
           }
         }
       ]
@@ -324,7 +345,10 @@
           "upgrades": {
             "cannon": ["jammingbeam"],
             "sensor": ["advancedsensors"],
-            "crew": ["cienaree", "gnkgonkdroid"]
+            "crew": [
+              "cienaree",
+              "gnkgonkdroid"
+            ]
           }
         }
       ]
@@ -454,7 +478,10 @@
           "upgrades": {
             "talent": ["outmaneuver"],
             "device": ["connernets"],
-            "modification": ["afterburners", "hullupgrade"]
+            "modification": [
+              "afterburners",
+              "hullupgrade"
+            ]
           }
         }
       ]
@@ -689,7 +716,10 @@
           "upgrades": {
             "missile": ["clustermissiles"],
             "gunner": ["skilledbombardier"],
-            "device": ["seismiccharges", "proximitymines"],
+            "device": [
+              "seismiccharges",
+              "proximitymines"
+            ],
             "modification": ["electronicbaffle"]
           }
         }
@@ -833,7 +863,10 @@
           "id": "soontirfel",
           "upgrades": {
             "talent": ["outmaneuver"],
-            "modification": ["afterburners", "stealthdevice"]
+            "modification": [
+              "afterburners",
+              "stealthdevice"
+            ]
           }
         }
       ]
@@ -1009,7 +1042,10 @@
           "id": "rearadmiralchiraneau",
           "upgrades": {
             "talent": ["swarmtactics"],
-            "crew": ["ministertua", "tacticalofficer"]
+            "crew": [
+              "ministertua",
+              "tacticalofficer"
+            ]
           }
         }
       ]
@@ -1021,7 +1057,10 @@
           "id": "patrolleader",
           "upgrades": {
             "gunner": ["fifthbrother"],
-            "crew": ["informant", "seventhsister"]
+            "crew": [
+              "informant",
+              "seventhsister"
+            ]
           }
         }
       ]
@@ -1032,7 +1071,10 @@
         {
           "id": "patrolleader",
           "upgrades": {
-            "modification": ["hullupgrade", "tacticalscrambler"]
+            "modification": [
+              "hullupgrade",
+              "tacticalscrambler"
+            ]
           }
         }
       ]
@@ -1129,7 +1171,10 @@
         {
           "id": "baronoftheempire",
           "upgrades": {
-            "talent": ["elusive", "outmaneuver"],
+            "talent": [
+              "elusive",
+              "outmaneuver"
+            ],
             "modification": ["afterburners"]
           }
         }
@@ -1155,7 +1200,7 @@
           "upgrades": {
             "force-power": ["hate"],
             "modification": ["shieldupgrade"],
-			"missile": ["protonrockets"]
+            "missile": ["protonrockets"]
           }
         }
       ]
@@ -1167,8 +1212,11 @@
           "id": "seventhsister",
           "upgrades": {
             "force-power": ["predictiveshot"],
-            "modification": ["afterburners", "hullupgrade"],
-			"missile": ["protonrockets"]
+            "modification": [
+              "afterburners",
+              "hullupgrade"
+            ],
+            "missile": ["protonrockets"]
           }
         }
       ]
@@ -1181,7 +1229,7 @@
           "upgrades": {
             "talent": ["disciplined"],
             "cannon": ["tractorbeam"],
-			"configuration": ["tiedefenderelite"]
+            "configuration": ["tiedefenderelite"]
           }
         }
       ]
@@ -1218,7 +1266,7 @@
           "upgrades": {
             "talent": ["interloperturn"],
             "cannon": ["tractorbeam"],
-			"configuration": ["tiedefenderelite"]
+            "configuration": ["tiedefenderelite"]
           }
         }
       ]
@@ -1231,7 +1279,7 @@
           "upgrades": {
             "talent": ["outmaneuver"],
             "modification": ["hullupgrade"],
-			"cannon": ["tractorbeam"]
+            "cannon": ["tractorbeam"]
           }
         }
       ]
@@ -1244,8 +1292,8 @@
           "upgrades": {
             "talent": ["predator"],
             "sensor": ["advancedsensors"],
-			"cannon": ["tractorbeam"],
-			"missile": ["ionmissiles"]
+            "cannon": ["tractorbeam"],
+            "missile": ["ionmissiles"]
           }
         }
       ]
@@ -1258,7 +1306,7 @@
           "upgrades": {
             "talent": ["outmaneuver"],
             "modification": ["shieldupgrade"],
-			"sensor": ["advancedsensors"]
+            "sensor": ["advancedsensors"]
           }
         }
       ]
@@ -1271,7 +1319,7 @@
           "upgrades": {
             "talent": ["elusive"],
             "sensor": ["advancedsensors"],
-			"missile": ["ionmissiles"]
+            "missile": ["ionmissiles"]
           }
         }
       ]
@@ -1282,9 +1330,12 @@
         {
           "id": "vultskerris",
           "upgrades": {
-            "talent": ["daredevil", "predator"],
+            "talent": [
+              "daredevil",
+              "predator"
+            ],
             "missile": ["magpulsewarheads"],
-			"configuration": ["tiedefenderelite"]
+            "configuration": ["tiedefenderelite"]
           }
         }
       ]
@@ -1297,7 +1348,7 @@
           "upgrades": {
             "force-power": ["sense"],
             "missile": ["magpulsewarheads"],
-			"configuration": ["tiedefenderelite"]
+            "configuration": ["tiedefenderelite"]
           }
         }
       ]
@@ -1308,7 +1359,10 @@
         {
           "id": "alphasquadronpilot",
           "upgrades": {
-            "modification": ["hullupgrade", "shieldupgrade"]
+            "modification": [
+              "hullupgrade",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -1321,7 +1375,7 @@
           "upgrades": {
             "talent": ["disciplined"],
             "configuration": ["sensitivecontrols"],
-			"modification": ["staticdischargevanes"]
+            "modification": ["staticdischargevanes"]
           }
         }
       ]
@@ -1333,7 +1387,10 @@
           "id": "alphasquadronpilot",
           "upgrades": {
             "configuration": ["sensitivecontrols"],
-            "modification": ["shieldupgrade", "targetingcomputer"]
+            "modification": [
+              "shieldupgrade",
+              "targetingcomputer"
+            ]
           }
         }
       ]
@@ -1356,7 +1413,10 @@
         {
           "id": "commandantgoran",
           "upgrades": {
-            "talent": ["disciplined", "margsablclosure"],
+            "talent": [
+              "disciplined",
+              "margsablclosure"
+            ],
             "configuration": ["sensitivecontrols"]
           }
         }
@@ -1382,7 +1442,7 @@
           "upgrades": {
             "talent": ["daredevil"],
             "configuration": ["sensitivecontrols"],
-			"modification": ["shieldupgrade"]
+            "modification": ["shieldupgrade"]
           }
         }
       ]
@@ -1394,7 +1454,7 @@
           "id": "sabersquadronace",
           "upgrades": {
             "talent": ["predator"],
-			"modification": ["shieldupgrade"]
+            "modification": ["shieldupgrade"]
           }
         }
       ]
@@ -1407,7 +1467,7 @@
           "upgrades": {
             "talent": ["daredevil"],
             "configuration": ["sensitivecontrols"],
-			"modification": ["targetingcomputer"]
+            "modification": ["targetingcomputer"]
           }
         }
       ]
@@ -1429,9 +1489,15 @@
         {
           "id": "gideonhask-tieininterceptor",
           "upgrades": {
-            "talent": ["disciplined", "elusive"],
+            "talent": [
+              "disciplined",
+              "elusive"
+            ],
             "configuration": ["sensitivecontrols"],
-			"modification": ["shieldupgrade", "targetingcomputer"]
+            "modification": [
+              "shieldupgrade",
+              "targetingcomputer"
+            ]
           }
         }
       ]
@@ -1442,8 +1508,14 @@
         {
           "id": "soontirfel",
           "upgrades": {
-            "talent": ["daredevil", "predator"],
-			"modification": ["afterburners", "shieldupgrade"]
+            "talent": [
+              "daredevil",
+              "predator"
+            ],
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -1454,7 +1526,11 @@
         {
           "id": "vultskerris-tieininterceptor",
           "upgrades": {
-            "talent": ["daredevil", "elusive", "predator"],
+            "talent": [
+              "daredevil",
+              "elusive",
+              "predator"
+            ],
             "configuration": ["sensitivecontrols"]
           }
         }
@@ -1468,7 +1544,7 @@
           "upgrades": {
             "talent": ["snapshot"],
             "configuration": ["maneuverassistmgk300"],
-		    "cannon": ["syncedlasercannons"]
+            "cannon": ["syncedlasercannons"]
           }
         }
       ]
@@ -1481,7 +1557,10 @@
           "upgrades": {
             "talent": ["deadeyeshot"],
             "configuration": ["maneuverassistmgk300"],
-		    "cannon": ["ioncannon", "heavylasercannon"]
+            "cannon": [
+              "ioncannon",
+              "heavylasercannon"
+            ]
           }
         }
       ]
@@ -1494,8 +1573,8 @@
           "upgrades": {
             "talent": ["ionlimiteroverride"],
             "configuration": ["maneuverassistmgk300"],
-		    "cannon": ["heavylasercannon"],
-			"modification": ["shieldupgrade"]
+            "cannon": ["heavylasercannon"],
+            "modification": ["shieldupgrade"]
           }
         }
       ]
@@ -1508,8 +1587,11 @@
           "upgrades": {
             "talent": ["predator"],
             "configuration": ["maneuverassistmgk300"],
-		    "cannon": ["syncedlasercannons"],
-			"modification": ["afterburners", "ablativeplating"]
+            "cannon": ["syncedlasercannons"],
+            "modification": [
+              "afterburners",
+              "ablativeplating"
+            ]
           }
         }
       ]
@@ -1522,7 +1604,7 @@
           "upgrades": {
             "modification": ["tacticalscrambler"],
             "crew": ["agentkallus"],
-		    "title": ["dauntless"]
+            "title": ["dauntless"]
           }
         }
       ]
@@ -1533,7 +1615,10 @@
         {
           "id": "patrolleader",
           "upgrades": {
-            "crew": ["darthvader", "000"],
+            "crew": [
+              "darthvader",
+              "000"
+            ],
             "gunner": ["bt1"]
           }
         }
@@ -1547,8 +1632,8 @@
           "upgrades": {
             "torpedo": ["protontorpedoes"],
             "gunner": ["veteranturretgunner"],
-		    "crew": ["gnkgonkdroid"],
-			"device": ["proximitymines"]
+            "crew": ["gnkgonkdroid"],
+            "device": ["proximitymines"]
           }
         }
       ]
@@ -1560,8 +1645,11 @@
           "id": "patrolleader",
           "upgrades": {
             "talent": ["lonewolf"],
-            "crew": ["grandinquisitor", "seventhsister"],
-		    "gunner": ["fifthbrother"]
+            "crew": [
+              "grandinquisitor",
+              "seventhsister"
+            ],
+            "gunner": ["fifthbrother"]
           }
         }
       ]
@@ -1574,10 +1662,16 @@
           "upgrades": {
             "command": ["strategiccommander"],
             "turret": ["dorsalturret"],
-		    "team": ["commsteam", "sensorexperts"],
-			"cargo": ["boostedscanners", "optimizedpowercore"],
-			"title": ["requiem"],
-			"hardpoint": ["targetingbattery"]
+            "team": [
+              "commsteam",
+              "sensorexperts"
+            ],
+            "cargo": [
+              "boostedscanners",
+              "optimizedpowercore"
+            ],
+            "title": ["requiem"],
+            "hardpoint": ["targetingbattery"]
           }
         }
       ]
@@ -1590,10 +1684,16 @@
           "upgrades": {
             "command": ["captainneeda"],
             "torpedo": ["advprotontorpedoes"],
-		    "team": ["ordnanceteam", "bombardmentspecialists"],
-			"cargo": ["boostedscanners"],
-			"title": ["impetuous"],
-			"hardpoint": ["ordnancetubes", "turbolaserbattery"]
+            "team": [
+              "ordnanceteam",
+              "bombardmentspecialists"
+            ],
+            "cargo": ["boostedscanners"],
+            "title": ["impetuous"],
+            "hardpoint": [
+              "ordnancetubes",
+              "turbolaserbattery"
+            ]
           }
         }
       ]
@@ -1604,7 +1704,10 @@
         {
           "id": "moffgideon",
           "upgrades": {
-            "talent": ["deadeyeshot", "outmaneuver"],
+            "talent": [
+              "deadeyeshot",
+              "outmaneuver"
+            ],
             "modification": ["hullupgrade"],
             "illicit": ["overtunedmodulators"]
           }
@@ -1618,7 +1721,10 @@
           "id": "isbjingoist",
           "upgrades": {
             "talent": ["ionlimiteroverride"],
-            "modification": ["afterburners", "shieldupgrade"],
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ],
             "illicit": ["falsetranspondercodes"]
           }
         }
@@ -1631,8 +1737,12 @@
           "id": "garsaxon",
           "upgrades": {
             "crew": ["imperialsupercommandos"],
-            "modification": ["dropseatbay", "shieldupgrade", "hullupgrade"],
-			"configuration": ["swivelwing"]
+            "modification": [
+              "dropseatbay",
+              "shieldupgrade",
+              "hullupgrade"
+            ],
+            "configuration": ["swivelwing"]
           }
         }
       ]
@@ -1645,7 +1755,7 @@
           "upgrades": {
             "configuration": ["combatboardingtubes"],
             "crew": ["imperialsupercommandos"],
-			"configuration": ["swivelwing"]
+            "configuration": ["swivelwing"]
           }
         }
       ]

--- a/data/quick-builds/galactic-republic.json
+++ b/data/quick-builds/galactic-republic.json
@@ -178,7 +178,10 @@
             "force-power": ["supernaturalreflexes"],
             "astromech": ["r2astromech"],
             "configuration": ["delta7b"],
-            "modification": ["afterburners", "shieldupgrade"]
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -189,7 +192,10 @@
         {
           "id": "plokoon",
           "upgrades": {
-            "force-power": ["battlemeditation", "sense"],
+            "force-power": [
+              "battlemeditation",
+              "sense"
+            ],
             "astromech": ["r4pastromech"],
             "modification": ["shieldupgrade"]
           }
@@ -253,7 +259,10 @@
           "upgrades": {
             "talent": ["saturationsalvo"],
             "missile": ["clustermissiles"],
-            "modification": ["afterburners", "munitionsfailsafe"]
+            "modification": [
+              "afterburners",
+              "munitionsfailsafe"
+            ]
           }
         }
       ]
@@ -426,7 +435,10 @@
             "talent": ["elusive"],
             "device": ["protonbombs"],
             "turret": ["ioncannonturret"],
-            "modification": ["delayedfuses", "shieldupgrade"],
+            "modification": [
+              "delayedfuses",
+              "shieldupgrade"
+            ],
             "astromech": ["r2astromech"]
           }
         }
@@ -504,7 +516,7 @@
           "upgrades": {
             "talent": ["predator"],
             "force-power": ["supernaturalreflexes"],
-			"astromech": ["r3astromech"]
+            "astromech": ["r3astromech"]
           }
         }
       ]
@@ -517,17 +529,17 @@
           "upgrades": {
             "talent": ["margsablclosure"],
             "force-power": ["patience"],
-			"astromech": ["r5astromech"],
-			"modification": ["hullupgrade"]
+            "astromech": ["r5astromech"],
+            "modification": ["hullupgrade"]
           }
         },
-		{
-		  "id": "transgalmegcontrollink",
-		  "upgrades": {
-			"hyperdrive": ["syliure31hyperdrive"],
-			"modification": ["shieldupgrade"]
-		  }
-		}
+        {
+          "id": "transgalmegcontrollink",
+          "upgrades": {
+            "hyperdrive": ["syliure31hyperdrive"],
+            "modification": ["shieldupgrade"]
+          }
+        }
       ]
     },
     {
@@ -536,8 +548,12 @@
         {
           "id": "yoda",
           "upgrades": {
-            "force-power": ["heightenedperception", "sense", "patience"],
-			"astromech": ["r2d2-republic"]
+            "force-power": [
+              "heightenedperception",
+              "sense",
+              "patience"
+            ],
+            "astromech": ["r2d2-republic"]
           }
         }
       ]
@@ -550,8 +566,11 @@
           "upgrades": {
             "talent": ["margsablclosure"],
             "force-power": ["extrememaneuvers"],
-			"astromech": ["r2d2-republic"],
-			"modification": ["afterburners", "shieldupgrade"]
+            "astromech": ["r2d2-republic"],
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -564,8 +583,8 @@
           "upgrades": {
             "missile": ["multimissilepods"],
             "gunner": ["suppressivegunner"],
-			"crew": ["ghostcompany"],
-			"modification": ["shieldupgrade"]
+            "crew": ["ghostcompany"],
+            "modification": ["shieldupgrade"]
           }
         }
       ]
@@ -576,10 +595,13 @@
         {
           "id": "hawk",
           "upgrades": {
-			"talent": ["deadeyeshot"],
+            "talent": ["deadeyeshot"],
             "missile": ["ionmissiles"],
             "gunner": ["clonecaptainrex"],
-			"crew": ["fives", "yoda"]
+            "crew": [
+              "fives",
+              "yoda"
+            ]
           }
         }
       ]
@@ -592,8 +614,11 @@
           "upgrades": {
             "missile": ["multimissilepods"],
             "gunner": ["suppressivegunner"],
-			"crew": ["plokoon", "wolfpack"],
-			"modification": ["shieldupgrade"]
+            "crew": [
+              "plokoon",
+              "wolfpack"
+            ],
+            "modification": ["shieldupgrade"]
           }
         }
       ]
@@ -605,9 +630,15 @@
           "id": "hound",
           "upgrades": {
             "missile": ["concussionmissiles"],
-            "gunner": ["suppressivegunner", "agilegunner"],
-			"crew": ["aaylasecura", "kitfisto"],
-			"modification": ["hullupgrade"]
+            "gunner": [
+              "suppressivegunner",
+              "agilegunner"
+            ],
+            "crew": [
+              "aaylasecura",
+              "kitfisto"
+            ],
+            "modification": ["hullupgrade"]
           }
         }
       ]
@@ -628,7 +659,7 @@
           "upgrades": {
             "talent": ["ionlimiteroverride"],
             "astromech": ["r7a7"],
-			"modification": ["precisionionengines"]
+            "modification": ["precisionionengines"]
           }
         }
       ]
@@ -641,7 +672,7 @@
           "upgrades": {
             "device": ["thermaldetonators"],
             "astromech": ["r3astromech"],
-			"configuration": ["alpha3bbesh"]
+            "configuration": ["alpha3bbesh"]
           }
         }
       ]
@@ -652,9 +683,12 @@
         {
           "id": "oddball-nimbusclassvwing",
           "upgrades": {
-            "talent": ["elusive", "ionlimiteroverride"],
+            "talent": [
+              "elusive",
+              "ionlimiteroverride"
+            ],
             "astromech": ["q7astromech"],
-			"modification": ["precisionionengines"]
+            "modification": ["precisionionengines"]
           }
         }
       ]
@@ -667,7 +701,7 @@
           "upgrades": {
             "talent": ["outmaneuver"],
             "astromech": ["r2astromech"],
-			"configuration": ["alpha3eesk"]
+            "configuration": ["alpha3eesk"]
           }
         }
       ]
@@ -679,7 +713,7 @@
           "id": "wilhufftarkin",
           "upgrades": {
             "astromech": ["r3astromech"],
-			"configuration": ["alpha3eesk"]
+            "configuration": ["alpha3eesk"]
           }
         }
       ]
@@ -691,11 +725,17 @@
           "id": "republicjudiciary",
           "upgrades": {
             "command": ["strategiccommander"],
-            "hardpoint": ["targetingbattery", "turbolaserbattery"],
+            "hardpoint": [
+              "targetingbattery",
+              "turbolaserbattery"
+            ],
             "crew": ["seasonednavigator"],
             "gunner": ["agilegunner"],
-			"team": ["damagecontrolteam", "gunneryspecialists"],
-			"cargo": ["boostedscanners"]
+            "team": [
+              "damagecontrolteam",
+              "gunneryspecialists"
+            ],
+            "cargo": ["boostedscanners"]
           }
         }
       ]
@@ -707,8 +747,11 @@
           "id": "slider",
           "upgrades": {
             "talent": ["outmaneuver"],
-			"torpedo": ["protontorpedoes"],
-			"modification": ["afterburners", "shieldupgrade"]
+            "torpedo": ["protontorpedoes"],
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -719,8 +762,8 @@
         {
           "id": "killer",
           "upgrades": {
-			"torpedo": ["protontorpedoes"],
-			"modification": ["afterburners"]
+            "torpedo": ["protontorpedoes"],
+            "modification": ["afterburners"]
           }
         }
       ]
@@ -732,7 +775,7 @@
           "id": "warthog-clonez95headhunter",
           "upgrades": {
             "talent": ["elusive"],
-			"torpedo": ["protontorpedoes"]
+            "torpedo": ["protontorpedoes"]
           }
         }
       ]
@@ -744,8 +787,8 @@
           "id": "boost",
           "upgrades": {
             "talent": ["enduring"],
-			"torpedo": ["homingtorpedoes"],
-			"modification": ["hullupgrade"]
+            "torpedo": ["homingtorpedoes"],
+            "modification": ["hullupgrade"]
           }
         }
       ]
@@ -757,8 +800,8 @@
           "id": "drift",
           "upgrades": {
             "talent": ["elusive"],
-			"torpedo": ["homingtorpedoes"],
-			"modification": ["afterburners"]
+            "torpedo": ["homingtorpedoes"],
+            "modification": ["afterburners"]
           }
         }
       ]
@@ -770,8 +813,8 @@
           "id": "hawk-clonez95headhunter",
           "upgrades": {
             "talent": ["outmaneuver"],
-			"missile": ["magpulsewarheads"],
-			"modification": ["afterburners"]
+            "missile": ["magpulsewarheads"],
+            "modification": ["afterburners"]
           }
         }
       ]
@@ -783,8 +826,8 @@
           "id": "stub",
           "upgrades": {
             "talent": ["elusive"],
-			"torpedo": ["protontorpedoes"],
-			"modification": ["afterburners"]
+            "torpedo": ["protontorpedoes"],
+            "modification": ["afterburners"]
           }
         }
       ]
@@ -795,7 +838,7 @@
         {
           "id": "7thskycorpspilot",
           "upgrades": {
-			"modification": ["angleddeflectors"]
+            "modification": ["angleddeflectors"]
           }
         }
       ]
@@ -806,8 +849,11 @@
         {
           "id": "knack",
           "upgrades": {
-            "talent": ["outmaneuver", "predator"],
-			"torpedo": ["protontorpedoes"]
+            "talent": [
+              "outmaneuver",
+              "predator"
+            ],
+            "torpedo": ["protontorpedoes"]
           }
         }
       ]
@@ -819,9 +865,9 @@
           "id": "reapersquadronscout",
           "upgrades": {
             "talent": ["outmaneuver"],
-			"missile": ["magpulsewarheads"],
-			"modification": ["shieldupgrade"],
-			"sensor": ["firecontrolsystem"]
+            "missile": ["magpulsewarheads"],
+            "modification": ["shieldupgrade"],
+            "sensor": ["firecontrolsystem"]
           }
         }
       ]
@@ -836,8 +882,11 @@
             "crew": ["niteowlcommandos"],
             "gunner": ["veterantailgunner"],
             "title": ["gauntlet"],
-            "modification": ["dropseatbay", "hullupgrade"],
-			"configuration": ["swivelwing"]
+            "modification": [
+              "dropseatbay",
+              "hullupgrade"
+            ],
+            "configuration": ["swivelwing"]
           }
         }
       ]
@@ -852,7 +901,7 @@
             "device": ["concussionbombs"],
             "gunner": ["veterantailgunner"],
             "modification": ["hullupgrade"],
-			"configuration": ["swivelwing"]
+            "configuration": ["swivelwing"]
           }
         }
       ]

--- a/data/quick-builds/rebel-alliance.json
+++ b/data/quick-builds/rebel-alliance.json
@@ -34,7 +34,10 @@
           "id": "jekporkins",
           "upgrades": {
             "talent": ["outmaneuver"],
-            "modification": ["afterburners", "hullupgrade"],
+            "modification": [
+              "afterburners",
+              "hullupgrade"
+            ],
             "astromech": ["r5d8"],
             "configuration": ["servomotorsfoils"]
           }
@@ -89,7 +92,10 @@
           "upgrades": {
             "talent": ["elusive"],
             "torpedo": ["iontorpedoes"],
-            "modification": ["afterburners", "hullupgrade"],
+            "modification": [
+              "afterburners",
+              "hullupgrade"
+            ],
             "astromech": ["r2astromech"],
             "configuration": ["servomotorsfoils"]
           }
@@ -206,7 +212,10 @@
           "upgrades": {
             "sensor": ["trajectorysimulator"],
             "missile": ["ionmissiles"],
-            "device": ["protonbombs", "connernets"],
+            "device": [
+              "protonbombs",
+              "connernets"
+            ],
             "modification": ["advancedslam"],
             "crew": ["perceptivecopilot"]
           }
@@ -271,7 +280,10 @@
           "id": "bladesquadronveteran",
           "upgrades": {
             "talent": ["predator"],
-            "cannon": ["ioncannon", "jammingbeam"]
+            "cannon": [
+              "ioncannon",
+              "jammingbeam"
+            ]
           }
         }
       ]
@@ -331,7 +343,10 @@
           "id": "braylenstramm",
           "upgrades": {
             "talent": ["squadleader"],
-            "cannon": ["jammingbeam", "heavylasercannon"],
+            "cannon": [
+              "jammingbeam",
+              "heavylasercannon"
+            ],
             "modification": ["electronicbaffle"]
           }
         }
@@ -373,7 +388,10 @@
             "crew": ["seasonednavigator"],
             "gunner": ["veterantailgunner"],
             "astromech": ["r3astromech"],
-            "modification": ["ablativeplating", "hullupgrade"]
+            "modification": [
+              "ablativeplating",
+              "hullupgrade"
+            ]
           }
         }
       ]
@@ -424,7 +442,10 @@
           "id": "wullffwarro",
           "upgrades": {
             "talent": ["selfless"],
-            "crew": ["gnkgonkdroid", "novicetechnician"],
+            "crew": [
+              "gnkgonkdroid",
+              "novicetechnician"
+            ],
             "modification": ["hullupgrade"]
           }
         }
@@ -524,7 +545,10 @@
           "upgrades": {
             "talent": ["elusive"],
             "device": ["seismiccharges"],
-            "modification": ["hullupgrade", "shieldupgrade"]
+            "modification": [
+              "hullupgrade",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -547,7 +571,10 @@
           "id": "rebelscout",
           "upgrades": {
             "crew": ["sabinewren"],
-            "device": ["seismiccharges", "protonbombs"],
+            "device": [
+              "seismiccharges",
+              "protonbombs"
+            ],
             "modification": ["engineupgrade"]
           }
         }
@@ -643,7 +670,10 @@
         {
           "id": "captainrex",
           "upgrades": {
-            "talent": ["elusive", "juke"],
+            "talent": [
+              "elusive",
+              "juke"
+            ],
             "modification": ["stealthdevice"]
           }
         }
@@ -690,7 +720,10 @@
           "id": "cassianandor",
           "upgrades": {
             "sensor": ["firecontrolsystem"],
-            "crew": ["jynerso", "bazemalbus"],
+            "crew": [
+              "jynerso",
+              "bazemalbus"
+            ],
             "configuration": ["pivotwing"]
           }
         }
@@ -756,8 +789,15 @@
           "id": "chewbacca",
           "upgrades": {
             "talent": ["predator"],
-            "crew": ["leiaorgana", "c3po", "r2d2-crew"],
-            "gunner": ["hansolo", "lukeskywalker"],
+            "crew": [
+              "leiaorgana",
+              "c3po",
+              "r2d2-crew"
+            ],
+            "gunner": [
+              "hansolo",
+              "lukeskywalker"
+            ],
             "modification": ["engineupgrade"],
             "title": ["millenniumfalcon"]
           }
@@ -883,7 +923,10 @@
         {
           "id": "dashrendar",
           "upgrades": {
-            "talent": ["experthandling", "trickshot"],
+            "talent": [
+              "experthandling",
+              "trickshot"
+            ],
             "illicit": ["riggedcargochute"],
             "crew": ["perceptivecopilot"],
             "title": ["outrider"]
@@ -974,7 +1017,10 @@
         {
           "id": "partisanrenegade",
           "upgrades": {
-            "crew": ["magvayarro", "sawgerrera"],
+            "crew": [
+              "magvayarro",
+              "sawgerrera"
+            ],
             "illicit": ["deadmansswitch"],
             "configuration": ["pivotwing"]
           }
@@ -990,7 +1036,10 @@
             "talent": ["outmaneuver"],
             "astromech": ["r2astromech"],
             "illicit": ["deadmansswitch"],
-            "modification": ["afterburners", "hullupgrade"],
+            "modification": [
+              "afterburners",
+              "hullupgrade"
+            ],
             "configuration": ["servomotorsfoils"]
           }
         }
@@ -1019,7 +1068,10 @@
             "talent": ["elusive"],
             "astromech": ["r2astromech"],
             "illicit": ["deadmansswitch"],
-            "modification": ["afterburners", "shieldupgrade"],
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ],
             "configuration": ["servomotorsfoils"]
           }
         }
@@ -1044,7 +1096,10 @@
         {
           "id": "kananjarrus",
           "upgrades": {
-            "crew": ["chopper-crew", "herasyndulla"],
+            "crew": [
+              "chopper-crew",
+              "herasyndulla"
+            ],
             "gunner": ["ezrabridger"],
             "turret": ["ioncannonturret"],
             "title": ["ghost"]
@@ -1170,7 +1225,10 @@
           "upgrades": {
             "talent": ["trickshot"],
             "sensor": ["passivesensors"],
-            "modification": ["hullupgrade", "angleddeflectors"],
+            "modification": [
+              "hullupgrade",
+              "angleddeflectors"
+            ],
             "configuration": ["pivotwing"]
           }
         }
@@ -1182,7 +1240,11 @@
         {
           "id": "leiaorgana",
           "upgrades": {
-            "crew": ["landocalrissian", "chewbacca", "r2d2-crew"],
+            "crew": [
+              "landocalrissian",
+              "chewbacca",
+              "r2d2-crew"
+            ],
             "modification": ["engineupgrade"],
             "title": ["millenniumfalcon"]
           }
@@ -1224,9 +1286,9 @@
             "talent": ["saturationsalvo"],
             "modification": ["shieldupgrade"],
             "cannon": ["syncedlasercannons"],
-			"configuration": ["stabilizedsfoils"],
-			"torpedo": ["plasmatorpedoes"],
-			"sensor": ["passivesensors"]
+            "configuration": ["stabilizedsfoils"],
+            "torpedo": ["plasmatorpedoes"],
+            "sensor": ["passivesensors"]
           }
         }
       ]
@@ -1240,7 +1302,7 @@
             "command": ["b6bladewingprototype-command"],
             "talent": ["deadeyeshot"],
             "sensor": ["passivesensors"],
-			"gunner": ["sabinewren-gunner"]
+            "gunner": ["sabinewren-gunner"]
           }
         }
       ]
@@ -1251,7 +1313,10 @@
         {
           "id": "outerrimsmuggler",
           "upgrades": {
-            "crew": ["landocalrissian", "informant"],
+            "crew": [
+              "landocalrissian",
+              "informant"
+            ],
             "modification": ["engineupgrade"],
             "illicit": ["riggedcargochute"]
           }
@@ -1264,7 +1329,11 @@
         {
           "id": "hansolo-modifiedyt1300lightfreighter",
           "upgrades": {
-            "crew": ["c3po", "chewbacca", "leiaorgana"],
+            "crew": [
+              "c3po",
+              "chewbacca",
+              "leiaorgana"
+            ],
             "illicit": ["riggedcargochute"],
             "title": ["millenniumfalcon"]
           }
@@ -1277,12 +1346,15 @@
         {
           "id": "landocalrissian-modifiedyt1300lightfreighter",
           "upgrades": {
-			"talent": ["swarmtactics"],
+            "talent": ["swarmtactics"],
             "crew": ["niennunb"],
-            "modification": ["engineupgrade", "hullupgrade"],
+            "modification": [
+              "engineupgrade",
+              "hullupgrade"
+            ],
             "title": ["millenniumfalcon"],
-			"missile": ["homingmissiles"],
-			"astromech": ["r3astromech"]
+            "missile": ["homingmissiles"],
+            "astromech": ["r3astromech"]
           }
         }
       ]
@@ -1293,8 +1365,15 @@
         {
           "id": "chewbacca",
           "upgrades": {
-            "crew": ["c3po", "leiaorgana", "r2d2-crew"],
-            "gunner": ["hansolo", "lukeskywalker"],
+            "crew": [
+              "c3po",
+              "leiaorgana",
+              "r2d2-crew"
+            ],
+            "gunner": [
+              "hansolo",
+              "lukeskywalker"
+            ],
             "title": ["millenniumfalcon"]
           }
         }
@@ -1340,7 +1419,10 @@
           "id": "ahsokatano-rz1awing",
           "upgrades": {
             "talent": ["margsablclosure"],
-            "force-power": ["patience", "sense"]
+            "force-power": [
+              "patience",
+              "sense"
+            ]
           }
         }
       ]
@@ -1351,7 +1433,10 @@
         {
           "id": "arvelcrynyd",
           "upgrades": {
-            "talent": ["intimidation", "juke"],
+            "talent": [
+              "intimidation",
+              "juke"
+            ],
             "missile": ["concussionmissiles"]
           }
         }
@@ -1375,7 +1460,10 @@
         {
           "id": "greensquadronpilot",
           "upgrades": {
-            "talent": ["juke", "outmaneuver"],
+            "talent": [
+              "juke",
+              "outmaneuver"
+            ],
             "modification": ["hullupgrade"]
           }
         }
@@ -1411,7 +1499,10 @@
         {
           "id": "jakefarrell",
           "upgrades": {
-            "talent": ["daredevil", "juke"],
+            "talent": [
+              "daredevil",
+              "juke"
+            ],
             "missile": ["protonrockets"]
           }
         }
@@ -1447,7 +1538,10 @@
         {
           "id": "sharabey-rz1awing",
           "upgrades": {
-            "talent": ["starbirdslash", "margsablclosure"],
+            "talent": [
+              "starbirdslash",
+              "margsablclosure"
+            ],
             "configuration": ["vectoredcannonsrz1"]
           }
         }
@@ -1472,7 +1566,10 @@
           "id": "ap5",
           "upgrades": {
             "astromech": ["chopper"],
-            "modification": ["shieldupgrade", "afterburners"],
+            "modification": [
+              "shieldupgrade",
+              "afterburners"
+            ],
             "title": ["phantom"]
           }
         }
@@ -1485,10 +1582,10 @@
           "id": "ezrabridger-sheathipedeclassshuttle",
           "upgrades": {
             "force-power": ["hate"],
-			"crew": ["maul"],
+            "crew": ["maul"],
             "modification": ["hullupgrade"],
             "title": ["phantom"],
-			"astromech": ["r5astromech"]
+            "astromech": ["r5astromech"]
           }
         }
       ]
@@ -1501,7 +1598,7 @@
           "upgrades": {
             "crew": ["kananjarrus"],
             "talent": ["elusive"],
-			"astromech": ["r2astromech"],
+            "astromech": ["r2astromech"],
             "title": ["phantom"]
           }
         }
@@ -1514,7 +1611,7 @@
           "id": "zeborrelios-sheathipedeclassshuttle",
           "upgrades": {
             "crew": ["herasyndulla"],
-			"talent": ["outmaneuver"],
+            "talent": ["outmaneuver"],
             "modification": ["hullupgrade"],
             "title": ["phantom"]
           }
@@ -1527,7 +1624,10 @@
         {
           "id": "chopper",
           "upgrades": {
-            "crew": ["herasyndulla", "zeborrelios"],
+            "crew": [
+              "herasyndulla",
+              "zeborrelios"
+            ],
             "title": ["ghost"]
           }
         }
@@ -1551,11 +1651,14 @@
         {
           "id": "herasyndulla-vcx100lightfreighter",
           "upgrades": {
-            "crew": ["chopper-crew", "kananjarrus"],
+            "crew": [
+              "chopper-crew",
+              "kananjarrus"
+            ],
             "talent": ["outmaneuver"],
             "title": ["ghost"],
-			"sensor": ["collisiondetector"],
-			"turret": ["dorsalturret"]
+            "sensor": ["collisiondetector"],
+            "turret": ["dorsalturret"]
           }
         }
       ]
@@ -1567,8 +1670,11 @@
           "id": "kananjarrus",
           "upgrades": {
             "force-power": ["sense"],
-			"turret": ["dorsalturret"],
-            "modification": ["hullupgrade", "tacticalscrambler"],
+            "turret": ["dorsalturret"],
+            "modification": [
+              "hullupgrade",
+              "tacticalscrambler"
+            ],
             "title": ["ghost"]
           }
         }
@@ -1583,9 +1689,15 @@
             "command": ["jandodonna"],
             "crew": ["torynfarr"],
             "cargo": ["boostedscanners"],
-			"hardpoint": ["ioncannonbattery", "turbolaserbattery"],
-			"team": ["commsteam", "sensorexperts"],
-			"title": ["dodonnaspride"]
+            "hardpoint": [
+              "ioncannonbattery",
+              "turbolaserbattery"
+            ],
+            "team": [
+              "commsteam",
+              "sensorexperts"
+            ],
+            "title": ["dodonnaspride"]
           }
         }
       ]
@@ -1599,9 +1711,12 @@
             "command": ["carlistrieekan"],
             "hardpoint": ["pointdefensebattery"],
             "crew": ["novicetechnician"],
-			"team": ["commsteam"],
-			"cargo": ["adaptiveshields", "optimizedpowercore"],
-			"title": ["brighthope"]
+            "team": ["commsteam"],
+            "cargo": [
+              "adaptiveshields",
+              "optimizedpowercore"
+            ],
+            "title": ["brighthope"]
           }
         }
       ]
@@ -1637,7 +1752,10 @@
           "id": "bodicavenj",
           "upgrades": {
             "talent": ["outmaneuver"],
-            "modification": ["beskarreinforcedplating", "mandalorianoptics"]
+            "modification": [
+              "beskarreinforcedplating",
+              "mandalorianoptics"
+            ]
           }
         }
       ]
@@ -1650,7 +1768,10 @@
           "upgrades": {
             "talent": ["clantraining"],
             "torpedo": ["protontorpedoes"],
-            "modification": ["hullupgrade", "mandalorianoptics"]
+            "modification": [
+              "hullupgrade",
+              "mandalorianoptics"
+            ]
           }
         }
       ]
@@ -1665,7 +1786,7 @@
             "crew": ["clanwrencommandos"],
             "title": ["nightbrother"],
             "modification": ["shieldupgrade"],
-			"configuration": ["swivelwing"]
+            "configuration": ["swivelwing"]
           }
         }
       ]
@@ -1679,8 +1800,8 @@
             "talent": ["predator"],
             "gunner": ["veterantailgunner"],
             "modification": ["hullupgrade"],
-			"title": ["nightbrother"],
-			"configuration": ["swivelwing"]
+            "title": ["nightbrother"],
+            "configuration": ["swivelwing"]
           }
         }
       ]
@@ -1693,7 +1814,7 @@
           "upgrades": {
             "talent": ["enduring"],
             "crew": ["clanwrencommandos"],
-			"configuration": ["swivelwing"]
+            "configuration": ["swivelwing"]
           }
         }
       ]

--- a/data/quick-builds/resistance.json
+++ b/data/quick-builds/resistance.json
@@ -240,7 +240,10 @@
           "id": "bluesquadronrecruit",
           "upgrades": {
             "tech": ["primedthrusters"],
-            "talent": ["composure", "snapshot"]
+            "talent": [
+              "composure",
+              "snapshot"
+            ]
           }
         }
       ]
@@ -294,7 +297,10 @@
             "tech": ["patternanalyzer"],
             "gunner": ["skilledbombardier"],
             "crew": ["seasonednavigator"],
-            "device": ["protonbombs", "connernets"]
+            "device": [
+              "protonbombs",
+              "connernets"
+            ]
           }
         }
       ]
@@ -319,7 +325,10 @@
         {
           "id": "benteene",
           "upgrades": {
-            "device": ["protonbombs", "connernets"]
+            "device": [
+              "protonbombs",
+              "connernets"
+            ]
           }
         }
       ]
@@ -332,7 +341,10 @@
           "upgrades": {
             "tech": ["advancedoptics"],
             "gunner": ["paigetico"],
-            "modification": ["hullupgrade", "ablativeplating"],
+            "modification": [
+              "hullupgrade",
+              "ablativeplating"
+            ],
             "device": ["protonbombs"]
           }
         }
@@ -383,7 +395,11 @@
         {
           "id": "resistancesympathizer",
           "upgrades": {
-            "crew": ["chewbacca-crew-swz19", "hansolo-crew", "c3po-crew"],
+            "crew": [
+              "chewbacca-crew-swz19",
+              "hansolo-crew",
+              "c3po-crew"
+            ],
             "talent": ["debrisgambit"]
           }
         }
@@ -440,7 +456,10 @@
         {
           "id": "covanell",
           "upgrades": {
-            "crew": ["leiaorgana-resistance", "korrsella"],
+            "crew": [
+              "leiaorgana-resistance",
+              "korrsella"
+            ],
             "talent": ["composure"]
           }
         }
@@ -479,7 +498,10 @@
         {
           "id": "logisticsdivisionpilot",
           "upgrades": {
-            "crew": ["amilynholdo", "larmadacy"],
+            "crew": [
+              "amilynholdo",
+              "larmadacy"
+            ],
             "torpedo": ["protontorpedoes"]
           }
         }
@@ -504,7 +526,10 @@
         {
           "id": "zizitlo",
           "upgrades": {
-            "talent": ["elusive", "snapshot"],
+            "talent": [
+              "elusive",
+              "snapshot"
+            ],
             "tech": ["advancedoptics"],
             "modification": ["afterburners"]
           }
@@ -543,7 +568,10 @@
           "upgrades": {
             "talent": ["elusive"],
             "missile": ["magpulsewarheads"],
-            "modification": ["advancedslam", "targetingcomputer"]
+            "modification": [
+              "advancedslam",
+              "targetingcomputer"
+            ]
           }
         }
       ]
@@ -571,7 +599,10 @@
           "upgrades": {
             "illicit": ["coaxiumhyperfuel"],
             "missile": ["magpulsewarheads"],
-            "modification": ["afterburners", "targetingcomputer"]
+            "modification": [
+              "afterburners",
+              "targetingcomputer"
+            ]
           }
         }
       ]
@@ -597,7 +628,11 @@
           "upgrades": {
             "talent": ["experthandling"],
             "astromech": ["r2astromech"],
-            "modification": ["engineupgrade", "hullupgrade", "targetingcomputer"]
+            "modification": [
+              "engineupgrade",
+              "hullupgrade",
+              "targetingcomputer"
+            ]
           }
         }
       ]
@@ -610,7 +645,10 @@
           "upgrades": {
             "turret": ["ioncannonturret"],
             "illicit": ["overtunedmodulators"],
-            "modification": ["engineupgrade", "targetingcomputer"]
+            "modification": [
+              "engineupgrade",
+              "targetingcomputer"
+            ]
           }
         }
       ]
@@ -623,8 +661,11 @@
           "upgrades": {
             "talent": ["tierfonbellyrun"],
             "turret": ["ioncannonturret"],
-			"illicit": ["overtunedmodulators"],
-            "modification": ["engineupgrade", "targetingcomputer"]
+            "illicit": ["overtunedmodulators"],
+            "modification": [
+              "engineupgrade",
+              "targetingcomputer"
+            ]
           }
         }
       ]
@@ -650,8 +691,11 @@
           "upgrades": {
             "talent": ["outmaneuver"],
             "turret": ["ioncannonturret"],
-			"astromech": ["r3astromech"],
-            "modification": ["shieldupgrade", "targetingcomputer"]
+            "astromech": ["r3astromech"],
+            "modification": [
+              "shieldupgrade",
+              "targetingcomputer"
+            ]
           }
         }
       ]
@@ -663,7 +707,7 @@
           "id": "shasazaro",
           "upgrades": {
             "turret": ["ioncannonturret"],
-			"astromech": ["watchfulastromech"],
+            "astromech": ["watchfulastromech"],
             "device": ["concussionbombs"],
             "configuration": ["wartimeloadout"]
           }
@@ -679,8 +723,11 @@
             "talent": ["experthandling"],
             "astromech": ["r2astromech"],
             "turret": ["ioncannonturret"],
-			"modification": ["delayedfuses", "engineupgrade"],
-			"device": ["concussionbombs"]
+            "modification": [
+              "delayedfuses",
+              "engineupgrade"
+            ],
+            "device": ["concussionbombs"]
           }
         }
       ]
@@ -693,8 +740,11 @@
           "upgrades": {
             "talent": ["predator"],
             "astromech": ["r3astromech"],
-			"turret": ["ioncannonturret"],
-            "modification": ["engineupgrade", "targetingcomputer"]
+            "turret": ["ioncannonturret"],
+            "modification": [
+              "engineupgrade",
+              "targetingcomputer"
+            ]
           }
         }
       ]
@@ -707,8 +757,8 @@
           "upgrades": {
             "talent": ["outmaneuver"],
             "torpedo": ["protontorpedoes"],
-			"astromech": ["r3astromech"],
-			"illicit": ["babufrik"],
+            "astromech": ["r3astromech"],
+            "illicit": ["babufrik"],
             "configuration": ["wartimeloadout"]
           }
         }
@@ -746,7 +796,10 @@
         {
           "id": "merlcobben",
           "upgrades": {
-            "talent": ["predator", "deadeyeshot"],
+            "talent": [
+              "predator",
+              "deadeyeshot"
+            ],
             "tech": ["automatedtargetpriority"],
             "modification": ["shieldupgrade"]
           }
@@ -759,7 +812,10 @@
         {
           "id": "seftinvanik",
           "upgrades": {
-            "talent": ["daredevil", "snapshot"],
+            "talent": [
+              "daredevil",
+              "snapshot"
+            ],
             "modification": ["hullupgrade"]
           }
         }
@@ -771,7 +827,10 @@
         {
           "id": "suralindajavos",
           "upgrades": {
-            "talent": ["snapshot", "starbirdslash"],
+            "talent": [
+              "snapshot",
+              "starbirdslash"
+            ],
             "missile": ["ionmissiles"],
             "modification": ["shieldupgrade"]
           }
@@ -784,7 +843,10 @@
         {
           "id": "wrobietyce",
           "upgrades": {
-            "talent": ["elusive", "starbirdslash"],
+            "talent": [
+              "elusive",
+              "starbirdslash"
+            ],
             "missile": ["concussionmissiles"]
           }
         }
@@ -836,11 +898,11 @@
           "id": "blacksquadronace-t70xwing",
           "upgrades": {
             "tech": ["primedthrusters"],
-			"talent": ["deadeyeshot"],
-			"torpedo": ["protontorpedoes"],
+            "talent": ["deadeyeshot"],
+            "torpedo": ["protontorpedoes"],
             "configuration": ["integratedsfoils"],
             "astromech": ["r3astromech"],
-			"modification": ["afterburners"]
+            "modification": ["afterburners"]
           }
         }
       ]
@@ -852,10 +914,10 @@
           "id": "caithrenalli",
           "upgrades": {
             "tech": ["primedthrusters"],
-			"talent": ["backwardstailslide"],
+            "talent": ["backwardstailslide"],
             "configuration": ["integratedsfoils"],
             "astromech": ["r4astromech"],
-			"torpedo": ["protontorpedoes"]
+            "torpedo": ["protontorpedoes"]
           }
         }
       ]
@@ -866,11 +928,14 @@
         {
           "id": "poedameron-swz68",
           "upgrades": {
-            "talent": ["backwardstailslide", "daredevil"],
+            "talent": [
+              "backwardstailslide",
+              "daredevil"
+            ],
             "configuration": ["integratedsfoils"],
             "astromech": ["r2d2-resistance"],
-			"modification": ["overdrivethruster"],
-			"title": ["blackone"]
+            "modification": ["overdrivethruster"],
+            "title": ["blackone"]
           }
         }
       ]
@@ -884,8 +949,8 @@
             "talent": ["snapshot"],
             "configuration": ["integratedsfoils"],
             "astromech": ["r6d8"],
-			"cannon": ["underslungblastercannon"],
-			"modification": ["hullupgrade"]
+            "cannon": ["underslungblastercannon"],
+            "modification": ["hullupgrade"]
           }
         }
       ]
@@ -899,8 +964,11 @@
             "command": ["stalwartcaptain"],
             "hardpoint": ["ioncannonbattery"],
             "turret": ["dorsalturret"],
-			"team": ["sensorexperts"],
-			"cargo": ["boostedscanners", "tibannareserves"]
+            "team": ["sensorexperts"],
+            "cargo": [
+              "boostedscanners",
+              "tibannareserves"
+            ]
           }
         }
       ]

--- a/data/quick-builds/scum-and-villainy.json
+++ b/data/quick-builds/scum-and-villainy.json
@@ -99,7 +99,10 @@
           "id": "lattsrazzi",
           "upgrades": {
             "crew": ["bobafett"],
-            "gunner": ["dengar", "bossk"],
+            "gunner": [
+              "dengar",
+              "bossk"
+            ],
             "illicit": ["feedbackarray"],
             "modification": ["staticdischargevanes"]
           }
@@ -114,7 +117,10 @@
           "upgrades": {
             "crew": ["jabbathehutt"],
             "gunner": ["hotshotgunner"],
-            "illicit": ["contrabandcybernetics", "riggedcargochute"]
+            "illicit": [
+              "contrabandcybernetics",
+              "riggedcargochute"
+            ]
           }
         }
       ]
@@ -199,7 +205,10 @@
             "talent": ["elusive"],
             "crew": ["perceptivecopilot"],
             "illicit": ["inertialdampeners"],
-            "device": ["seismiccharges", "proximitymines"],
+            "device": [
+              "seismiccharges",
+              "proximitymines"
+            ],
             "title": ["andrasta"]
           }
         }
@@ -236,7 +245,10 @@
           "id": "fennrau",
           "upgrades": {
             "talent": ["daredevil"],
-            "modification": ["afterburners", "hullupgrade"]
+            "modification": [
+              "afterburners",
+              "hullupgrade"
+            ]
           }
         }
       ]
@@ -271,7 +283,10 @@
           "upgrades": {
             "talent": ["predator"],
             "torpedo": ["iontorpedoes"],
-            "modification": ["afterburners", "hullupgrade"]
+            "modification": [
+              "afterburners",
+              "hullupgrade"
+            ]
           }
         }
       ]
@@ -343,7 +358,10 @@
           "upgrades": {
             "force-power": ["sense"],
             "gunner": ["veteranturretgunner"],
-            "illicit": ["inertialdampeners", "deadmansswitch"]
+            "illicit": [
+              "inertialdampeners",
+              "deadmansswitch"
+            ]
           }
         }
       ]
@@ -435,7 +453,10 @@
           "id": "cartelmarauder",
           "upgrades": {
             "missile": ["concussionmissiles"],
-            "modification": ["munitionsfailsafe", "hullupgrade"]
+            "modification": [
+              "munitionsfailsafe",
+              "hullupgrade"
+            ]
           }
         }
       ]
@@ -517,7 +538,10 @@
         {
           "id": "palobgodalhi",
           "upgrades": {
-            "talent": ["juke", "debrisgambit"],
+            "talent": [
+              "juke",
+              "debrisgambit"
+            ],
             "modification": ["stealthdevice"],
             "illicit": ["contrabandcybernetics"]
           }
@@ -614,7 +638,10 @@
           "upgrades": {
             "crew": ["unkarplutt"],
             "illicit": ["feedbackarray"],
-            "modification": ["shieldupgrade", "hullupgrade"],
+            "modification": [
+              "shieldupgrade",
+              "hullupgrade"
+            ],
             "device": ["seismiccharges"]
           }
         }
@@ -728,7 +755,10 @@
           "upgrades": {
             "talent": ["juke"],
             "missile": ["clustermissiles"],
-            "modification": ["munitionsfailsafe", "stealthdevice"]
+            "modification": [
+              "munitionsfailsafe",
+              "stealthdevice"
+            ]
           }
         }
       ]
@@ -740,7 +770,10 @@
           "id": "inaldra",
           "upgrades": {
             "cannon": ["ioncannon"],
-            "modification": ["hullupgrade", "shieldupgrade"]
+            "modification": [
+              "hullupgrade",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -895,8 +928,14 @@
         {
           "id": "ndrusuhlak",
           "upgrades": {
-            "talent": ["crackshot", "outmaneuver"],
-            "modification": ["hullupgrade", "stealthdevice"]
+            "talent": [
+              "crackshot",
+              "outmaneuver"
+            ],
+            "modification": [
+              "hullupgrade",
+              "stealthdevice"
+            ]
           }
         }
       ]
@@ -946,7 +985,10 @@
           "upgrades": {
             "talent": ["crackshot"],
             "missile": ["clustermissiles"],
-            "modification": ["afterburners", "shieldupgrade"]
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -969,7 +1011,10 @@
           "id": "kaatoleeachos",
           "upgrades": {
             "talent": ["saturationsalvo"],
-            "missile": ["clustermissiles", "concussionmissiles"],
+            "missile": [
+              "clustermissiles",
+              "concussionmissiles"
+            ],
             "illicit": ["deadmansswitch"],
             "modification": ["munitionsfailsafe"]
           }
@@ -1030,7 +1075,10 @@
           "upgrades": {
             "talent": ["elusive"],
             "sensor": ["advancedsensors"],
-            "crew": ["000", "zuckuss"],
+            "crew": [
+              "000",
+              "zuckuss"
+            ],
             "gunner": ["bt1"],
             "title": ["misthunter"]
           }
@@ -1130,7 +1178,10 @@
           "upgrades": {
             "turret": ["ioncannonturret"],
             "gunner": ["skilledbombardier"],
-            "device": ["connernets", "proximitymines"]
+            "device": [
+              "connernets",
+              "proximitymines"
+            ]
           }
         }
       ]
@@ -1193,8 +1244,14 @@
         {
           "id": "miningguildsurveyor",
           "upgrades": {
-            "talent": ["swarmtactics", "trickshot"],
-            "modification": ["staticdischargevanes", "shieldupgrade"]
+            "talent": [
+              "swarmtactics",
+              "trickshot"
+            ],
+            "modification": [
+              "staticdischargevanes",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -1226,7 +1283,10 @@
           "id": "ahhav",
           "upgrades": {
             "talent": ["elusive"],
-            "modification": ["afterburners", "hullupgrade"]
+            "modification": [
+              "afterburners",
+              "hullupgrade"
+            ]
           }
         }
       ]
@@ -1237,7 +1297,10 @@
         {
           "id": "foremanproach",
           "upgrades": {
-            "talent": ["predator", "swarmtactics"],
+            "talent": [
+              "predator",
+              "swarmtactics"
+            ],
             "modification": ["hullupgrade"]
           }
         }
@@ -1249,7 +1312,10 @@
         {
           "id": "foremanproach",
           "upgrades": {
-            "talent": ["crackshot", "fearless"]
+            "talent": [
+              "crackshot",
+              "fearless"
+            ]
           }
         }
       ]
@@ -1283,7 +1349,10 @@
         {
           "id": "bossk-z95af4headhunter",
           "upgrades": {
-            "talent": ["snapshot", "predator"],
+            "talent": [
+              "snapshot",
+              "predator"
+            ],
             "modification": ["afterburners"]
           }
         }
@@ -1363,13 +1432,16 @@
         {
           "id": "leemakai",
           "upgrades": {
-            "talent": ["margsablclosure", "saturationsalvo"],
+            "talent": [
+              "margsablclosure",
+              "saturationsalvo"
+            ],
             "turret": ["ioncannonturret"],
             "tech": ["targetingsynchronizer"],
             "torpedo": ["plasmatorpedoes"],
-			"gunner": ["weaponssystemsofficer"],
-			"astromech": ["r4b11"],
-			"device": ["concussionbombs"]
+            "gunner": ["weaponssystemsofficer"],
+            "astromech": ["r4b11"],
+            "device": ["concussionbombs"]
           }
         }
       ]
@@ -1446,7 +1518,7 @@
             "crew": ["lattsrazzi"],
             "gunner": ["dengar"],
             "modification": ["shieldupgrade"],
-			"torpedo": ["advprotontorpedoes"]
+            "torpedo": ["advprotontorpedoes"]
           }
         }
       ]
@@ -1459,7 +1531,10 @@
           "upgrades": {
             "talent": ["lonewolf"],
             "torpedo": ["advprotontorpedoes"],
-            "crew": ["000", "informant"]
+            "crew": [
+              "000",
+              "informant"
+            ]
           }
         }
       ]
@@ -1473,9 +1548,12 @@
             "talent": ["predator"],
             "torpedo": ["protontorpedoes"],
             "illicit": ["contrabandcybernetics"],
-            "modification": ["hullupgrade", "shieldupgrade"],
-			"astromech": ["r5p8"],
-			"title": ["punishingone"]
+            "modification": [
+              "hullupgrade",
+              "shieldupgrade"
+            ],
+            "astromech": ["r5p8"],
+            "title": ["punishingone"]
           }
         }
       ]
@@ -1487,7 +1565,10 @@
           "id": "cartelspacer",
           "upgrades": {
             "talent": ["intimidation"],
-            "cannon": ["jammingbeam", "ioncannon"],
+            "cannon": [
+              "jammingbeam",
+              "ioncannon"
+            ],
             "modification": ["shieldupgrade"]
           }
         }
@@ -1603,8 +1684,11 @@
           "id": "trandoshanslaver",
           "upgrades": {
             "missile": ["homingmissiles"],
-            "crew": ["cikatrovizago", "freelanceslicer"],
-			"gunner": ["greedo"],
+            "crew": [
+              "cikatrovizago",
+              "freelanceslicer"
+            ],
+            "gunner": ["greedo"],
             "illicit": ["feedbackarray"]
           }
         }
@@ -1619,18 +1703,18 @@
             "talent": ["predator"],
             "missile": ["homingmissiles"],
             "crew": ["gnkgonkdroid"],
-			"gunner": ["bt1"],
+            "gunner": ["bt1"],
             "title": ["houndstooth"]
           }
         },
-		{
-		  "id": "nashtahpup",
-		  "upgrades": {
-			"talent": ["predator"],
-			"missile": ["homingmissiles"],
-			"illicit": ["feedbackarray"]
-		  }
-		}
+        {
+          "id": "nashtahpup",
+          "upgrades": {
+            "talent": ["predator"],
+            "missile": ["homingmissiles"],
+            "illicit": ["feedbackarray"]
+          }
+        }
       ]
     },
     {
@@ -1643,7 +1727,7 @@
             "cannon": ["tractorbeam"],
             "illicit": ["feedbackarray"],
             "modification": ["ablativeplating"],
-			"crew": ["tacticalofficer"]
+            "crew": ["tacticalofficer"]
           }
         }
       ]
@@ -1672,10 +1756,16 @@
             "hardpoint": ["pointdefensebattery"],
             "turret": ["dorsalturret"],
             "crew": ["novicetechnician"],
-			"team": ["commsteam", "igrmdroids"],
-			"cargo": ["adaptiveshields", "tibannareserves"],
-			"illicit": ["quickreleaselocks"],
-			"title": ["merchantone"]
+            "team": [
+              "commsteam",
+              "igrmdroids"
+            ],
+            "cargo": [
+              "adaptiveshields",
+              "tibannareserves"
+            ],
+            "illicit": ["quickreleaselocks"],
+            "title": ["merchantone"]
           }
         }
       ]
@@ -1687,11 +1777,14 @@
           "id": "lawlesspirates",
           "upgrades": {
             "command": ["zealouscaptain"],
-            "hardpoint": ["tractortentacles", "protoncannonbattery"],
+            "hardpoint": [
+              "tractortentacles",
+              "protoncannonbattery"
+            ],
             "crew": ["novicetechnician"],
             "team": ["corsaircrew"],
-			"cargo": ["tibannareserves"],
-			"title": ["nautolansrevenge"]
+            "cargo": ["tibannareserves"],
+            "title": ["nautolansrevenge"]
           }
         }
       ]
@@ -1703,11 +1796,17 @@
           "id": "lawlesspirates",
           "upgrades": {
             "command": ["hondoohnakacommand"],
-            "hardpoint": ["tractortentacles", "drillbeak"],
+            "hardpoint": [
+              "tractortentacles",
+              "drillbeak"
+            ],
             "crew": ["seasonednavigator"],
-            "team": ["corsaircrew", "gunneryspecialists"],
-			"cargo": ["boostedscanners"],
-			"title": ["grappler"]
+            "team": [
+              "corsaircrew",
+              "gunneryspecialists"
+            ],
+            "cargo": ["boostedscanners"],
+            "title": ["grappler"]
           }
         }
       ]
@@ -1749,9 +1848,9 @@
             "cannon": ["syncedlasercannons"],
             "illicit": ["overtunedmodulators"],
             "modification": ["shieldupgrade"],
-			"crew": ["freelanceslicer"],
-			"device": ["blazerbomb"],
-			"title": ["xanadublood"]
+            "crew": ["freelanceslicer"],
+            "device": ["blazerbomb"],
+            "title": ["xanadublood"]
           }
         }
       ]
@@ -1775,7 +1874,10 @@
         {
           "id": "mandalorianroyalguard",
           "upgrades": {
-            "modification": ["afterburners", "beskarreinforcedplating"]
+            "modification": [
+              "afterburners",
+              "beskarreinforcedplating"
+            ]
           }
         }
       ]
@@ -1800,7 +1902,7 @@
           "upgrades": {
             "force-power": ["heightenedperception"],
             "title": ["nightbrother"],
-			"configuration": ["swivelwing"]
+            "configuration": ["swivelwing"]
           }
         }
       ]
@@ -1815,7 +1917,7 @@
             "crew": ["mandaloriansupercommandos"],
             "title": ["nightbrother"],
             "modification": ["dropseatbay"],
-			"configuration": ["swivelwing"]
+            "configuration": ["swivelwing"]
           }
         }
       ]
@@ -1829,7 +1931,7 @@
             "talent": ["enduring"],
             "device": ["blazerbomb"],
             "modification": ["shieldupgrade"],
-			"illicit": ["overtunedmodulators"]
+            "illicit": ["overtunedmodulators"]
           }
         }
       ]
@@ -1841,10 +1943,16 @@
           "id": "themandalorian",
           "upgrades": {
             "talent": ["notorious"],
-			"crew": ["kuiil", "thechild"],
+            "crew": [
+              "kuiil",
+              "thechild"
+            ],
             "title": ["razorcrest"],
-            "modification": ["burnoutthrusters", "hullupgrade"],
-			"illicit": ["trackingfob"]
+            "modification": [
+              "burnoutthrusters",
+              "hullupgrade"
+            ],
+            "illicit": ["trackingfob"]
           }
         }
       ]
@@ -1855,9 +1963,15 @@
         {
           "id": "guildbountyhunter",
           "upgrades": {
-            "crew": ["pelimotto", "ig11"],
+            "crew": [
+              "pelimotto",
+              "ig11"
+            ],
             "modification": ["hullupgrade"],
-			"illicit": ["hotshottailblaster", "trackingfob"]
+            "illicit": [
+              "hotshottailblaster",
+              "trackingfob"
+            ]
           }
         }
       ]
@@ -1869,11 +1983,14 @@
           "id": "q90",
           "upgrades": {
             "talent": ["outmaneuver"],
-			"crew": ["themandalorian", "thechild"],
+            "crew": [
+              "themandalorian",
+              "thechild"
+            ],
             "gunner": ["migsmayfeld"],
             "modification": ["burnoutthrusters"],
-			"illicit": ["trackingfob"],
-			"title": ["razorcrest"]
+            "illicit": ["trackingfob"],
+            "title": ["razorcrest"]
           }
         }
       ]
@@ -1884,7 +2001,7 @@
         {
           "id": "outerrimenforcer",
           "upgrades": {
-			"illicit": ["trackingfob"]
+            "illicit": ["trackingfob"]
           }
         }
       ]

--- a/data/quick-builds/separatist-alliance.json
+++ b/data/quick-builds/separatist-alliance.json
@@ -31,7 +31,10 @@
           "id": "precisehunter",
           "upgrades": {
             "missile": ["concussionmissiles"],
-            "modification": ["afterburners", "shieldupgrade"]
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -56,7 +59,10 @@
           "id": "haorchallprototype",
           "upgrades": {
             "missile": ["energyshellcharges"],
-            "modification": ["stealthdevice", "afterburners"]
+            "modification": [
+              "stealthdevice",
+              "afterburners"
+            ]
           }
         }
       ]
@@ -91,7 +97,10 @@
         {
           "id": "darkcourier",
           "upgrades": {
-            "crew": ["countdooku", "generalgrievous"],
+            "crew": [
+              "countdooku",
+              "generalgrievous"
+            ],
             "tactical-relay": ["k2b4"],
             "title": ["scimitar"]
           }
@@ -120,7 +129,10 @@
         {
           "id": "countdooku",
           "upgrades": {
-            "force-power": ["brilliantevasion", "predictiveshot"],
+            "force-power": [
+              "brilliantevasion",
+              "predictiveshot"
+            ],
             "torpedo": ["iontorpedoes"],
             "crew": ["generalgrievous"],
             "modification": ["hullupgrade"],
@@ -137,7 +149,10 @@
           "upgrades": {
             "talent": ["daredevil"],
             "tactical-relay": ["kraken"],
-            "modification": ["imperviumplating", "stealthdevice"]
+            "modification": [
+              "imperviumplating",
+              "stealthdevice"
+            ]
           }
         }
       ]
@@ -277,7 +292,10 @@
         {
           "id": "colicoidinterceptor",
           "upgrades": {
-            "modification": ["hullupgrade", "independentcalculations"],
+            "modification": [
+              "hullupgrade",
+              "independentcalculations"
+            ],
             "sensor": ["firecontrolsystem"]
           }
         }
@@ -367,7 +385,7 @@
             "cannon": ["jammingbeam"],
             "device": ["thermaldetonators"],
             "gunner": ["suppressivegunner"],
-			"modification": ["ablativeplating"]
+            "modification": ["ablativeplating"]
           }
         }
       ]
@@ -380,7 +398,7 @@
           "upgrades": {
             "illicit": ["falsetranspondercodes"],
             "crew": ["zamwesell"],
-			"gunner": ["bobafett-gunner"],
+            "gunner": ["bobafett-gunner"],
             "title": ["slavei-swz82"]
           }
         }
@@ -393,9 +411,9 @@
           "id": "zamwesell",
           "upgrades": {
             "talent": ["deadeyeshot"],
-			"illicit": ["falsetranspondercodes"],
+            "illicit": ["falsetranspondercodes"],
             "crew": ["jangofett"],
-			"gunner": ["hotshotgunner"],
+            "gunner": ["hotshotgunner"],
             "title": ["slavei-swz82"]
           }
         }
@@ -410,7 +428,7 @@
             "missile": ["ionmissiles"],
             "device": ["concussionbombs"],
             "modification": ["delayedfuses"],
-			"configuration": ["repulsorliftstabilizers"]
+            "configuration": ["repulsorliftstabilizers"]
           }
         }
       ]
@@ -424,7 +442,7 @@
             "missile": ["ionmissiles"],
             "device": ["concussionbombs"],
             "modification": ["delayedfuses"],
-			"configuration": ["repulsorliftstabilizers"]
+            "configuration": ["repulsorliftstabilizers"]
           }
         }
       ]
@@ -437,7 +455,7 @@
           "upgrades": {
             "missile": ["ionmissiles"],
             "cannon": ["syncedlasercannons"],
-			"configuration": ["repulsorliftstabilizers"]
+            "configuration": ["repulsorliftstabilizers"]
           }
         }
       ]
@@ -449,7 +467,7 @@
           "id": "onderonoppressor",
           "upgrades": {
             "missile": ["multimissilepods"],
-			"configuration": ["repulsorliftstabilizers"]
+            "configuration": ["repulsorliftstabilizers"]
           }
         }
       ]
@@ -474,10 +492,13 @@
           "id": "dgs286",
           "upgrades": {
             "missile": ["multimissilepods"],
-			"tactical-relay": ["kalani"],
+            "tactical-relay": ["kalani"],
             "device": ["concussionbombs"],
-            "modification": ["afterburners", "shieldupgrade"],
-			"configuration": ["repulsorliftstabilizers"]
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ],
+            "configuration": ["repulsorliftstabilizers"]
           }
         }
       ]
@@ -488,7 +509,10 @@
         {
           "id": "berwerkret",
           "upgrades": {
-            "talent": ["ensnare", "snapshot"],
+            "talent": [
+              "ensnare",
+              "snapshot"
+            ],
             "modification": ["hullupgrade"]
           }
         }
@@ -500,7 +524,10 @@
         {
           "id": "chertek",
           "upgrades": {
-            "talent": ["graviticdeflection", "juke"],
+            "talent": [
+              "graviticdeflection",
+              "juke"
+            ],
             "modification": ["targetingcomputer"]
           }
         }
@@ -513,7 +540,10 @@
           "id": "gorgol",
           "upgrades": {
             "talent": ["graviticdeflection"],
-            "modification": ["shieldupgrade", "stealthdevice"]
+            "modification": [
+              "shieldupgrade",
+              "stealthdevice"
+            ]
           }
         }
       ]
@@ -524,7 +554,10 @@
         {
           "id": "petranakiarenaace",
           "upgrades": {
-            "talent": ["ensnare", "snapshot"],
+            "talent": [
+              "ensnare",
+              "snapshot"
+            ],
             "modification": ["stealthdevice"]
           }
         }
@@ -536,7 +569,10 @@
         {
           "id": "stalgasinhiveguard",
           "upgrades": {
-            "talent": ["ensnare", "graviticdeflection"],
+            "talent": [
+              "ensnare",
+              "graviticdeflection"
+            ],
             "modification": ["targetingcomputer"]
           }
         }
@@ -548,8 +584,14 @@
         {
           "id": "sunfac",
           "upgrades": {
-            "talent": ["ensnare", "predator"],
-            "modification": ["afterburners", "shieldupgrade"]
+            "talent": [
+              "ensnare",
+              "predator"
+            ],
+            "modification": [
+              "afterburners",
+              "shieldupgrade"
+            ]
           }
         }
       ]
@@ -560,7 +602,10 @@
         {
           "id": "haorchallprototype",
           "upgrades": {
-            "missile": ["discordmissiles", "energyshellcharges"],
+            "missile": [
+              "discordmissiles",
+              "energyshellcharges"
+            ],
             "modification": ["stealthdevice"]
           }
         }
@@ -575,11 +620,14 @@
             "command": ["stalwartcaptain"],
             "hardpoint": ["turbolaserbattery"],
             "cannon": ["heavylasercannon"],
-			"turret": ["dorsalturret"],
-			"missile": ["clustermissiles"],
-			"team": ["bombardmentspecialists"],
-			"cargo": ["boostedscanners", "tibannareserves"],
-			"configuration": ["corsairrefit"]
+            "turret": ["dorsalturret"],
+            "missile": ["clustermissiles"],
+            "team": ["bombardmentspecialists"],
+            "cargo": [
+              "boostedscanners",
+              "tibannareserves"
+            ],
+            "configuration": ["corsairrefit"]
           }
         }
       ]
@@ -590,8 +638,11 @@
         {
           "id": "colicoiddestroyer",
           "upgrades": {
-            "hardpoint": ["tractortentacles", "drillbeak"],
-			"cargo": ["optimizedpowercore"]
+            "hardpoint": [
+              "tractortentacles",
+              "drillbeak"
+            ],
+            "cargo": ["optimizedpowercore"]
           }
         }
       ]
@@ -603,10 +654,16 @@
           "id": "colicoiddestroyer",
           "upgrades": {
             "command": ["asajjventresscommand"],
-            "hardpoint": ["tractortentacles", "enhancedpropulsion"],
+            "hardpoint": [
+              "tractortentacles",
+              "enhancedpropulsion"
+            ],
             "crew": ["seasonednavigator"],
-			"team": ["droidcrew", "tractortechnicians"],
-			"title": ["trident"]
+            "team": [
+              "droidcrew",
+              "tractortechnicians"
+            ],
+            "title": ["trident"]
           }
         }
       ]
@@ -618,13 +675,19 @@
           "id": "colicoiddestroyer",
           "upgrades": {
             "command": ["rifftamson"],
-            "hardpoint": ["tractortentacles", "protoncannonbattery"],
-			"torpedo": ["protontorpedoes"],
+            "hardpoint": [
+              "tractortentacles",
+              "protoncannonbattery"
+            ],
+            "torpedo": ["protontorpedoes"],
             "crew": ["novicetechnician"],
-			"gunner": ["hotshotgunner"],
-			"team": ["droidcrew", "gunneryspecialists"],
-			"cargo": ["tibannareserves"],
-			"title": ["neimoidiangrasp"]
+            "gunner": ["hotshotgunner"],
+            "team": [
+              "droidcrew",
+              "gunneryspecialists"
+            ],
+            "cargo": ["tibannareserves"],
+            "title": ["neimoidiangrasp"]
           }
         }
       ]
@@ -636,7 +699,7 @@
           "id": "ig111",
           "upgrades": {
             "talent": ["predator"],
-			"cannon": ["protoncannons"],
+            "cannon": ["protoncannons"],
             "modification": ["shieldupgrade"]
           }
         }
@@ -649,7 +712,7 @@
           "id": "magnaguardprotector",
           "upgrades": {
             "talent": ["enduring"],
-			"cannon": ["protoncannons"],
+            "cannon": ["protoncannons"],
             "modification": ["independentcalculations"]
           }
         }
@@ -662,7 +725,7 @@
           "id": "magnaguardexecutioner",
           "upgrades": {
             "talent": ["outmaneuver"],
-			"cannon": ["protoncannons"]
+            "cannon": ["protoncannons"]
           }
         }
       ]
@@ -674,10 +737,10 @@
           "id": "cadbane-separatistalliance",
           "upgrades": {
             "talent": ["outmaneuver"],
-			"cannon": ["syncedlasercannons"],
+            "cannon": ["syncedlasercannons"],
             "modification": ["afterburners"],
-			"crew": ["freelanceslicer"],
-			"title": ["xanadublood"]
+            "crew": ["freelanceslicer"],
+            "title": ["xanadublood"]
           }
         }
       ]
@@ -689,7 +752,7 @@
           "id": "ig101",
           "upgrades": {
             "talent": ["enduring"],
-			"cannon": ["protoncannons"],
+            "cannon": ["protoncannons"],
             "modification": ["hullupgrade"]
           }
         }
@@ -702,7 +765,7 @@
           "id": "ig102",
           "upgrades": {
             "talent": ["elusive"],
-			"cannon": ["syncedlasercannons"]
+            "cannon": ["syncedlasercannons"]
           }
         }
       ]
@@ -717,7 +780,7 @@
             "device": ["blazerbomb"],
             "crew": ["deathwatchcommandos"],
             "modification": ["shieldupgrade"],
-			"configuration": ["swivelwing"]
+            "configuration": ["swivelwing"]
           }
         }
       ]
@@ -730,7 +793,7 @@
           "upgrades": {
             "talent": ["outmaneuver"],
             "gunner": ["veterantailgunner"],
-			"configuration": ["swivelwing"]
+            "configuration": ["swivelwing"]
           }
         }
       ]
@@ -742,8 +805,11 @@
           "id": "deathwatchwarrior",
           "upgrades": {
             "device": ["concussionbombs"],
-            "modification": ["hullupgrade", "shieldupgrade"],
-			"configuration": ["swivelwing"]
+            "modification": [
+              "hullupgrade",
+              "shieldupgrade"
+            ],
+            "configuration": ["swivelwing"]
           }
         }
       ]

--- a/data/upgrades/cannon.json
+++ b/data/upgrades/cannon.json
@@ -134,7 +134,10 @@
       {
         "title": "Synced Laser Cannons",
         "type": "Cannon",
-        "slots": ["Cannon", "Cannon"],
+        "slots": [
+          "Cannon",
+          "Cannon"
+        ],
         "attack": {
           "arc": "Front Arc",
           "value": 3,
@@ -167,7 +170,10 @@
         "charges": { "value": 2, "recovers": 1 },
         "title": "Proton Cannons",
         "type": "Cannon",
-        "slots": ["Cannon", "Cannon"],
+        "slots": [
+          "Cannon",
+          "Cannon"
+        ],
         "attack": {
           "arc": "Bullseye Arc",
           "value": 4,

--- a/data/upgrades/command.json
+++ b/data/upgrades/command.json
@@ -87,7 +87,10 @@
         "ability": "While a friendly large or huge ship at range 0-3 executes a maneuver, it may suffer 1 [Hit] damage to execute a maneuver of the same bearing and difficulty of a speed 1 higher or lower instead.",
         "title": "Admiral Ozzel",
         "type": "Command",
-        "slots": ["Command", "Crew"],
+        "slots": [
+          "Command",
+          "Crew"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/admiralozzel.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/admiralozzel.png"
       }
@@ -106,7 +109,10 @@
         "ability": "During the End Phase, you may choose up to 2 friendly ships at range 0-1. If you do, each of these ships does not remove 1 calculate or evade token.",
         "title": "Azmorigan",
         "type": "Command",
-        "slots": ["Command", "Crew"],
+        "slots": [
+          "Command",
+          "Crew"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/azmorigan.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/azmorigan.png"
       }
@@ -125,7 +131,10 @@
         "ability": "After a friendly ship at range 0-4 reveals its dial, you may spend 1 [Charge]. If you do, it sets its dial to another maneuver of the same difficulty and speed.",
         "title": "Captain Needa",
         "type": "Command",
-        "slots": ["Command", "Crew"],
+        "slots": [
+          "Command",
+          "Crew"
+        ],
         "charges": { "value": 4, "recovers": 0 },
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/captainneeda.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/captainneeda.png"
@@ -145,7 +154,10 @@
         "ability": "After a friendly ship at range 0-2 is destroyed, you may choose a friendly ship at range 0-2. If you do, it may perform a red [Evade] action.",
         "title": "Carlist Rieekan",
         "type": "Command",
-        "slots": ["Command", "Crew"],
+        "slots": [
+          "Command",
+          "Crew"
+        ],
         "grants": [
           {
             "type": "action",
@@ -170,7 +182,10 @@
         "ability": "Friendly ships at range 0-3 can spend your focus and evade tokens.",
         "title": "Jan Dodonna",
         "type": "Command",
-        "slots": ["Command", "Crew"],
+        "slots": [
+          "Command",
+          "Crew"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/jandodonna.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/jandodonna.png"
       }
@@ -189,7 +204,10 @@
         "ability": "After you are destroyed, each friendly ship at range 0-1 gains 1 focus token. After you are destroyed, you are not removed until the end of the End Phase.",
         "title": "Raymus Antilles",
         "type": "Command",
-        "slots": ["Command", "Crew"],
+        "slots": [
+          "Command",
+          "Crew"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/raymusantilles.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/raymusantilles.png"
       }
@@ -208,7 +226,10 @@
         "ability": "After you are destroyed, you are not removed until the end of the End Phase.",
         "title": "Stalwart Captain",
         "type": "Command",
-        "slots": ["Command", "Crew"],
+        "slots": [
+          "Command",
+          "Crew"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/stalwartcaptain.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/stalwartcaptain.png"
       }
@@ -228,7 +249,10 @@
         "ability": "After a friendly ship at range 0-4 reveals its dial, you may spend 1 [Charge]. If you do, it sets its dial to another maneuver of the same difficulty and speed.",
         "title": "Strategic Commander",
         "type": "Command",
-        "slots": ["Command", "Crew"],
+        "slots": [
+          "Command",
+          "Crew"
+        ],
         "charges": { "value": 3, "recovers": 0 },
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/strategiccommander.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/strategiccommander.png"
@@ -265,8 +289,10 @@
     "cost": { "value": 4 },
     "restrictions": [
       { "factions": ["Galactic Republic"] },
-      { "ships": ["delta7aethersprite", "eta2actis"] }
-    ]
+      { "ships": [
+          "delta7aethersprite",
+          "eta2actis"
+        ] }]
   },
   {
     "name": "B6 Blade Wing Prototype",
@@ -280,7 +306,10 @@
         "ability": "Add [Gunner] slot. Attack ([Lock]): Gain 1 ion token to perform this attack. If this attack hits, the defender suffers 1 additional [Hit]/[Critical Hit] damage for each matching uncanceled result after the first.",
         "title": "B6 Blade Wing Prototype",
         "type": "Command",
-        "slots": ["Command", "Title"],
+        "slots": [
+          "Command",
+          "Title"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/b6bladewingprototype-command.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/b6bladewingprototype-command.png"
       }
@@ -288,8 +317,7 @@
     "cost": { "value": 4 },
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["asf01bwing"] }
-    ]
+      { "ships": ["asf01bwing"] }]
   },
   {
     "name": "Bounty",
@@ -428,8 +456,7 @@
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
       { "standardized": true },
-      { "non-limited": false }
-    ]
+      { "non-limited": false }]
   },
   {
     "name": "Mar Tuuk",
@@ -443,7 +470,10 @@
         "ability": "Setup: After placing forces, choose 1 friendly wing of ships with [Calculate] on their action bars and place that wing in reserve. During the End Phase, you may place that wing within your deployment area or beyond range 2 of any enemy shp. Then you may choose 1 enemy ship at range 0-1 of you; each ship in that wing acquires a lock on it.",
         "title": "Mar Tuuk",
         "type": "Command",
-        "slots": ["Command", "Crew"],
+        "slots": [
+          "Command",
+          "Crew"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/martuuk.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/martuuk.png"
       }
@@ -451,8 +481,7 @@
     "cost": { "value": 4 },
     "restrictions": [
       { "factions": ["Separatist Alliance"] },
-      { "sizes": ["Huge"] }
-    ]
+      { "sizes": ["Huge"] }]
   },
   {
     "name": "Riff Tamson",
@@ -466,7 +495,10 @@
         "ability": "During the Engagement Phase, at initiative 5, you may spend 1 [Energy] to perform a bonus [Hardpoint] attack. After you perform an attack, if the defender was dealt 1 or more faceup damage cards, it gains 2 strain tokens.",
         "title": "Riff Tamson",
         "type": "Command",
-        "slots": ["Command", "Crew"],
+        "slots": [
+          "Command",
+          "Crew"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/rifftamson.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/rifftamson.png"
       }
@@ -474,8 +506,7 @@
     "cost": { "value": 6 },
     "restrictions": [
       { "factions": ["Separatist Alliance"] },
-      { "sizes": ["Huge"] }
-    ]
+      { "sizes": ["Huge"] }]
   },
   {
     "name": "Asajj Ventress",
@@ -489,8 +520,11 @@
         "ability": "During the System Phase, you may spend 1 [Force]. IF you do, each enemy ship in your [Front Arc] at range 0-1 gains 1 strain token unless it chooses to gain 1 jam token.",
         "title": "Asajj Ventress",
         "type": "Command",
-        "slots": ["Command", "Crew"],
-        "grants" : [
+        "slots": [
+          "Command",
+          "Crew"
+        ],
+        "grants": [
           {
             "type": "action",
             "value": {
@@ -507,9 +541,11 @@
     ],
     "cost": { "value": 6 },
     "restrictions": [
-      { "factions": ["Separatist Alliance", "Scum and Villainy"] },
-      { "sizes": ["Huge"] }
-    ]
+      { "factions": [
+          "Separatist Alliance",
+          "Scum and Villainy"
+        ] },
+      { "sizes": ["Huge"] }]
   },
   {
     "name": "Zealous Captain",
@@ -523,7 +559,10 @@
         "ability": "During the Engagement Phase, at initiative 4, you may spend 1 [Energy] to perform a bonus [Hardpoint] attack.",
         "title": "Zealous Captain",
         "type": "Command",
-        "slots": ["Command", "Crew"],
+        "slots": [
+          "Command",
+          "Crew"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/zealouscaptain.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/zealouscaptain.png"
       }
@@ -544,8 +583,11 @@
         "charges": { "value": 2, "recovers": 0 },
         "title": "Hondo Ohnaka",
         "type": "Command",
-        "slots": ["Command", "Crew"],
-        "grants" : [
+        "slots": [
+          "Command",
+          "Crew"
+        ],
+        "grants": [
           {
             "type": "action",
             "value": {
@@ -560,9 +602,7 @@
       }
     ],
     "cost": { "value": 7 },
-    "restrictions": [
-      { "sizes": ["Huge"] }
-    ]
+    "restrictions": [{ "sizes": ["Huge"] }]
   },
   {
     "name": "General Grievous",
@@ -576,7 +616,10 @@
         "ability": "During the Engagement Phase, at initiative 4, you may spend 1 [Energy] to perform a bonus [Hardpoint] attack. You can perform attacks against friendly ships. After you perform an attack, if the defender was destroyed, each friendly ship at range 0-2 of it may perform a [Calculate] action.",
         "title": "General Grievous",
         "type": "Command",
-        "slots": ["Command", "Crew"],
+        "slots": [
+          "Command",
+          "Crew"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/generalgrievouscommand.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/generalgrievouscommand.png"
       }
@@ -584,8 +627,7 @@
     "cost": { "value": 5 },
     "restrictions": [
       { "sizes": ["Huge"] },
-      { "factions": ["Separatist Alliance"] }
-    ]
+      { "factions": ["Separatist Alliance"] }]
   },
   {
     "name": "Combat Boarding Tube",
@@ -599,14 +641,15 @@
         "ability": "During the System Phase, if you would drop a [Crew] remote and there is an enemy medium, large, or huge ship at range 0-1 in your [Rear Arc], you may place that device in the play area in your [Rear Arc] at range 0-1 so that it is at range 0 of that enemy ship instead. Then, that enemy ship gains 1 deplete, strain, or stress token of your choice.",
         "title": "Combat Boarding Tube",
         "type": "Command",
-        "slots": ["Command", "Configuration"],
+        "slots": [
+          "Command",
+          "Configuration"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/combatboardingtube.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/combatboardingtube.png"
       }
     ],
     "cost": { "value": "?" },
-    "restrictions": [
-      { "ships": ["gauntletfighter"] }
-    ]
+    "restrictions": [{ "ships": ["gauntletfighter"] }]
   }
 ]

--- a/data/upgrades/configuration.json
+++ b/data/upgrades/configuration.json
@@ -252,7 +252,10 @@
       {
         "title": "Calibrated Laser Targeting",
         "type": "Configuration",
-        "slots": ["Configuration", "Modification"],
+        "slots": [
+          "Configuration",
+          "Modification"
+        ],
         "ability": "While you perform a primary attack, if the defender is in your [Bullseye Arc], add 1 [Focus] result.",
         "image": "https://infinitearenas.com/xw2/images/upgrades/calibratedlasertargeting.png",
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/calibratedlasertargeting.png"
@@ -560,8 +563,7 @@
     ],
     "restrictions": [
       { "shipAbility": ["Autothrusters"] },
-      { "standardized": true }
-    ],
+      { "standardized": true }],
     "cost": { "value": 0 },
     "standard": true,
     "extended": true,
@@ -588,8 +590,7 @@
     "restrictions": [
       { "factions": ["Galactic Empire"] },
       { "ships": ["tieddefender"] },
-      { "standardized": true }
-    ],
+      { "standardized": true }],
     "cost": { "value": 0 },
     "standard": true,
     "extended": true,
@@ -626,8 +627,7 @@
     ],
     "restrictions": [
       { "shipAbility": ["Vectored Thrusters"] },
-      { "standardized": true }
-    ],
+      { "standardized": true }],
     "cost": { "value": 0 }
   },
   {
@@ -638,7 +638,10 @@
       {
         "title": "Wartime Loadout",
         "type": "Configuration",
-        "slots": ["Configuration", "Modification"],
+        "slots": [
+          "Configuration",
+          "Modification"
+        ],
         "ability": "Gain 1 [Torpedo] slot and 1 [Missile] slot. Replace your ship ability with the following:",
         "shipAbility": {
           "name": "Devastating Barrage",
@@ -660,7 +663,9 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "ships": ["btanr2ywing"] }, { "standardized": true }],
+    "restrictions": [
+      { "ships": ["btanr2ywing"] },
+      { "standardized": true }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -673,7 +678,10 @@
       {
         "title": "Enhanced Jamming Suite",
         "type": "Configuration",
-        "slots": ["Configuration", "Tech"],
+        "slots": [
+          "Configuration",
+          "Tech"
+        ],
         "ability": "While you jam, you can choose yourself or another friendly ship. While you defend, if the attacker has no green tokens or there is a jammed ship in the attack arc, you may roll 1 additional defense die.",
         "grants": [
           {

--- a/data/upgrades/crew.json
+++ b/data/upgrades/crew.json
@@ -307,8 +307,7 @@
     "cost": { "value": 4 },
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "action": { "type": "Coordinate" } }
-    ],
+      { "action": { "type": "Coordinate" } }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -363,7 +362,10 @@
         "title": "Death Troopers",
         "type": "Crew",
         "ability": "During the Activation Phase, enemy ships at range 0-1 cannot remove stress tokens.",
-        "slots": ["Crew", "Crew"],
+        "slots": [
+          "Crew",
+          "Crew"
+        ],
         "image": "https://infinitearenas.com/xw2/images/upgrades/deathtroopers.png",
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/deathtroopers.png"
       }
@@ -412,7 +414,10 @@
         "type": "Crew",
         "ability": "While another friendly ship defends or performs an attack, you may spend 1 [Force] to modify 1 of its dice as though that ship had spent 1 [Force].",
         "image": "https://infinitearenas.com/xw2/images/upgrades/emperorpalpatine.png",
-        "slots": ["Crew", "Crew"],
+        "slots": [
+          "Crew",
+          "Crew"
+        ],
         "force": { "value": 1, "recovers": 1 },
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/emperorpalpatine.png"
       }
@@ -521,8 +526,7 @@
     "cost": { "value": 4 },
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "action": { "type": "Lock" } }
-    ],
+      { "action": { "type": "Lock" } }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -624,7 +628,10 @@
         "type": "Crew",
         "ability": "During the End Phase, you may choose 1 friendly ship at range 0-2 and spend 1 [Charge]. If you do, that ship recovers 1 [Charge] on 1 of its equipped [Illicit] upgrades.",
         "image": "https://infinitearenas.com/xw2/images/upgrades/jabbathehutt.png",
-        "slots": ["Crew", "Crew"],
+        "slots": [
+          "Crew",
+          "Crew"
+        ],
         "charges": { "value": 4, "recovers": 0 },
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/jabbathehutt.png"
       }
@@ -911,8 +918,7 @@
     "cost": { "value": 7 },
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "action": { "type": "Coordinate" } }
-    ],
+      { "action": { "type": "Coordinate" } }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -1124,7 +1130,10 @@
         "title": "Supreme Leader Snoke",
         "type": "Crew",
         "ability": "During the System Phase, you may choose any number of enemy ships beyond range 1. If you do, spend that many [Force] to flip each chosen ship's dial faceup.",
-        "slots": ["Crew", "Crew"],
+        "slots": [
+          "Crew",
+          "Crew"
+        ],
         "force": { "value": 1, "recovers": 1 },
         "image": "https://infinitearenas.com/xw2/images/upgrades/supremeleadersnoke.png",
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/supremeleadersnoke.png"
@@ -1359,9 +1368,10 @@
       }
     ],
     "cost": { "value": 14 },
-    "restrictions": [
-      { "factions": ["Galactic Republic", "Separatist Alliance"] }
-    ],
+    "restrictions": [{ "factions": [
+          "Galactic Republic",
+          "Separatist Alliance"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -1530,7 +1540,10 @@
         "ability": "After a friendly ship reveals a non-[0 [Stationary]] maneuver, you may spend 1 [Force]. If you do, the chosen ship reduces the difficulty of that maneuver.",
         "title": "Leia Organa",
         "type": "Crew",
-        "slots": ["Crew", "Crew"],
+        "slots": [
+          "Crew",
+          "Crew"
+        ],
         "force": { "value": 1, "recovers": 1 },
         "grants": [
           {
@@ -1811,7 +1824,10 @@
       {
         "title": "Wolfpack",
         "type": "Crew",
-        "slots": ["Crew", "Gunner"],
+        "slots": [
+          "Crew",
+          "Gunner"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/wolfpack.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/wolfpack.png",
         "ability": "After a friendly ship at range 0-3 defends, if the attacker is in your firing arc, the defender may gain 1 strain token to acquire a lock on the attacker."
@@ -1857,7 +1873,10 @@
       {
         "title": "Ghost Company",
         "type": "Crew",
-        "slots": ["Crew", "Gunner"],
+        "slots": [
+          "Crew",
+          "Gunner"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/ghostcompany.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/ghostcompany.png",
         "ability": "After you perform a primary attack, if you are focused, you may perform a [Single Turret Arc] attack against a ship you have not attacked this round as a bonus attack.",
@@ -1934,9 +1953,10 @@
       }
     ],
     "cost": { "value": 3 },
-    "restrictions": [
-      { "factions": ["Scum and Villainy", "Separatist Alliance"] }
-    ],
+    "restrictions": [{ "factions": [
+          "Scum and Villainy",
+          "Separatist Alliance"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -1951,16 +1971,20 @@
         "title": "Zam Wesell",
         "type": "Crew",
         "slots": ["Crew"],
-        "conditions": ["youdbettermeanbusiness", "youshouldthankme"],
+        "conditions": [
+          "youdbettermeanbusiness",
+          "youshouldthankme"
+        ],
         "charges": { "value": 2, "recovers": 0 },
         "image": "https://infinitearenas.com/xw2/images/upgrades/zamwesell.png",
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/zamwesell.png"
       }
     ],
     "cost": { "value": 11 },
-    "restrictions": [
-      { "factions": ["Scum and Villainy", "Separatist Alliance"] }
-    ],
+    "restrictions": [{ "factions": [
+          "Scum and Villainy",
+          "Separatist Alliance"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2007,9 +2031,11 @@
       }
     ],
     "cost": { "value": 6 },
-    "restrictions": [
-      { "factions": ["Scum and Villainy", "Galactic Empire", "First Order"] }
-    ],
+    "restrictions": [{ "factions": [
+          "Scum and Villainy",
+          "Galactic Empire",
+          "First Order"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2056,9 +2082,11 @@
       }
     ],
     "cost": { "value": 7 },
-    "restrictions": [
-      { "factions": ["Galactic Empire", "Rebel Alliance", "Scum and Villainy"] }
-    ],
+    "restrictions": [{ "factions": [
+          "Galactic Empire",
+          "Rebel Alliance",
+          "Scum and Villainy"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2160,8 +2188,10 @@
     "cost": { "value": 3 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "sizes": ["Medium", "Large"] }
-    ],
+      { "sizes": [
+          "Medium",
+          "Large"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2189,9 +2219,10 @@
       }
     ],
     "cost": { "value": 7 },
-    "restrictions": [
-      { "factions": ["Scum and Villainy", "Galactic Republic"] }
-    ],
+    "restrictions": [{ "factions": [
+          "Scum and Villainy",
+          "Galactic Republic"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2255,9 +2286,10 @@
       }
     ],
     "cost": { "value": 6 },
-    "restrictions": [
-      { "factions": ["Galactic Republic", "Separatist Alliance"] }
-    ],
+    "restrictions": [{ "factions": [
+          "Galactic Republic",
+          "Separatist Alliance"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2277,7 +2309,10 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "factions": ["Scum and Villainy", "Rebel Alliance"] }],
+    "restrictions": [{ "factions": [
+          "Scum and Villainy",
+          "Rebel Alliance"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2359,9 +2394,10 @@
       }
     ],
     "cost": { "value": 10 },
-    "restrictions": [
-      { "factions": ["Scum and Villainy", "Separatist Alliance"] }
-    ],
+    "restrictions": [{ "factions": [
+          "Scum and Villainy",
+          "Separatist Alliance"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2381,7 +2417,10 @@
       }
     ],
     "cost": { "value": 7 },
-    "restrictions": [{ "factions": ["Scum and Villainy", "Rebel Alliance"] }],
+    "restrictions": [{ "factions": [
+          "Scum and Villainy",
+          "Rebel Alliance"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2427,9 +2466,10 @@
       }
     ],
     "cost": { "value": 9 },
-    "restrictions": [
-      { "factions": ["Scum and Villainy", "Separatist Alliance"] }
-    ],
+    "restrictions": [{ "factions": [
+          "Scum and Villainy",
+          "Separatist Alliance"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2514,9 +2554,10 @@
       }
     ],
     "cost": { "value": 10 },
-    "restrictions": [
-      { "factions": ["Scum and Villainy", "Galactic Republic"] }
-    ],
+    "restrictions": [{ "factions": [
+          "Scum and Villainy",
+          "Galactic Republic"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2530,7 +2571,10 @@
         "title": "Maul",
         "type": "Crew",
         "ability": "Add [Illicit] slot.",
-        "slots": ["Crew", "Crew"],
+        "slots": [
+          "Crew",
+          "Crew"
+        ],
         "force": { "value": 1, "recovers": 1 },
         "grants": [
           {
@@ -2558,7 +2602,10 @@
         "title": "Clan Wren Commandos",
         "type": "Crew",
         "ability": "During the System Phase, you may spend 1 [Charge] to drop a Commando Team remote using the [1 [Straight]] template. You can place that device using its front or rear guides. This card's [Charge] cannot be recovered.",
-        "slots": ["Crew", "Crew"],
+        "slots": [
+          "Crew",
+          "Crew"
+        ],
         "charges": { "value": 2, "recovers": 0 },
         "device": {
           "name": "Clan Wren Commandos",
@@ -2587,8 +2634,11 @@
     "cost": { "value": 8 },
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "sizes": ["Medium", "Large", "Huge"] }
-    ],
+      { "sizes": [
+          "Medium",
+          "Large",
+          "Huge"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2602,7 +2652,10 @@
         "title": "Imperial Super Commandos",
         "type": "Crew",
         "ability": "During the System Phase, you may spend 1 [Charge] to drop a Commando Team remote using the [1 [Straight]] template. You can place that device using its front or rear guides. This card's [Charge] cannot be recovered.",
-        "slots": ["Crew", "Crew"],
+        "slots": [
+          "Crew",
+          "Crew"
+        ],
         "charges": { "value": 2, "recovers": 0 },
         "device": {
           "name": "Imperial Super Commandos",
@@ -2631,8 +2684,11 @@
     "cost": { "value": 8 },
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "sizes": ["Medium", "Large", "Huge"] }
-    ],
+      { "sizes": [
+          "Medium",
+          "Large",
+          "Huge"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2646,7 +2702,10 @@
         "title": "Mandalorian Super Commandos",
         "type": "Crew",
         "ability": "During the System Phase, you may spend 1 [Charge] to drop a Commando Team remote using the [1 [Straight]] template. You can place that device using its front or rear guides. This card's [Charge] cannot be recovered.",
-        "slots": ["Crew", "Crew"],
+        "slots": [
+          "Crew",
+          "Crew"
+        ],
         "charges": { "value": 2, "recovers": 0 },
         "device": {
           "name": "Mandalorian Super Commandos",
@@ -2675,8 +2734,11 @@
     "cost": { "value": 8 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "sizes": ["Medium", "Large", "Huge"] }
-    ],
+      { "sizes": [
+          "Medium",
+          "Large",
+          "Huge"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2690,7 +2752,10 @@
         "title": "Nite Owl Commandos",
         "type": "Crew",
         "ability": "During the System Phase, you may spend 1 [Charge] to drop a Commando Team remote using the [1 [Straight]] template. You can place that device using its front or rear guides. This card's [Charge] cannot be recovered.",
-        "slots": ["Crew", "Crew"],
+        "slots": [
+          "Crew",
+          "Crew"
+        ],
         "charges": { "value": 2, "recovers": 0 },
         "device": {
           "name": "Nite Owl Commandos",
@@ -2719,8 +2784,11 @@
     "cost": { "value": 8 },
     "restrictions": [
       { "factions": ["Galactic Republic"] },
-      { "sizes": ["Medium", "Large", "Huge"] }
-    ],
+      { "sizes": [
+          "Medium",
+          "Large",
+          "Huge"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2734,7 +2802,10 @@
         "title": "Death Watch Commandos",
         "type": "Crew",
         "ability": "During the System Phase, you may spend 1 [Charge] to drop a Commando Team remote using the [1 [Straight]] template. You can place that device using its front or rear guides. This card's [Charge] cannot be recovered.",
-        "slots": ["Crew", "Crew"],
+        "slots": [
+          "Crew",
+          "Crew"
+        ],
         "charges": { "value": 2, "recovers": 0 },
         "device": {
           "name": "Death Watch Commandos",
@@ -2763,8 +2834,11 @@
     "cost": { "value": 8 },
     "restrictions": [
       { "factions": ["Separatist Alliance"] },
-      { "sizes": ["Medium", "Large", "Huge"] }
-    ],
+      { "sizes": [
+          "Medium",
+          "Large",
+          "Huge"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -2795,7 +2869,10 @@
       {
         "title": "Wolfpack",
         "type": "Crew",
-        "slots": ["Crew", "Gunner"],
+        "slots": [
+          "Crew",
+          "Gunner"
+        ],
         "ability": "While you perform an attack, you may spend a lock belonging to a friendly Plo Koon ship or ship with the Born for This ability that is on the defender to reroll any number of attack dice."
       }
     ],

--- a/data/upgrades/device.json
+++ b/data/upgrades/device.json
@@ -8,7 +8,10 @@
         "title": "Bomblet Generator",
         "type": "Device",
         "ability": "During the System Phase, you may spend 1 [Charge] to drop a Bomblet with the [1 [Straight]] template. At the start of the Activation Phase, you may spend 1 shield to recover 2 [Charge].",
-        "slots": ["Device", "Device"],
+        "slots": [
+          "Device",
+          "Device"
+        ],
         "charges": { "value": 2, "recovers": 0 },
         "device": {
           "name": "Bomblet",
@@ -191,7 +194,10 @@
         "type": "Device",
         "ability": "During the System Phase, you may spend 1 [Charge] to drop an Electro-Proton Bomb with the [1 [Straight]] template. Then place 1 fuse marker on that device. This card's [Charge] cannot be recovered.",
         "image": "https://infinitearenas.com/xw2/images/upgrades/electroprotonbomb.png",
-        "slots": ["Device", "Modification"],
+        "slots": [
+          "Device",
+          "Modification"
+        ],
         "charges": { "value": 1, "recovers": 0 },
         "device": {
           "name": "Electro-Proton Bomb",

--- a/data/upgrades/gunner.json
+++ b/data/upgrades/gunner.json
@@ -280,8 +280,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["First Order"] },
-      { "ships": ["tiesffighter"] }
-    ],
+      { "ships": ["tiesffighter"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -609,9 +608,11 @@
     ],
     "cost": { "value": 6 },
     "restrictions": [
-      { "sizes": ["Large", "Huge"] },
-      { "factions": ["Scum and Villainy"] }
-    ],
+      { "sizes": [
+          "Large",
+          "Huge"
+        ] },
+      { "factions": ["Scum and Villainy"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -652,9 +653,10 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [
-      { "factions": ["Galactic Republic", "Separatist Alliance"] }
-    ],
+    "restrictions": [{ "factions": [
+          "Galactic Republic",
+          "Separatist Alliance"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -674,7 +676,10 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "factions": ["Galactic Empire", "Scum and Villainy"] }],
+    "restrictions": [{ "factions": [
+          "Galactic Empire",
+          "Scum and Villainy"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true

--- a/data/upgrades/hardpoint.json
+++ b/data/upgrades/hardpoint.json
@@ -185,8 +185,7 @@
     "epic": true,
     "restrictions": [
       { "sizes": ["Huge"] },
-      { "ships": ["tridentclassassaultship"] }
-    ],
+      { "ships": ["tridentclassassaultship"] }],
     "sides": [
       {
         "ability": "Setup: Equip this side faceup. Bonus Attack. Bonus Attack: Spend 1 [Energy]. Bonus Attack: Spend 1 [Energy]. Bonus Attack: Spend 1 [Energy]. Bonus Attack: Spend 1 [Energy].",
@@ -224,7 +223,10 @@
         "ability": "Setup: Equip this side faceup. Bonus Attack: Change 1 [Hit] result to a [Critical Hit] result. Bonus Attack: Spend 1 [Energy]. Change 1 [Hit] result to a [Critical Hit] result.",
         "title": "Proton Cannon Battery",
         "type": "Hardpoint",
-        "slots": ["Hardpoint", "Cargo"],
+        "slots": [
+          "Hardpoint",
+          "Cargo"
+        ],
         "attack": {
           "arc": "Bullseye Arc",
           "value": 4,
@@ -238,7 +240,10 @@
         "ability": "Action: Spend 1 [Energy] to repair this card.",
         "title": "Proton Cannon Battery (Offline)",
         "type": "Hardpoint",
-        "slots": ["Hardpoint", "Cargo"],
+        "slots": [
+          "Hardpoint",
+          "Cargo"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/"
       }
     ],
@@ -256,22 +261,27 @@
         "ability": "Setup: Equip this side faceup. At the start of the End Phase, you may spend 2 [Energy] to execute a white [2 [Straight]], [1 [Bank Left]], or [1 [Bank Right]] maneuver.",
         "title": "Enhanced Propulsion",
         "type": "Hardpoint",
-        "slots": ["Hardpoint", "Cargo"],
+        "slots": [
+          "Hardpoint",
+          "Cargo"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/"
       },
       {
         "ability": "Action: Spend 1 [Energy] to repair this card.",
         "title": "Enhanced Propulsion (Offline)",
         "type": "Hardpoint",
-        "slots": ["Hardpoint", "Cargo"],
+        "slots": [
+          "Hardpoint",
+          "Cargo"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/"
       }
     ],
     "cost": { "value": 6 },
     "restrictions": [
       { "sizes": ["Huge"] },
-      { "ships": ["tridentclassassaultship"] }
-    ]
+      { "ships": ["tridentclassassaultship"] }]
   },
   {
     "name": "Drill Beak",
@@ -285,7 +295,10 @@
         "ability": "Setup: Equip this side faceup. You can perform this attack at range 0. Bonus Attack: Spend 1 [Energy]. If the attack range is 0, change all [Hit] results to [Critical Hit] results.",
         "title": "Drill Beak",
         "type": "Hardpoint",
-        "slots": ["Hardpoint", "Cargo"],
+        "slots": [
+          "Hardpoint",
+          "Cargo"
+        ],
         "attack": {
           "arc": "Rear Arc",
           "value": 3,
@@ -299,14 +312,16 @@
         "ability": "Action: Spend 1 [Energy] to repair this card.",
         "title": "Drill Beak (Offline)",
         "type": "Hardpoint",
-        "slots": ["Hardpoint", "Cargo"],
+        "slots": [
+          "Hardpoint",
+          "Cargo"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/"
       }
     ],
     "cost": { "value": 4 },
     "restrictions": [
       { "sizes": ["Huge"] },
-      { "ships": ["tridentclassassaultship"] }
-    ]
+      { "ships": ["tridentclassassaultship"] }]
   }
 ]

--- a/data/upgrades/illicit.json
+++ b/data/upgrades/illicit.json
@@ -15,7 +15,10 @@
       }
     ],
     "cost": { "value": 8 },
-    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "restrictions": [{ "sizes": [
+          "Small",
+          "Medium"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -118,7 +121,10 @@
       }
     ],
     "cost": { "value": 3 },
-    "restrictions": [{ "sizes": ["Medium", "Large"] }],
+    "restrictions": [{ "sizes": [
+          "Medium",
+          "Large"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -235,7 +241,10 @@
         "image": "https://infinitearenas.com/xw2/images/upgrades/babufrik.png"
       }
     ],
-    "restrictions": [{ "factions": ["Scum and Villainy", "Resistance"] }],
+    "restrictions": [{ "factions": [
+          "Scum and Villainy",
+          "Resistance"
+        ] }],
     "cost": { "value": 5 },
     "standard": true,
     "extended": true,
@@ -303,7 +312,10 @@
         "image": "https://infinitearenas.com/xw2/images/upgrades/hotshottailblaster.png"
       }
     ],
-    "restrictions": [{ "sizes": ["Medium", "Large"] }],
+    "restrictions": [{ "sizes": [
+          "Medium",
+          "Large"
+        ] }],
     "cost": { "value": 2 },
     "standard": true,
     "extended": true,

--- a/data/upgrades/missile.json
+++ b/data/upgrades/missile.json
@@ -8,7 +8,10 @@
         "title": "Barrage Rockets",
         "type": "Missile",
         "ability": "Attack ([Focus]): Spend 1 [Charge]. If the defender is in your [Bullseye Arc], you may spend 1 or more [Charge] to reroll that many attack dice.",
-        "slots": ["Missile", "Missile"],
+        "slots": [
+          "Missile",
+          "Missile"
+        ],
         "charges": { "value": 5, "recovers": 0 },
         "attack": {
           "arc": "Front Arc",
@@ -185,8 +188,7 @@
     ],
     "restrictions": [
       { "action": { "type": "Calculate", "difficulty": "White" } },
-      { "factions": ["Separatist Alliance"] }
-    ],
+      { "factions": ["Separatist Alliance"] }],
     "cost": { "value": 4 },
     "standard": true,
     "extended": true,
@@ -231,7 +233,10 @@
       {
         "title": "Diamond-Boron Missiles",
         "type": "Missile",
-        "slots": ["Missile", "Missile"],
+        "slots": [
+          "Missile",
+          "Missile"
+        ],
         "ability": "Attack ([Lock]): Spend 1 [Charge]. After this attack hits, you may spend 1 [Charge]. If you do, each ship at range 0-1 of the defender with agility equal to or less than the defender's rolls 1 attack die and suffers 1 [Hit]/[Critical Hit] damage for each matching result.",
         "charges": { "value": 3, "recovers": 0 },
         "attack": {
@@ -287,7 +292,10 @@
         "charges": { "value": 1, "recovers": 0 },
         "title": "Electro-Chaff Missiles",
         "type": "Missile",
-        "slots": ["Missile", "Device"],
+        "slots": [
+          "Missile",
+          "Device"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/electrochaffmissiles.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/electrochaffmissiles.png"
       }
@@ -314,7 +322,10 @@
         "charges": { "value": 5, "recovers": 0 },
         "title": "Multi-Missile Pods",
         "type": "Missile",
-        "slots": ["Missile", "Missile"],
+        "slots": [
+          "Missile",
+          "Missile"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/multimissilepods.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/multimissilepods.png"
       }

--- a/data/upgrades/modification.json
+++ b/data/upgrades/modification.json
@@ -15,7 +15,10 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "sizes": ["Medium", "Large"] }],
+    "restrictions": [{ "sizes": [
+          "Medium",
+          "Large"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -220,7 +223,10 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "sizes": ["Medium", "Large"] }],
+    "restrictions": [{ "sizes": [
+          "Medium",
+          "Large"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -262,8 +268,7 @@
     ],
     "restrictions": [
       { "factions": ["Galactic Republic"] },
-      { "action": { "type": "Lock", "difficulty": "White" } }
-    ],
+      { "action": { "type": "Lock", "difficulty": "White" } }],
     "cost": { "value": 1 },
     "standard": true,
     "extended": true,
@@ -314,14 +319,20 @@
     "limited": 0,
     "xws": "angleddeflectors",
     "cost": { "value": 4 },
-    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "restrictions": [{ "sizes": [
+          "Small",
+          "Medium"
+        ] }],
     "sides": [
       {
         "text": "Starfighter shields often have manual overrides that allow them to be angled for increased front or rear protection. However, doing so leaves the ship exposed if the pilot's situational awareness falters.",
         "title": "Angled Deflectors",
         "type": "Modification",
         "slots": ["Modification"],
-        "restrictions": [{ "sizes": ["Small", "Medium"] }],
+        "restrictions": [{ "sizes": [
+              "Small",
+              "Medium"
+            ] }],
         "grants": [
           { "type": "stat", "value": "shields", "amount": -1 },
           {
@@ -378,8 +389,7 @@
     ],
     "restrictions": [
       { "shipAbility": ["Networked Calculations"] },
-      { "standardized": true }
-    ],
+      { "standardized": true }],
     "cost": { "value": 2 },
     "standard": true,
     "extended": true,
@@ -511,8 +521,10 @@
     ],
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "sizes": ["Small", "Medium"] }
-    ],
+      { "sizes": [
+          "Small",
+          "Medium"
+        ] }],
     "cost": { "value": 6 },
     "standard": true,
     "extended": true,

--- a/data/upgrades/tactical-relay.json
+++ b/data/upgrades/tactical-relay.json
@@ -21,8 +21,7 @@
     ],
     "restrictions": [
       { "factions": ["Separatist Alliance"] },
-      { "solitary": true }
-    ],
+      { "solitary": true }],
     "cost": { "value": 8 },
     "standard": true,
     "extended": true,
@@ -44,8 +43,7 @@
     ],
     "restrictions": [
       { "factions": ["Separatist Alliance"] },
-      { "solitary": true }
-    ],
+      { "solitary": true }],
     "cost": { "value": 3 },
     "standard": true,
     "extended": true,
@@ -67,8 +65,7 @@
     ],
     "restrictions": [
       { "factions": ["Separatist Alliance"] },
-      { "solitary": true }
-    ],
+      { "solitary": true }],
     "cost": { "value": 4 },
     "standard": true,
     "extended": true,
@@ -90,8 +87,7 @@
     ],
     "restrictions": [
       { "factions": ["Separatist Alliance"] },
-      { "solitary": true }
-    ],
+      { "solitary": true }],
     "cost": { "value": 6 },
     "standard": true,
     "extended": true,

--- a/data/upgrades/talent.json
+++ b/data/upgrades/talent.json
@@ -56,8 +56,7 @@
     "cost": { "value": 5 },
     "restrictions": [
       { "sizes": ["Small"] },
-      { "action": { "type": "Boost", "difficulty": "White" } }
-    ],
+      { "action": { "type": "Boost", "difficulty": "White" } }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -84,7 +83,10 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "restrictions": [{ "sizes": [
+          "Small",
+          "Medium"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -105,7 +107,10 @@
       }
     ],
     "cost": { "value": 4 },
-    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "restrictions": [{ "sizes": [
+          "Small",
+          "Medium"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -233,7 +238,10 @@
       }
     ],
     "cost": { "value": 7 },
-    "restrictions": [{ "sizes": ["Small", "Medium"] }],
+    "restrictions": [{ "sizes": [
+          "Small",
+          "Medium"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -476,8 +484,7 @@
     ],
     "restrictions": [
       { "factions": ["Galactic Republic"] },
-      { "keywords": ["Clone"] }
-    ],
+      { "keywords": ["Clone"] }],
     "cost": { "value": 3 },
     "standard": true,
     "extended": true,
@@ -784,8 +791,7 @@
     "cost": { "value": 1 },
     "restrictions": [
       { "action": { "type": "Reload" } },
-      { "keywords": ["TIE"] }
-    ],
+      { "keywords": ["TIE"] }],
     "standard": true,
     "extended": true,
     "epic": true

--- a/data/upgrades/team.json
+++ b/data/upgrades/team.json
@@ -234,7 +234,10 @@
         "title": "Corsair Crew",
         "type": "Team",
         "text": "While you perform an attack against a standard ship, you may spend 1 [Hit] result. If you do, the defender gains 1 deplete token.",
-        "slots": ["Team", "Gunner"],
+        "slots": [
+          "Team",
+          "Gunner"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/corsaircrew.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/corsaircrew.png"
       }

--- a/data/upgrades/tech.json
+++ b/data/upgrades/tech.json
@@ -53,7 +53,9 @@
       }
     ],
     "cost": { "value": 2 },
-    "restrictions": [{ "factions": ["First Order"] }, { "sizes": ["Large"] }],
+    "restrictions": [
+      { "factions": ["First Order"] },
+      { "sizes": ["Large"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -133,8 +135,7 @@
     "cost": { "value": 1 },
     "restrictions": [
       { "factions": ["First Order"] },
-      { "action": { "type": "Lock" } }
-    ],
+      { "action": { "type": "Lock" } }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -149,7 +150,10 @@
         "charges": { "value": 2, "recovers": 0 },
         "title": "Deuterium Power Cells",
         "type": "Tech",
-        "slots": ["Tech", "Modification"],
+        "slots": [
+          "Tech",
+          "Modification"
+        ],
         "artwork": "https://infinitearenas.com/xw2/images/artwork/upgrades/deuteriumpowercells.png",
         "image": "https://infinitearenas.com/xw2/images/upgrades/deuteriumpowercells.png"
       }
@@ -223,9 +227,10 @@
       }
     ],
     "cost": { "value": 1 },
-    "restrictions": [
-      { "ships": ["tiewiwhispermodifiedinterceptor", "tievnsilencer"] }
-    ],
+    "restrictions": [{ "ships": [
+          "tiewiwhispermodifiedinterceptor",
+          "tievnsilencer"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true

--- a/data/upgrades/title.json
+++ b/data/upgrades/title.json
@@ -24,8 +24,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["firesprayclasspatrolcraft"] }
-    ],
+      { "ships": ["firesprayclasspatrolcraft"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -53,7 +52,9 @@
       }
     ],
     "cost": { "value": 0 },
-    "restrictions": [{ "factions": ["Resistance"] }, { "ships": ["t70xwing"] }],
+    "restrictions": [
+      { "factions": ["Resistance"] },
+      { "ships": ["t70xwing"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -75,8 +76,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "ships": ["vt49decimator"] }
-    ],
+      { "ships": ["vt49decimator"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -98,8 +98,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["vcx100lightfreighter"] }
-    ],
+      { "ships": ["vcx100lightfreighter"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -126,8 +125,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["scurrgh6bomber"] }
-    ],
+      { "ships": ["scurrgh6bomber"] }],
     "standard": false,
     "extended": true,
     "epic": true
@@ -149,8 +147,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["yv666lightfreighter"] }
-    ],
+      { "ships": ["yv666lightfreighter"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -172,8 +169,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["aggressorassaultfighter"] }
-    ],
+      { "ships": ["aggressorassaultfighter"] }],
     "standard": false,
     "extended": true,
     "epic": true
@@ -195,8 +191,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["customizedyt1300lightfreighter"] }
-    ],
+      { "ships": ["customizedyt1300lightfreighter"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -219,8 +214,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["firesprayclasspatrolcraft"] }
-    ],
+      { "ships": ["firesprayclasspatrolcraft"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -249,8 +243,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["modifiedyt1300lightfreighter"] }
-    ],
+      { "ships": ["modifiedyt1300lightfreighter"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -280,8 +273,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["g1astarfighter"] }
-    ],
+      { "ships": ["g1astarfighter"] }],
     "standard": false,
     "extended": true,
     "epic": true
@@ -305,9 +297,11 @@
     ],
     "cost": { "value": 0 },
     "restrictions": [
-      { "factions": ["Rebel Alliance", "Scum and Villainy"] },
-      { "ships": ["hwk290lightfreighter"] }
-    ],
+      { "factions": [
+          "Rebel Alliance",
+          "Scum and Villainy"
+        ] },
+      { "ships": ["hwk290lightfreighter"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -329,8 +323,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["yt2400lightfreighter"] }
-    ],
+      { "ships": ["yt2400lightfreighter"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -352,8 +345,10 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["attackshuttle", "sheathipedeclassshuttle"] }
-    ],
+      { "ships": [
+          "attackshuttle",
+          "sheathipedeclassshuttle"
+        ] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -379,8 +374,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["jumpmaster5000"] }
-    ],
+      { "ships": ["jumpmaster5000"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -402,8 +396,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "ships": ["lambdaclasst4ashuttle"] }
-    ],
+      { "ships": ["lambdaclasst4ashuttle"] }],
     "standard": false,
     "extended": true,
     "epic": true
@@ -425,8 +418,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["lancerclasspursuitcraft"] }
-    ],
+      { "ships": ["lancerclasspursuitcraft"] }],
     "standard": false,
     "extended": true,
     "epic": true
@@ -449,8 +441,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["firesprayclasspatrolcraft"] }
-    ],
+      { "ships": ["firesprayclasspatrolcraft"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -497,8 +488,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Resistance"] },
-      { "ships": ["scavengedyt1300"] }
-    ],
+      { "ships": ["scavengedyt1300"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -520,8 +510,7 @@
     ],
     "restrictions": [
       { "factions": ["Separatist Alliance"] },
-      { "ships": ["belbullab22starfighter"] }
-    ],
+      { "ships": ["belbullab22starfighter"] }],
     "cost": { "value": 0 },
     "standard": true,
     "extended": true,
@@ -553,8 +542,7 @@
     ],
     "restrictions": [
       { "factions": ["Separatist Alliance"] },
-      { "ships": ["sithinfiltrator"] }
-    ],
+      { "ships": ["sithinfiltrator"] }],
     "cost": { "value": 0 },
     "standard": true,
     "extended": true,
@@ -584,8 +572,7 @@
     ],
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "ships": ["raiderclasscorvette"] }
-    ],
+      { "ships": ["raiderclasscorvette"] }],
     "cost": { "value": 5 }
   },
   {
@@ -612,8 +599,7 @@
     ],
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "ships": ["gozanticlasscruiser"] }
-    ],
+      { "ships": ["gozanticlasscruiser"] }],
     "cost": { "value": 8 }
   },
   {
@@ -635,8 +621,7 @@
     ],
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["gr75mediumtransport"] }
-    ],
+      { "ships": ["gr75mediumtransport"] }],
     "cost": { "value": 5 }
   },
   {
@@ -662,8 +647,7 @@
     ],
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["croccruiser"] }
-    ],
+      { "ships": ["croccruiser"] }],
     "cost": { "value": 4 }
   },
   {
@@ -691,8 +675,7 @@
     ],
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "ships": ["raiderclasscorvette"] }
-    ],
+      { "ships": ["raiderclasscorvette"] }],
     "cost": { "value": 3 }
   },
   {
@@ -735,8 +718,7 @@
     ],
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["cr90corelliancorvette"] }
-    ],
+      { "ships": ["cr90corelliancorvette"] }],
     "cost": { "value": 4 }
   },
   {
@@ -763,8 +745,7 @@
     ],
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "ships": ["raiderclasscorvette"] }
-    ],
+      { "ships": ["raiderclasscorvette"] }],
     "cost": { "value": 4 }
   },
   {
@@ -792,8 +773,7 @@
     ],
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["croccruiser"] }
-    ],
+      { "ships": ["croccruiser"] }],
     "cost": { "value": 7 }
   },
   {
@@ -816,8 +796,7 @@
     ],
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "ships": ["raiderclasscorvette"] }
-    ],
+      { "ships": ["raiderclasscorvette"] }],
     "cost": { "value": 6 }
   },
   {
@@ -843,8 +822,7 @@
     ],
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["cr90corelliancorvette"] }
-    ],
+      { "ships": ["cr90corelliancorvette"] }],
     "cost": { "value": 4 }
   },
   {
@@ -861,7 +839,9 @@
         "image": "https://infinitearenas.com/xw2/images/upgrades/kazsfireball.png"
       }
     ],
-    "restrictions": [{ "factions": ["Resistance"] }, { "ships": ["fireball"] }],
+    "restrictions": [
+      { "factions": ["Resistance"] },
+      { "ships": ["fireball"] }],
     "cost": { "value": 0 },
     "standard": true,
     "extended": true,
@@ -887,8 +867,7 @@
     ],
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["cr90corelliancorvette"] }
-    ],
+      { "ships": ["cr90corelliancorvette"] }],
     "cost": { "value": 5 }
   },
   {
@@ -914,8 +893,7 @@
     ],
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["gr75mediumtransport"] }
-    ],
+      { "ships": ["gr75mediumtransport"] }],
     "cost": { "value": 12 }
   },
   {
@@ -950,8 +928,7 @@
     ],
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["croccruiser"] }
-    ],
+      { "ships": ["croccruiser"] }],
     "cost": { "value": 8 }
   },
   {
@@ -978,8 +955,7 @@
     ],
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["gr75mediumtransport"] }
-    ],
+      { "ships": ["gr75mediumtransport"] }],
     "cost": { "value": 3 }
   },
   {
@@ -1001,8 +977,7 @@
     ],
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "ships": ["gozanticlasscruiser"] }
-    ],
+      { "ships": ["gozanticlasscruiser"] }],
     "cost": { "value": 7 }
   },
   {
@@ -1029,8 +1004,7 @@
     ],
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "ships": ["gozanticlasscruiser"] }
-    ],
+      { "ships": ["gozanticlasscruiser"] }],
     "cost": { "value": 6 }
   },
   {
@@ -1053,8 +1027,7 @@
     ],
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["cr90corelliancorvette"] }
-    ],
+      { "ships": ["cr90corelliancorvette"] }],
     "cost": { "value": 5 }
   },
   {
@@ -1081,8 +1054,7 @@
     ],
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["cr90corelliancorvette"] }
-    ],
+      { "ships": ["cr90corelliancorvette"] }],
     "cost": { "value": 4 }
   },
   {
@@ -1108,8 +1080,7 @@
     ],
     "restrictions": [
       { "factions": ["Galactic Empire"] },
-      { "ships": ["gozanticlasscruiser"] }
-    ],
+      { "ships": ["gozanticlasscruiser"] }],
     "cost": { "value": 7 }
   },
   {
@@ -1131,9 +1102,11 @@
       }
     ],
     "restrictions": [
-      { "factions": ["Scum and Villainy", "Separatist Alliance"] },
-      { "ships": ["firesprayclasspatrolcraft"] }
-    ],
+      { "factions": [
+          "Scum and Villainy",
+          "Separatist Alliance"
+        ] },
+      { "ships": ["firesprayclasspatrolcraft"] }],
     "cost": { "value": 0 }
   },
   {
@@ -1154,8 +1127,7 @@
     "cost": { "value": 0 },
     "restrictions": [
       { "factions": ["Rebel Alliance"] },
-      { "ships": ["asf01bwing"] }
-    ],
+      { "ships": ["asf01bwing"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -1185,8 +1157,7 @@
     "cost": { "value": 2 },
     "restrictions": [
       { "factions": ["Scum and Villainy"] },
-      { "ships": ["tridentclassassaultship"] }
-    ]
+      { "ships": ["tridentclassassaultship"] }]
   },
   {
     "name": "Grappler",
@@ -1233,8 +1204,7 @@
     "cost": { "value": 5 },
     "restrictions": [
       { "factions": ["Separatist Alliance"] },
-      { "ships": ["tridentclassassaultship"] }
-    ]
+      { "ships": ["tridentclassassaultship"] }]
   },
   {
     "name": "Trident",
@@ -1257,8 +1227,7 @@
     "cost": { "value": 4 },
     "restrictions": [
       { "factions": ["Separatist Alliance"] },
-      { "ships": ["tridentclassassaultship"] }
-    ]
+      { "ships": ["tridentclassassaultship"] }]
   },
   {
     "name": "Nightbrother",
@@ -1269,7 +1238,10 @@
         "ability": "After you reveal a non-blue maneuver, if you are stressed, you may spend 2 [Charge] to gain 1 focus or evade token. Add [Crew] slot.",
         "title": "Nightbrother",
         "type": "Title",
-        "slots": ["Title", "Modification"],
+        "slots": [
+          "Title",
+          "Modification"
+        ],
         "charges": { "value": 2, "recovers": 1 },
         "grants": [{ "type": "slot", "value": "Crew", "amount": 1 }],
         "image": "https://infinitearenas.com/xw2/images/upgrades/nightbrother.png",
@@ -1278,9 +1250,11 @@
     ],
     "cost": { "value": 0 },
     "restrictions": [
-      { "factions": ["Scum and Villainy", "Rebel Alliance"] },
-      { "ships": ["gauntletfighter"] }
-    ],
+      { "factions": [
+          "Scum and Villainy",
+          "Rebel Alliance"
+        ] },
+      { "ships": ["gauntletfighter"] }],
     "standard": true,
     "extended": true,
     "epic": true
@@ -1294,7 +1268,10 @@
         "ability": "During the System Phase, you may spend 1 [Charge] to repair 1 faceup ship damage card. Add [Crew] slot.",
         "title": "Gauntlet",
         "type": "Title",
-        "slots": ["Title", "Modification"],
+        "slots": [
+          "Title",
+          "Modification"
+        ],
         "charges": { "value": 2, "recovers": 0 },
         "grants": [{ "type": "slot", "value": "Crew", "amount": -1 }],
         "image": "https://infinitearenas.com/xw2/images/upgrades/gauntlet.png",
@@ -1303,9 +1280,11 @@
     ],
     "cost": { "value": 0 },
     "restrictions": [
-      { "factions": ["Galactic Republic", "Separatist Alliance"] },
-      { "ships": ["gauntletfighter"] }
-    ],
+      { "factions": [
+          "Galactic Republic",
+          "Separatist Alliance"
+        ] },
+      { "ships": ["gauntletfighter"] }],
     "standard": true,
     "extended": true,
     "epic": true

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jsonlint-cli": "^1.0.1",
     "lint-staged": "^10.0.7",
     "node-fetch": "^3.1.1",
-    "prettier": "^1.19.1",
+    "prettier": "^2.8.8",
     "ts-node": "^10.5.0",
     "typescript": "^4.5.5"
   },
@@ -36,11 +36,8 @@
     ],
     "*.json": "prettier --write"
   },
-  "prettier": {
-    "tabWidth": 2,
-    "printWidth": 80
-  },
   "dependencies": {
+    "prettier-plugin-multiline-arrays": "^1.1.3",
     "string-math": "^1.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,13 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@augment-vir/common@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@augment-vir/common/-/common-8.1.0.tgz#78c2aaff0ef512501a1101f05d5155f0094ee05a"
+  integrity sha512-mVE9upO/BIHdRIH/HoJAHDaHk57AxtQ3BvmI0B2o2xMvripDxuPf7jhxL793uyJtprLF2X6yE0BhG/rgLeHLbw==
+  dependencies:
+    type-fest "^3.5.1"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6", "@babel/code-frame@^7.21.4":
   version "7.21.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.21.4.tgz#d0fa9e4413aca81f2b23b9442797bda1826edb39"
@@ -3102,10 +3109,17 @@ please-upgrade-node@^3.2.0:
   dependencies:
     semver-compare "^1.0.0"
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier-plugin-multiline-arrays@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-multiline-arrays/-/prettier-plugin-multiline-arrays-1.1.3.tgz#667bc65c3c2e5d00548bcde2cf78b188b8fe74f3"
+  integrity sha512-8I4FWatPhZXAsPMKM5E6h92ZRLAniJDdl9Uyy5aBvz9jJxc27CYQJIKBXdRW1SHrgKjEeWchmsAkLVyORIEOqw==
+  dependencies:
+    "@augment-vir/common" "^8.1.0"
+
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^24.9.0:
   version "24.9.0"
@@ -3698,6 +3712,11 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^3.5.1:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.11.0.tgz#e78ea6b50d6a6b1e4609035fb9ea8f1e3c328194"
+  integrity sha512-JaPw5U9ixP0XcpUbQoVSbxSDcK/K4nww20C3kjm9yE6cDRRhptU28AH60VWf9ltXmCrIfIbtt9J+2OUk2Uqiaw==
 
 typescript@^4.5.5:
   version "4.9.5"


### PR DESCRIPTION
Added the prettier-plugin-multiline-arrays (https://www.npmjs.com/package/prettier-plugin-multiline-arrays) plugin in order to force prettier to split all arrays into multiline, which should help with readability and future maintenance.
