### PR TITLE
Scum - Y-wing - Leema Kai - No Talent

### DIFF
--- a/data/pilots/scum-and-villainy/btl-a4-y-wing.json
+++ b/data/pilots/scum-and-villainy/btl-a4-y-wing.json
@@ -130,7 +130,6 @@
       "cost": 3,
       "loadout": 8,
       "slots": [
-        "Talent",
         "Tech",
         "Turret",
         "Torpedo",


### PR DESCRIPTION
Leema Kai (Scum Y-wing) shouldn't have a Talent slot.