### PR TITLE
Add the S&V YT-2400 to the manifest

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -57,6 +57,7 @@
         "data/pilots/scum-and-villainy/starviper-class-attack-platform.json",
         "data/pilots/scum-and-villainy/trident-class-assault-ship.json",
         "data/pilots/scum-and-villainy/yv-666-light-freighter.json",
+        "data/pilots/scum-and-villainy/yt-2400-light-freighter.json",
         "data/pilots/scum-and-villainy/z-95-af4-headhunter.json"
       ]
     },


### PR DESCRIPTION
Add the file for the YT-2400 Scum & Villainy pilots that was missing from the manifest. 